### PR TITLE
Add hf metadata quering

### DIFF
--- a/common/constants.py
+++ b/common/constants.py
@@ -32,3 +32,7 @@ MIN_EVALUATION_PERIOD = datetime.timedelta(minutes=60)
 
 # Miner compressed index cache freshness.
 MINER_CACHE_FRESHNESS = datetime.timedelta(minutes=20)
+
+HF_METADATA_QUERY_DATE = datetime.datetime(
+    year=2024, month=7, day=22, tzinfo=datetime.timezone.utc
+)

--- a/common/constants.py
+++ b/common/constants.py
@@ -32,9 +32,3 @@ MIN_EVALUATION_PERIOD = datetime.timedelta(minutes=60)
 
 # Miner compressed index cache freshness.
 MINER_CACHE_FRESHNESS = datetime.timedelta(minutes=20)
-RETWEET_ELIGIBLE_DATE = datetime.datetime(
-    year=2024, month=6, day=10, tzinfo=datetime.timezone.utc
-)
-RETWEET_HALT_DATE = datetime.datetime(
-    year=2024, month=7, day=6, tzinfo=datetime.timezone.utc
-)

--- a/common/protocol.py
+++ b/common/protocol.py
@@ -21,6 +21,7 @@ from common.data import (
     DataEntityBucket,
     DataEntity,
     DataEntityBucketId,
+    HuggingFaceMetadata
 )
 from typing import Dict, List, Optional, Tuple
 
@@ -114,6 +115,20 @@ class GetContentsByBuckets(BaseProtocol):
     )
 
 
+class GetHuggingFaceMetadata(BaseProtocol):
+    """
+    Protocol by which Validators can retrieve HuggingFace metadata from a Miner.
+    """
+
+    # Required request output, filled by receiving axon.
+    metadata: List[HuggingFaceMetadata] = pydantic.Field(
+        title="metadata",
+        description="List of HuggingFace metadata entries.",
+        frozen=False,
+        repr=False,
+        default_factory=list,
+    )
+
 # TODO Protocol for Users to Query Data which will accept query parameters such as a startDatetime, endDatetime.
 
 # How many times validators can send requests per validation period.
@@ -121,4 +136,5 @@ REQUEST_LIMIT_BY_TYPE_PER_PERIOD = {
     GetMinerIndex: 1,
     GetDataEntityBucket: 1,
     GetContentsByBuckets: 5,
+    GetHuggingFaceMetadata: 1, # New entry for HuggingFace metadata requests
 }

--- a/common/protocol.py
+++ b/common/protocol.py
@@ -124,9 +124,7 @@ class GetHuggingFaceMetadata(BaseProtocol):
     metadata: List[HuggingFaceMetadata] = pydantic.Field(
         title="metadata",
         description="List of HuggingFace metadata entries.",
-        frozen=False,
-        repr=False,
-        default_factory=list,
+        default_factory=list
     )
 
 # TODO Protocol for Users to Query Data which will accept query parameters such as a startDatetime, endDatetime.

--- a/huggingface_utils/huggingface_uploader.py
+++ b/huggingface_utils/huggingface_uploader.py
@@ -30,10 +30,11 @@ def remove_all_files_in_directory(directory):
 
 
 class HuggingFaceUploader:
-    def __init__(self, db_path, output_dir='hf_storage'):
+    def __init__(self, db_path: str, miner_uid:int, output_dir: str = 'hf_storage'):
         self.db_path = db_path
         self.output_dir = output_dir
         self.hf_api = HfApi()
+        self.miner_uid = miner_uid
         self.hf_token = os.getenv("HUGGINGFACE_TOKEN")
 
     def upload_sql_to_huggingface(self, storage, chunk_size=1_000_000):
@@ -65,7 +66,7 @@ class HuggingFaceUploader:
                 ))
 
             except Exception as e:
-                bt.logging.info(f"Failed to load and save data from table {self.table_name}: {e}")
+                bt.logging.info(f"Failed to load and save data from table DataEntity: {e}")
 
         storage.store_hf_dataset_info(hf_values)
 
@@ -74,7 +75,7 @@ class HuggingFaceUploader:
             bt.logging.error("Hugging Face token not found. Please check your environment variables.")
             return
 
-        dataset_name = 'reddit_dataset' if source == 1 else 'x_dataset'
+        dataset_name = f'reddit_dataset_{self.miner_uid}' if source == 1 else f'x_dataset{self.miner_uid}'
         repo_id = f"{self.hf_api.whoami(self.hf_token)['name']}/{dataset_name}"
 
         self.hf_api.create_repo(token=self.hf_token, repo_id=dataset_name, private=False, repo_type="dataset",

--- a/huggingface_utils/huggingface_uploader.py
+++ b/huggingface_utils/huggingface_uploader.py
@@ -47,6 +47,7 @@ class HuggingFaceUploader:
             try:
 
                 query = f"SELECT datetime, label, content FROM DataEntity WHERE source = {source};"
+                bt.logging.info(f"Started uploading the data into HF with the source: {source}")
                 with sqlite3.connect(self.db_path) as conn:
                     df_iterator = pd.read_sql_query(query, conn, chunksize=chunk_size)
 
@@ -57,6 +58,7 @@ class HuggingFaceUploader:
                     bt.logging.info(f"Saved Parquet file: {parquet_path}")
 
                 repo_id = self.upload_parquet_to_hf(source)
+                bt.logging.info(f'Dataset {repo_id} uploaded.')
                 remove_all_files_in_directory(self.output_dir)
 
                 hf_values.append(HuggingFaceMetadata(

--- a/huggingface_utils/huggingface_uploader.py
+++ b/huggingface_utils/huggingface_uploader.py
@@ -3,7 +3,7 @@ import pandas as pd
 import bittensor as bt
 import os
 from huggingface_hub import HfApi
-from huggingface_utils.utils import preprocess_reddit_df, preprocess_twitter_df
+from huggingface_utils.utils import preprocess_reddit_df, preprocess_twitter_df, generate_static_integer
 from dotenv import load_dotenv
 import datetime as dt
 from common.data import HuggingFaceMetadata
@@ -75,7 +75,7 @@ class HuggingFaceUploader:
             bt.logging.error("Hugging Face token not found. Please check your environment variables.")
             return
 
-        dataset_name = f'reddit_dataset_{self.miner_uid}' if source == 1 else f'x_dataset{self.miner_uid}'
+        dataset_name = f'reddit_dataset_{self.miner_uid}' if source == 1 else f'x_dataset_{self.miner_uid}'
         repo_id = f"{self.hf_api.whoami(self.hf_token)['name']}/{dataset_name}"
 
         self.hf_api.create_repo(token=self.hf_token, repo_id=dataset_name, private=False, repo_type="dataset",

--- a/huggingface_utils/utils.py
+++ b/huggingface_utils/utils.py
@@ -1,11 +1,18 @@
 import pandas as pd
 import json
+import hashlib
 from dotenv import load_dotenv
 
 load_dotenv()
 
 TWEET_DATASET_COLUMNS = ['text', 'label', 'tweet_hashtags', 'datetime']
 REDDIT_DATASET_COLUMNS = ['text', 'label', 'dataType', 'communityName', 'datetime']
+
+
+def generate_static_integer(hotkey: str, max_value=256) -> int:
+    hash_value = hashlib.md5(hotkey.encode()).digest()
+    integer_value = int.from_bytes(hash_value, byteorder='big')
+    return integer_value % max_value
 
 
 def preprocess_twitter_df(df: pd.DataFrame):

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -122,6 +122,7 @@ class Miner:
         if self.use_hf_uploader:
             self.hf_uploader = HuggingFaceUploader(
                 db_path=self.config.neuron.database_name,
+                miner_uid=self.uid
             )
 
         # Instantiate storage.

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -30,6 +30,7 @@ from common.protocol import (
     GetDataEntityBucket,
     GetMinerIndex,
     GetContentsByBuckets,
+    GetHuggingFaceMetadata,
     REQUEST_LIMIT_BY_TYPE_PER_PERIOD,
 )
 from neurons.config import NeuronType
@@ -101,6 +102,10 @@ class Miner:
                 forward_fn=self.get_contents_by_buckets,
                 blacklist_fn=self.get_contents_by_buckets_blacklist,
                 priority_fn=self.get_contents_by_buckets_priority,
+            ).attach(
+                forward_fn=self.get_huggingface_metadata,
+                blacklist_fn=self.get_huggingface_metadata_blacklist,
+                priority_fn=self.get_huggingface_metadata_priority,
             )
             bt.logging.success(f"Axon created: {self.axon}.")
 
@@ -397,6 +402,26 @@ class Miner:
         )
 
         return synapse
+
+    async def get_huggingface_metadata(self, synapse: GetHuggingFaceMetadata) -> GetHuggingFaceMetadata:
+        bt.logging.info(f"Got a GetHuggingFaceMetadata request from {synapse.dendrite.hotkey}.")
+
+        # Query the HuggingFace metadata from the database
+        synapse.metadata = self.storage.get_hf_metadata()
+
+        if not synapse.metadata:
+            bt.logging.info(f"No HuggingFace metadata available. Returning empty list to {synapse.dendrite.hotkey}.")
+        else:
+            bt.logging.success(
+                f"Returning {len(synapse.metadata)} HuggingFace metadata entries to {synapse.dendrite.hotkey}.")
+
+        return synapse
+
+    async def get_huggingface_metadata_blacklist(self, synapse: GetHuggingFaceMetadata) -> typing.Tuple[bool, str]:
+        return self.default_blacklist(synapse)
+
+    async def get_huggingface_metadata_priority(self, synapse: GetHuggingFaceMetadata) -> float:
+        return self.default_priority(synapse)
 
     async def get_data_entity_bucket_blacklist(
         self, synapse: GetDataEntityBucket

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -190,6 +190,7 @@ class Miner:
         while not self.should_exit:
             try:
                 if self.storage.should_upload_hf_data():
+                    bt.logging.info("Trying to upload the data into HuggingFace.")
                     self.hf_uploader.upload_sql_to_huggingface(self.storage)
             # In case of unforeseen errors, the refresh thread will log the error and continue operations.
             except Exception:

--- a/scraping/x/utils.py
+++ b/scraping/x/utils.py
@@ -4,7 +4,6 @@ import traceback
 from typing import Dict, List
 from urllib.parse import urlparse
 from common.data import DataEntity
-from common.constants import RETWEET_ELIGIBLE_DATE, RETWEET_HALT_DATE
 import datetime as dt
 from scraping import utils
 from scraping.scraper import ValidationResult
@@ -186,24 +185,12 @@ def validate_tweet_content(
             content_size_bytes_validated=entity.content_size_bytes,
         )
 
-    if is_retweet and dt.datetime.now(dt.timezone.utc) >= RETWEET_HALT_DATE:
+    if is_retweet:
         return ValidationResult(
             is_valid=False,
             reason="Retweets are no longer eligible after July 6, 2024.",
             content_size_bytes_validated=entity.content_size_bytes
         )
-
-    if is_retweet:
-        if actual_tweet_obfuscated_timestamp >= RETWEET_ELIGIBLE_DATE:
-            return ValidationResult(
-                    is_valid=False,
-                    reason="That is not an original tweet; it's a retweet created after eligible date.",
-                    content_size_bytes_validated=entity.content_size_bytes,
-                )
-        else:
-            bt.logging.info(
-                f"That is not an original tweet; it's a retweet. It will not be scored starting June 6th."
-            )
 
 
     # Wahey! A valid Tweet.

--- a/storage/miner/sqlite_miner_storage.py
+++ b/storage/miner/sqlite_miner_storage.py
@@ -259,9 +259,9 @@ class SqliteMinerStorage(MinerStorage):
             i = 0
             for row in cursor:
                 hf_metadata = HuggingFaceMetadata(
-                    repo_name=row['repo_name'],
+                    repo_name=row['uri'],
                     source=row['source'],
-                    updated_at=row['updated_at']
+                    updated_at=row['updatedAt']
                 )
 
                 hf_metadatas.append(hf_metadata)

--- a/storage/miner/sqlite_miner_storage.py
+++ b/storage/miner/sqlite_miner_storage.py
@@ -246,6 +246,28 @@ class SqliteMinerStorage(MinerStorage):
             print(f"An error occurred: {e}")
             return False
 
+    def get_hf_metadata(self) -> List[HuggingFaceMetadata]:
+        sql_query = """
+            SELECT * FROM HFMetaData;
+        """
+
+        with contextlib.closing(self._create_connection()) as connection:
+            cursor = connection.cursor()
+            cursor.execute(sql_query)
+            hf_metadatas = []
+
+            i = 0
+            for row in cursor:
+                hf_metadata = HuggingFaceMetadata(
+                    repo_name=row['repo_name'],
+                    source=row['source'],
+                    updated_at=row['updated_at']
+                )
+
+                hf_metadatas.append(hf_metadata)
+
+        return hf_metadatas
+
     def list_data_entities_in_data_entity_bucket(
         self, data_entity_bucket_id: DataEntityBucketId
     ) -> List[DataEntity]:

--- a/storage/miner/sqlite_miner_storage.py
+++ b/storage/miner/sqlite_miner_storage.py
@@ -221,7 +221,12 @@ class SqliteMinerStorage(MinerStorage):
     def should_upload_hf_data(self) -> bool:
         sql_query = """
             SELECT datetime(AVG(strftime('%s', UpdatedAt)), 'unixepoch') AS AvgUpdatedAt
-            FROM HFMetaData;
+            FROM (
+                SELECT UpdatedAt
+                FROM HFMetaData
+                ORDER BY UpdatedAt DESC
+                LIMIT 2
+            );
         """
         try:
             with contextlib.closing(self._create_connection()) as connection:
@@ -248,7 +253,9 @@ class SqliteMinerStorage(MinerStorage):
 
     def get_hf_metadata(self) -> List[HuggingFaceMetadata]:
         sql_query = """
-            SELECT * FROM HFMetaData;
+            SELECT * FROM HFMetaData
+            ORDER BY UpdatedAt DESC
+            LIMIT 2;
         """
 
         with contextlib.closing(self._create_connection()) as connection:

--- a/storage/validator/sqlite_memory_validator_storage.py
+++ b/storage/validator/sqlite_memory_validator_storage.py
@@ -3,8 +3,8 @@ import datetime as dt
 import bittensor as bt
 import sqlite3
 import threading
-from typing import Any, Dict, Optional, Set, Tuple
-from common.data import CompressedMinerIndex, DataLabel
+from typing import Any, Dict, Optional, Set, Tuple, List
+from common.data import CompressedMinerIndex, DataLabel, HuggingFaceMetadata
 from common.data_v2 import ScorableDataEntityBucket, ScorableMinerIndex
 from storage.validator.validator_storage import ValidatorStorage
 
@@ -108,6 +108,14 @@ class SqliteMemoryValidatorStorage(ValidatorStorage):
     MINER_INDEX_TABLE_BUCKET_SIZE_INDEX = """CREATE INDEX IF NOT EXISTS bucket_size_index
                                              ON MinerIndex (source, labelId, timeBucketId, contentSizeBytes)"""
 
+    HF_METADATA_TABLE_CREATE = """CREATE TABLE IF NOT EXISTS HFMetadata (
+                                        minerId     INTEGER         NOT NULL,
+                                        repo_name   TEXT            NOT NULL,
+                                        source      INTEGER         NOT NULL,
+                                        updated_at  TIMESTAMP       NOT NULL,
+                                        PRIMARY KEY (minerId, repo_name)
+                                        )"""
+
     def __init__(self):
         sqlite3.register_converter("timestamp", tz_aware_timestamp_adapter)
 
@@ -127,6 +135,7 @@ class SqliteMemoryValidatorStorage(ValidatorStorage):
                 SqliteMemoryValidatorStorage.MINER_INDEX_TABLE_BUCKET_SIZE_INDEX
             )
 
+            cursor.execute(SqliteMemoryValidatorStorage.HF_METADATA_TABLE_CREATE)
             # Lock to avoid concurrency issues on interacting with the database.
             self.lock = threading.RLock()
 
@@ -319,7 +328,7 @@ class SqliteMemoryValidatorStorage(ValidatorStorage):
         """Removes the index and miner details for the specified miner."""
         with self.lock:
             self._delete_miner_index(hotkey)
-
+            self._delete_hf_metadata(hotkey)
             with contextlib.closing(self._create_connection()) as connection:
                 cursor = connection.cursor()
                 cursor.execute("DELETE FROM Miner WHERE hotkey = ?", [hotkey])
@@ -337,3 +346,92 @@ class SqliteMemoryValidatorStorage(ValidatorStorage):
                     return result[0]
                 else:
                     return None
+
+    # Hugging face functionality
+    def upsert_hf_metadata(self, hotkey: str, metadata: List[HuggingFaceMetadata]):
+        """Stores or updates the HuggingFace metadata for a specific miner."""
+        bt.logging.trace(f"{hotkey}: Upserting HuggingFace metadata with {len(metadata)} entries")
+
+        with self.lock:
+            with contextlib.closing(self._create_connection()) as connection:
+                cursor = connection.cursor()
+                cursor.execute("SELECT minerId FROM Miner WHERE hotkey = ?", [hotkey])
+                result = cursor.fetchone()
+                if result is None:
+                    bt.logging.warning(f"{hotkey}: Attempted to upsert HF metadata for non-existent miner")
+                    return
+                miner_id = result[0]
+
+                for entry in metadata:
+                    cursor.execute("""
+                        INSERT OR REPLACE INTO HFMetadata 
+                        (minerId, repo_name, source, updated_at) 
+                        VALUES (?, ?, ?, ?)
+                    """, (miner_id, entry.repo_name, entry.source, entry.updated_at))
+                connection.commit()
+
+    def read_hf_metadata(self, miner_hotkey: str) -> List[HuggingFaceMetadata]:
+        """Gets the HuggingFace metadata for a specific miner."""
+        with self.lock:
+            with contextlib.closing(self._create_connection()) as connection:
+                cursor = connection.cursor()
+                cursor.execute("SELECT minerId FROM Miner WHERE hotkey = ?", [miner_hotkey])
+                result = cursor.fetchone()
+                if result is None:
+                    return []
+                miner_id = result[0]
+
+                cursor.execute("""
+                    SELECT repo_name, source, updated_at 
+                    FROM HFMetadata 
+                    WHERE minerId = ?
+                """, (miner_id,))
+                return [HuggingFaceMetadata(
+                    repo_name=row[0],
+                    source=row[1],
+                    updated_at=row[2]
+                ) for row in cursor.fetchall()]
+
+    def _delete_hf_metadata(self, miner_hotkey: str):
+        """Removes the HuggingFace metadata for the specified miner."""
+        bt.logging.trace(f"{miner_hotkey}: Deleting HuggingFace metadata")
+
+        with contextlib.closing(self._create_connection()) as connection:
+            cursor = connection.cursor()
+            cursor.execute("SELECT minerId FROM Miner WHERE hotkey = ?", [miner_hotkey])
+            result = cursor.fetchone()
+            if result is not None:
+                cursor.execute("DELETE FROM HFMetadata WHERE minerId = ?", [result[0]])
+                connection.commit()
+
+    def has_hf_metadata(self, miner_hotkey: str) -> bool:
+        """Checks if a specific miner has any HuggingFace metadata."""
+        with self.lock:
+            with contextlib.closing(self._create_connection()) as connection:
+                cursor = connection.cursor()
+                cursor.execute("SELECT minerId FROM Miner WHERE hotkey = ?", [miner_hotkey])
+                result = cursor.fetchone()
+                if result is None:
+                    return False
+                miner_id = result[0]
+
+                cursor.execute("SELECT EXISTS(SELECT 1 FROM HFMetadata WHERE minerId = ?)", (miner_id,))
+                return bool(cursor.fetchone()[0])
+
+    def read_hf_metadata_last_updated(self, miner_hotkey: str) -> Optional[dt.datetime]:
+        """Gets when a specific miner's HuggingFace metadata was last updated."""
+        with self.lock:
+            with contextlib.closing(self._create_connection()) as connection:
+                cursor = connection.cursor()
+                cursor.execute("SELECT minerId FROM Miner WHERE hotkey = ?", [miner_hotkey])
+                result = cursor.fetchone()
+                if result is None:
+                    return None
+                miner_id = result[0]
+
+                # TODO DO WE NEED TO TAKE MAX VALUE?
+                cursor.execute(
+                    "SELECT MAX(updated_at) FROM HFMetadata WHERE minerId = ?", (miner_id,)
+                )
+                result = cursor.fetchone()
+                return result[0] if result and result[0] is not None else None

--- a/tests/integration/test_protocol.py
+++ b/tests/integration/test_protocol.py
@@ -1,4 +1,4 @@
-from typing import Callable, Tuple
+from typing import Callable, Tuple, List
 import unittest
 import bittensor as bt
 import datetime as dt
@@ -12,9 +12,10 @@ from common.data import (
     DataLabel,
     DataSource,
     TimeBucket,
+    HuggingFaceMetadata,
 )
 
-from common.protocol import GetDataEntityBucket, GetMinerIndex
+from common.protocol import GetDataEntityBucket, GetMinerIndex, GetHuggingFaceMetadata
 from storage.miner.miner_storage import MinerStorage
 from storage.miner.sqlite_miner_storage import SqliteMinerStorage
 from storage.validator.sqlite_memory_validator_storage import (
@@ -28,10 +29,10 @@ class FakeMiner:
     """A simple implementation of a miner that defines the protocol forward functions."""
 
     def __init__(
-        self,
-        index: GetMinerIndex = None,
-        entities: GetDataEntityBucket = None,
-        storage: MinerStorage = None,
+            self,
+            index: GetMinerIndex = None,
+            entities: GetDataEntityBucket = None,
+            storage: MinerStorage = None,
     ):
         self.index = index
         self.entities = entities
@@ -47,16 +48,17 @@ class FakeMiner:
         return self.index
 
     def get_data_bucket(
-        self, request: old_protocol.GetDataEntityBucket
+            self, request: old_protocol.GetDataEntityBucket
     ) -> old_protocol.GetDataEntityBucket:
         return self.entities
 
+    def get_huggingface_metadata(self, request: GetHuggingFaceMetadata) -> GetHuggingFaceMetadata:
+        if self.storage:
+            request.metadata = self.storage.get_hf_metadata()
+        return request
+
 
 class IntegrationTestProtocol(unittest.TestCase):
-    # The commented out tests run a mini E2E test for round trip serialization of a protocol message.
-    # To run it, first make sure you have a wallet named "unit_test" with hotkey "unit_test".
-    # Then update the axon info to use the correct addresses for your wallets.
-
     def _insert_and_get_index(self, storage: MinerStorage) -> CompressedMinerIndex:
         now = dt.datetime.now()
         # Create an entity for bucket 1.
@@ -104,6 +106,23 @@ class IntegrationTestProtocol(unittest.TestCase):
             }
         )
 
+    def _insert_test_hf_metadata(self, storage: MinerStorage) -> List[HuggingFaceMetadata]:
+        now = dt.datetime.now(dt.timezone.utc)
+        test_metadata = [
+            HuggingFaceMetadata(
+                repo_name="test_repo_1",
+                source=DataSource.REDDIT,
+                updated_at=now
+            ),
+            HuggingFaceMetadata(
+                repo_name="test_repo_2",
+                source=DataSource.X,
+                updated_at=now + dt.timedelta(hours=1)
+            ),
+        ]
+        storage.store_hf_dataset_info(test_metadata)
+        return test_metadata
+
     def setUp(self):
         # Enable logging
         bt.logging(
@@ -123,13 +142,7 @@ class IntegrationTestProtocol(unittest.TestCase):
         self.miner_storage = SqliteMinerStorage()
 
     def _test_round_trip(self, forward_fn: Callable, request: bt.Synapse) -> bt.Synapse:
-        """Base test for verifying a protocol message between dendrite and axon.
-
-        Args:
-            - forward_fn: The function that handles the request on the axon.
-            - request: The request to send to the axon.
-        """
-
+        """Base test for verifying a protocol message between dendrite and axon."""
         port = 1234
         axon = bt.axon(
             wallet=self.wallet,
@@ -144,7 +157,6 @@ class IntegrationTestProtocol(unittest.TestCase):
 
             dendrite = bt.dendrite(wallet=self.wallet)
 
-            request = GetMinerIndex()
             response = dendrite.query(
                 axons=bt.AxonInfo(
                     version=1,
@@ -191,11 +203,6 @@ class IntegrationTestProtocol(unittest.TestCase):
 
     def test_get_miner_index(self):
         """Tests a round trip using the new compressed miner format."""
-
-        # TODO: Eventually this should write entries to the FakeMiner's storage
-        # and then have the FakeMiner read them back out. For now, we just create
-        # the response the miner will return directly.
-
         compressed_index = self._create_test_index()
 
         expected_response = GetMinerIndex(
@@ -213,8 +220,7 @@ class IntegrationTestProtocol(unittest.TestCase):
             response.compressed_index_serialized,
         )
 
-        # TODO: Refactor the vali so that we can directly use vali code here.
-        # Now that we have the response, write it t othe vali DB.
+        # Now that we have the response, write it to the vali DB.
         got_compressed_index = vali_utils.get_miner_index_from_response(response)
         self.assertEqual(got_compressed_index, compressed_index)
 
@@ -244,7 +250,6 @@ class IntegrationTestProtocol(unittest.TestCase):
 
     def test_get_compressed_miner_index(self):
         """Tests a round trip using the new compressed miner format."""
-
         expected_index = self._insert_and_get_index(self.miner_storage)
 
         # Send a request to the fake miner to get the miner index.
@@ -252,8 +257,7 @@ class IntegrationTestProtocol(unittest.TestCase):
         miner = FakeMiner(storage=self.miner_storage)
         response = self._test_round_trip(miner.get_miner_index, request)
 
-        # TODO: Refactor the vali so that we can directly use vali code here.
-        # Now that we have the response, write it t othe vali DB.
+        # Now that we have the response, write it to the vali DB.
         got_compressed_index = vali_utils.get_miner_index_from_response(response)
         self.assertTrue(
             test_utils.are_compressed_indexes_equal(
@@ -284,6 +288,22 @@ class IntegrationTestProtocol(unittest.TestCase):
             scorable_index.last_updated - dt.datetime.utcnow()
             < dt.timedelta(seconds=30)
         )
+
+    def test_get_huggingface_metadata(self):
+        """Tests a round trip for HuggingFace metadata."""
+        expected_metadata = self._insert_test_hf_metadata(self.miner_storage)
+
+        request = GetHuggingFaceMetadata()
+        miner = FakeMiner(storage=self.miner_storage)
+        response = self._test_round_trip(miner.get_huggingface_metadata, request)
+
+        self.assertTrue(response.is_success)
+        self.assertEqual(len(response.metadata), len(expected_metadata))
+
+        for expected, actual in zip(expected_metadata, response.metadata):
+            self.assertEqual(expected.repo_name, actual.repo_name)
+            self.assertEqual(expected.source, actual.source)
+            self.assertEqual(expected.updated_at, actual.updated_at)
 
 
 if __name__ == "__main__":

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -118,13 +118,14 @@ class MinerEvaluator:
 
         ##########
         # Query HuggingFace metadata
-        hf_metadata = await self._query_huggingface_metadata(hotkey, uid, axon_info)
-        if hf_metadata is not None:
-            bt.logging.info(f"{hotkey}: Retrieved HuggingFace metadata with {len(hf_metadata)} entries.")
-            # You can process or store this metadata as needed
-            # For now, we're just logging it
-        else:
-            bt.logging.info(f"{hotkey}: No HuggingFace metadata available for miner.")
+        if hotkey == '5FxJhi6vT1KEEYXcegtGBJnTkbdBZavYtprHdf6zo6pqfvkR':  # TODO ADD THE OUR MINER HOTKEY
+            hf_metadata = await self._query_huggingface_metadata(hotkey, uid, axon_info)
+            if hf_metadata is not None:
+                bt.logging.info(f"{hotkey}: Retrieved HuggingFace metadata with {len(hf_metadata)} entries.")
+                # You can process or store this metadata as needed
+                # For now, we're just logging it
+            else:
+                bt.logging.info(f"{hotkey}: No HuggingFace metadata available for miner.")
         ##########
         # From that index, find a data entity bucket to sample and get it from the miner.
         chosen_data_entity_bucket: DataEntityBucket = (

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -406,7 +406,8 @@ class MinerEvaluator:
                 return None
 
             response = responses[0]
-            bt.logging.success(f"{hotkey}: Got HuggingFace metadata with {len(response.metadata)} entries.")
+            bt.logging.success(f"{hotkey}: Got HuggingFace metadata with {len(response.metadata)} entries. Entries:"
+                               f" {response.metadata}")
             return response.metadata
         except Exception:
             bt.logging.error(

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -8,6 +8,7 @@ from common import constants
 from common.data_v2 import ScorableMinerIndex
 from common.metagraph_syncer import MetagraphSyncer
 import common.utils as utils
+import datetime as dt
 import bittensor as bt
 from common.data import (
     CompressedMinerIndex,
@@ -17,6 +18,7 @@ from common.data import (
     HuggingFaceMetadata,
 )
 from common.protocol import GetDataEntityBucket, GetMinerIndex, GetHuggingFaceMetadata
+from common.constants import HF_METADATA_QUERY_DATE
 from rewards.data_value_calculator import DataValueCalculator
 from scraping.provider import ScraperProvider
 from scraping.scraper import ScraperId, ValidationResult
@@ -118,7 +120,7 @@ class MinerEvaluator:
 
         ##########
         # Query HuggingFace metadata
-        if hotkey == '5FxJhi6vT1KEEYXcegtGBJnTkbdBZavYtprHdf6zo6pqfvkR':  # TODO ADD THE OUR MINER HOTKEY
+        if dt.datetime.now(dt.timezone.utc) >= HF_METADATA_QUERY_DATE:
             hf_metadata = await self._query_huggingface_metadata(hotkey, uid, axon_info)
             if hf_metadata is not None:
                 bt.logging.info(f"{hotkey}: Retrieved HuggingFace metadata with {len(hf_metadata)} entries.")

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -14,8 +14,9 @@ from common.data import (
     DataEntityBucket,
     DataEntity,
     DataSource,
+    HuggingFaceMetadata,
 )
-from common.protocol import GetDataEntityBucket, GetMinerIndex
+from common.protocol import GetDataEntityBucket, GetMinerIndex, GetHuggingFaceMetadata
 from rewards.data_value_calculator import DataValueCalculator
 from scraping.provider import ScraperProvider
 from scraping.scraper import ScraperId, ValidationResult
@@ -115,6 +116,16 @@ class MinerEvaluator:
             )
             return
 
+        ##########
+        # Query HuggingFace metadata
+        hf_metadata = await self._query_huggingface_metadata(hotkey, uid, axon_info)
+        if hf_metadata is not None:
+            bt.logging.info(f"{hotkey}: Retrieved HuggingFace metadata with {len(hf_metadata)} entries.")
+            # You can process or store this metadata as needed
+            # For now, we're just logging it
+        else:
+            bt.logging.info(f"{hotkey}: No HuggingFace metadata available for miner.")
+        ##########
         # From that index, find a data entity bucket to sample and get it from the miner.
         chosen_data_entity_bucket: DataEntityBucket = (
             vali_utils.choose_data_entity_bucket_to_query(index)
@@ -371,6 +382,34 @@ class MinerEvaluator:
         except Exception:
             bt.logging.error(
                 f"{hotkey} Failed to update and get miner index.",
+                traceback.format_exc(),
+            )
+            return None
+
+    async def _query_huggingface_metadata(
+            self, hotkey: str, uid: int, miner_axon: bt.AxonInfo
+    ) -> Optional[List[HuggingFaceMetadata]]:
+        bt.logging.info(f"{hotkey}: Getting HuggingFace metadata from miner.")
+
+        try:
+            synapse = GetHuggingFaceMetadata(version=constants.PROTOCOL_VERSION)
+            async with bt.dendrite(wallet=self.wallet) as dendrite:
+                responses = await dendrite.forward(
+                    axons=[miner_axon],
+                    synapse=synapse,
+                    timeout=120,
+                )
+
+            if not responses or len(responses) == 0 or not isinstance(responses[0], GetHuggingFaceMetadata):
+                bt.logging.info(f"{hotkey}: Miner failed to respond with HuggingFace metadata.")
+                return None
+
+            response = responses[0]
+            bt.logging.success(f"{hotkey}: Got HuggingFace metadata with {len(response.metadata)} entries.")
+            return response.metadata
+        except Exception:
+            bt.logging.error(
+                f"{hotkey} Failed to query HuggingFace metadata.",
                 traceback.format_exc(),
             )
             return None


### PR DESCRIPTION
What’s New:
• HFMetaData Querying: Validators can now query HFMetaData directly from miners
• NOTE: Validator HFMetaData Querying will NOT affect validation scoring and rewards. This will be gradually implemented in future sprints
• Miner Updates: Enhanced to support validator queries from HFMetaData table
• Logs updates: Added more logs to have a better visibility on HF upload operations.
• Improved Validation Test Cases: Thanks to @dan for spotting this!
• Enhanced HuggingFace Storage: New unique identifier system for multiple miners (kudos to @leaf)
• The datasets names will be displayed on the databox dashboard( soon)