### PR TITLE
Get desirabilities API endpoint

### DIFF
--- a/vali_utils/api/routes.py
+++ b/vali_utils/api/routes.py
@@ -236,7 +236,7 @@ async def set_desirabilities(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.post("/get_desirabilities")
+@router.get("/get_desirabilities")
 @endpoint_error_handler
 async def get_desirability_list(
         validator=Depends(get_validator),


### PR DESCRIPTION
Get desirabilities API endpoint:
returns a list of distribution labels in the network:
example:
```
{
  "distribution": {
    "REDDIT": {
      "weight": 0.6,
      "default_scale_factor": 0.3,
      "label_scale_factors": {
        "r/bitcoin": 1,
        "r/bitcoincash": 1,
        "r/bittensor_": 1,
        "r/btc": 1,
        "r/cryptocurrency": 1,
        "r/cryptomarkets": 1,
        "r/worldpolitics": 0.8,
        "r/worldnews": 1,
        "r/wallstreetbets": 0.7,
        "r/politics": 1
      }
    },
    "X": {
      "weight": 0.4,
      "default_scale_factor": 0.3,
      "label_scale_factors": {
        "#bitcoin": 1,
        "#bitcoiner": 1,
        "#bitcoinnews": 1,
        "#btc": 1,
        "#crypto": 1,
        "#defi": 1,
        "#decentralizedfinance": 1,
        "#tao": 1,
        "#israel": 1,
        "#ukraine": 1,
        "#trump": 1,
        "#harris": 1,
        "#macrocosmos": 1,
        "#macrocosmosai": 1
      }
    }
  },
  "max_age_in_hours": 720
}
```