### PR TITLE
Update the HF validation. 

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -17,7 +17,6 @@
 
 
 import copy
-import datetime as dt
 import sys
 import torch
 import numpy as np
@@ -48,7 +47,6 @@ warnings.filterwarnings(
 )
 
 bt.logging.set_trace(True) # TODO remove it in future
-
 
 
 class Validator:

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -23,7 +23,6 @@ import numpy as np
 import asyncio
 import threading
 import time
-import datetime as dt
 import os
 import wandb
 import subprocess
@@ -45,6 +44,9 @@ warnings.filterwarnings(
     category=DeprecationWarning,
     message="datetime.datetime.utcnow() is deprecated"
 )
+# import datetime after the warning filter
+import datetime as dt
+
 
 bt.logging.set_trace(True) # TODO remove it in future
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -38,7 +38,14 @@ from neurons import __spec_version__ as spec_version
 from rewards.data_value_calculator import DataValueCalculator
 from rich.table import Table
 from rich.console import Console
+import warnings
 
+# Filter out the specific deprecation warning from datetime.utcnow()
+warnings.filterwarnings(
+    "ignore",
+    category=DeprecationWarning,
+    message="datetime.datetime.utcnow() is deprecated"
+)
 
 bt.logging.set_trace(True) # TODO remove it in future
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,6 @@ requests==2.32.3
 huggingface-hub==0.27.1
 datasets~=2.20.0
 pyarrow==17.0.0
+fsspec==2024.5.0
 psutil==5.9.8
 loguru==0.7.3

--- a/vali_utils/api/routes.py
+++ b/vali_utils/api/routes.py
@@ -34,8 +34,8 @@ async def query_data(request: QueryRequest,
     """Handle data queries targeting test miner"""
     try:
 
-        # Get all miner UIDs and sort by stake
-        miner_uids = utils.get_miner_uids(validator.metagraph, validator.uid)
+        # Get all miner UIDs and sort by incentive
+        miner_uids = utils.get_miner_uids(validator.metagraph, validator.uid, 10_000)
         miner_scores = [(uid, float(validator.metagraph.I[uid])) for uid in miner_uids]
         miner_scores.sort(key=lambda x: x[1], reverse=True)
 
@@ -256,7 +256,7 @@ async def query_bucket(
 async def health_check(validator=Depends(get_validator),
                        api_key: str = Depends(verify_api_key)):
     """Health check endpoint"""
-    miner_uids = utils.get_miner_uids(validator.metagraph, validator.uid)
+    miner_uids = utils.get_miner_uids(validator.metagraph, validator.uid, 10_000)
     return {
         "status": "healthy" if validator.is_healthy() else "unhealthy",
         "timestamp": dt.datetime.utcnow(),

--- a/vali_utils/api/routes.py
+++ b/vali_utils/api/routes.py
@@ -105,7 +105,7 @@ async def query_data(request: QueryRequest,
                 "status": "success",
                 "data": unique_data[:request.limit],
                 "meta": {
-                    "miner_hotkey": TEST_MINER_HOTKEY,
+                    "miner_hotkey": hotkey,
                     "miner_uid": uid,
                     "items_returned": len(unique_data)
                 }

--- a/vali_utils/hf_utils.py
+++ b/vali_utils/hf_utils.py
@@ -1,14 +1,17 @@
 """Module for HuggingFace dataset utilities and validation."""
 import os
 import random
-from typing import List, Dict, Any, Tuple
 import bittensor as bt
 import pandas as pd
 from datasets import load_dataset
 import itertools
 import asyncio
 import datetime as dt
-from huggingface_hub import HfApi
+import pyarrow.parquet as pq
+import fsspec
+
+from typing import List, Dict, Any, Tuple, Optional
+from huggingface_hub import HfApi, hf_hub_url
 from huggingface_utils.encoding_system import SymKeyEncodingKeyManager, decode_url
 from scraping.reddit.reddit_custom_scraper import RedditCustomScraper
 from scraping.x.apidojo_scraper import ApiDojoTwitterScraper
@@ -19,38 +22,109 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
-def get_latest_commit_files(repo_id: str) -> List[str]:
+def get_latest_commit_files(repo_id: str) -> Tuple[List[str], Optional[str]]:
+    """
+    Retrieve new or modified parquet files from the latest commit along with its commit date.
+
+    Args:
+        repo_id (str): The HuggingFace dataset repository ID.
+
+    Returns:
+        Tuple[List[str], Optional[str]]: A tuple containing:
+            - A list of new/modified parquet file paths.
+            - The commit date (as a string) or None if unavailable.
+    """
     api = HfApi(token=os.getenv('HUGGINGFACE_TOKEN', ''))
     try:
-        # Get the commit history
         commits = api.list_repo_commits(repo_id=repo_id, repo_type="dataset")
-
         for i, commit in enumerate(commits):
-            # Get files from this commit
             current_files = set(api.list_repo_files(repo_id=repo_id, revision=commit.commit_id, repo_type="dataset"))
-
-            # Get files from previous commit (if it exists)
             previous_files = set()
             if i + 1 < len(commits):
-                previous_files = set(
-                    api.list_repo_files(repo_id=repo_id, revision=commits[i + 1].commit_id, repo_type="dataset"))
-
-            # Find new or modified files
+                previous_files = set(api.list_repo_files(repo_id=repo_id, revision=commits[i + 1].commit_id, repo_type="dataset"))
             new_or_modified_files = current_files - previous_files
-
-            # Filter for new or modified parquet files
-            new_parquet_files = [file for file in new_or_modified_files if
-                                 file.endswith('.parquet') and file.startswith('data/')]
-
+            new_parquet_files = [file for file in new_or_modified_files if file.endswith('.parquet') and file.startswith('data/')]
             if new_parquet_files:
-                return new_parquet_files
-
+                # Attempt to extract commit date from several potential attributes
+                commit_date = getattr(commit, "created_at", None)
+                if commit_date is None:
+                    commit_date = getattr(commit, "commit_date", None)
+                if commit_date is None and hasattr(commit, "commit"):
+                    commit_date = commit.commit.get("author", {}).get("date", None)
+                return new_parquet_files, commit_date
         bt.logging.warning("No commits with new parquet files found")
-        return []
-
+        return [], None
     except Exception as e:
         bt.logging.error(f"An error occurred while fetching commit information: {str(e)}")
-        return []
+        return [], None
+
+
+def compare_latest_commits_parquet_files(repo_id: str) -> Tuple[bool, List[str], Optional[str]]:
+    """
+    Compare the parquet files between the two latest commits.
+
+    Args:
+        repo_id (str): The HuggingFace dataset repository ID.
+
+    Returns:
+        Tuple[bool, List[str], Optional[str]]: A tuple containing:
+            - A boolean indicating whether the two latest commits have the same parquet files.
+            - The list of parquet files from the latest commit.
+            - The commit date of the latest commit (if available).
+    """
+    api = HfApi(token=os.getenv('HUGGINGFACE_TOKEN', ''))
+    try:
+        commits = api.list_repo_commits(repo_id=repo_id, repo_type="dataset")
+        if len(commits) < 2:
+            bt.logging.warning("Not enough commits to compare.")
+            latest_files = list(api.list_repo_files(repo_id=repo_id, revision=commits[0].commit_id, repo_type="dataset"))
+            parquet_files = [file for file in latest_files if file.endswith('.parquet') and file.startswith('data/')]
+            commit_date = getattr(commits[0], "created_at", None)
+            if commit_date is None:
+                commit_date = getattr(commits[0], "commit_date", None)
+            if commit_date is None and hasattr(commits[0], "commit"):
+                commit_date = commits[0].commit.get("author", {}).get("date", None)
+            return True, parquet_files, commit_date
+
+        latest_commit = commits[0]
+        second_commit = commits[1]
+        latest_files = list(api.list_repo_files(repo_id=repo_id, revision=latest_commit.commit_id, repo_type="dataset"))
+        second_files = list(api.list_repo_files(repo_id=repo_id, revision=second_commit.commit_id, repo_type="dataset"))
+        latest_parquet = [file for file in latest_files if file.endswith('.parquet') and file.startswith('data/')]
+        second_parquet = [file for file in second_files if file.endswith('.parquet') and file.startswith('data/')]
+        same = set(latest_parquet) == set(second_parquet)
+        commit_date = getattr(latest_commit, "created_at", None)
+        if commit_date is None:
+            commit_date = getattr(latest_commit, "commit_date", None)
+        if commit_date is None and hasattr(latest_commit, "commit"):
+            commit_date = latest_commit.commit.get("author", {}).get("date", None)
+        return same, latest_parquet, commit_date
+    except Exception as e:
+        bt.logging.error(f"Error comparing commits: {str(e)}")
+        return False, [], None
+
+
+def get_parquet_file_structure(repo_id: str, file: str) -> dict:
+    """
+    Retrieve the schema (structure) of a parquet file from a HuggingFace dataset repository
+    without downloading the entire file.
+
+    Args:
+        repo_id (str): The repository ID.
+        file (str): The parquet file path in the repo.
+
+    Returns:
+        dict: The schema of the parquet file.
+    """
+    try:
+        file_url = hf_hub_url(repo_id=repo_id, filename=file, repo_type="dataset")
+        with fsspec.open(file_url, "rb") as f:
+            parquet_file = pq.ParquetFile(f)
+            schema = parquet_file.schema_arrow
+            return schema.to_dict()
+    except Exception as e:
+        bt.logging.error(f"Error retrieving parquet structure: {str(e)}")
+        return {}
 
 
 def get_validation_data(repo_id: str, files: List[str], num_rows: int = 10) -> Tuple[List[str], pd.DataFrame]:
@@ -62,57 +136,49 @@ def get_validation_data(repo_id: str, files: List[str], num_rows: int = 10) -> T
     """
     if not files:
         raise ValueError("No parquet files found in the dataset.")
-
     selected_file = random.choice(files)
     bt.logging.trace(f"Selected file: {selected_file}")
-
     dataset = load_dataset(
         repo_id,
         data_files={'train': selected_file},
         split='train',
         streaming=True
     )
-
     random_seed = random.randint(0, 2 ** 32 - 1)
     shuffled_dataset = dataset.shuffle(buffer_size=10_000, seed=random_seed)
-
     selected_rows = list(itertools.islice(shuffled_dataset, num_rows))
     df = pd.DataFrame(selected_rows)
-
     encoded_urls = []
     if 'url_encoded' in df.columns:
         encoded_urls = df['url_encoded'].dropna().tolist()[:10]
-
     return encoded_urls, df
 
 
 def decode_dataframe(df: pd.DataFrame, encoding_key: str) -> pd.DataFrame:
     """
-    Decode only username fields, leave URLs encoded for miner validation.
+    Decode only username fields, leaving URLs encoded for miner validation.
     """
     decoded_df = df.copy()
     key_manager = SymKeyEncodingKeyManager(encoding_key)
     key_manager.sym_key = encoding_key.encode()
     fernet = key_manager.get_fernet()
-
-    # Only decode username, leave url_encoded as is
     if 'username_encoded' in decoded_df.columns:
         decoded_df['username'] = decoded_df['username_encoded'].apply(
             lambda x: decode_url(x, fernet) if x else None
         )
         decoded_df = decoded_df.drop(columns=['username_encoded'])
-
-    # Keep url_encoded column for miner validation
     return decoded_df
 
 
 async def validate_hf_content(df: pd.DataFrame, source: DataSource) -> HFValidationResult:
-    """Validate DataFrame content using appropriate scraper."""
+    """
+    Validate DataFrame content using the appropriate scraper.
+    """
     try:
         if source == DataSource.REDDIT:
             scraper = RedditCustomScraper()
         elif source == DataSource.X:
-            scraper = ApiDojoTwitterScraper() # todo
+            scraper = ApiDojoTwitterScraper()  # todo: update as needed
         else:
             bt.logging.error(f"Unknown data source {source}")
             return HFValidationResult(
@@ -120,9 +186,7 @@ async def validate_hf_content(df: pd.DataFrame, source: DataSource) -> HFValidat
                 reason=f"Unknown data source {source}",
                 validation_percentage=0
             )
-
         return await scraper.validate_hf(entities=df.to_dict(orient='records'))
-
     except Exception as e:
         bt.logging.error(f"Error validating content: {str(e)}")
         return HFValidationResult(
@@ -135,8 +199,21 @@ async def validate_hf_content(df: pd.DataFrame, source: DataSource) -> HFValidat
 async def test_hf(repo_id: str):
     print(f"Testing HuggingFace utilities with repo: {repo_id}")
 
-    # Test encoding key (you should replace this with a real encoding key)
-    test_encoding_key = "XdcRI9sPT2e43a8fda53H13HpGqpQLTZHHeIoHPtIMI="
+    # Compare the two latest commits for parquet files.
+    same_commits, latest_parquet_files, latest_commit_date = compare_latest_commits_parquet_files(repo_id)
+    if same_commits:
+        print("The latest two commits have the same parquet files.")
+    else:
+        print("The latest two commits have different parquet files.")
+    if latest_commit_date:
+        print(f"Latest parquet commit date: {latest_commit_date}")
+    else:
+        print("No commit date found for the latest parquet changes.")
+    if same_commits and latest_parquet_files:
+        structure = get_parquet_file_structure(repo_id, latest_parquet_files[0])
+        print(f"Structure of parquet file '{latest_parquet_files[0]}': {structure}")
+    else:
+        print("Skipping parquet structure retrieval due to differences in commits or missing files.")
 
     async def run_test(test_name, test_func, *args):
         print(f"\nTesting {test_name}:")
@@ -148,29 +225,28 @@ async def test_hf(repo_id: str):
             print(f"Error: {str(e)}")
             return None
 
-    # Test get_latest_commit_files
-    new_parquet_files = await run_test("get_latest_commit_files", get_latest_commit_files, repo_id)
+    # Test get_latest_commit_files and show the commit date.
+    result = await run_test("get_latest_commit_files", get_latest_commit_files, repo_id)
+    if result:
+        new_parquet_files, commit_date = result
+        print(f"Latest commit date from get_latest_commit_files: {commit_date}")
+    else:
+        new_parquet_files, commit_date = [], None
 
     if new_parquet_files:
-        # Test get_validation_data
-        encoded_urls, encoded_df = await run_test("get_validation_data", get_validation_data, repo_id,
-                                                  new_parquet_files)
-
+        encoded_urls, encoded_df = await run_test("get_validation_data", get_validation_data, repo_id, new_parquet_files)
         if encoded_urls and not encoded_df.empty:
-            # Test decoding
+            test_encoding_key = "XdcRI9sPT2e43a8fda53H13HpGqpQLTZHHeIoHPtIMI="
             decoded_df = await run_test("decode_dataframe", decode_dataframe, encoded_df, test_encoding_key)
-
             if isinstance(decoded_df, pd.DataFrame) and not decoded_df.empty:
-                # Test content validation
                 test_metadata = HuggingFaceMetadata(
                     repo_name=repo_id,
                     source=DataSource.X,
                     updated_at=dt.datetime.now(),
                     encoding_key=test_encoding_key
                 )
-                validation_result = await run_test("validate_hf_content", validate_hf_content, decoded_df,
-                                                   test_metadata.source)
-                print(f"validation result: {validation_result}")
+                validation_result = await run_test("validate_hf_content", validate_hf_content, decoded_df, test_metadata.source)
+                print(f"Validation result: {validation_result}")
             else:
                 print("Could not proceed with validation due to decoding failure.")
         else:
@@ -180,6 +256,5 @@ async def test_hf(repo_id: str):
 
 
 if __name__ == "__main__":
-    # You can change this to any repository you have access to
-    test_repo_id = "arrmlet/x_dataset_123456"
+    test_repo_id = "arrmlet/x_dataset_123456"  # Change to your repository ID as needed
     asyncio.run(test_hf(test_repo_id))

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -304,7 +304,7 @@ class MinerEvaluator:
                     except Exception as e:
                         bt.logging.error(f"{hotkey}: Failed to parse commit date: {commit_date}. Error: {str(e)}")
                         commit_datetime = None
-                    if commit_datetime and (dt.datetime.utcnow() - commit_datetime) < dt.timedelta(hours=17):
+                    if commit_datetime and (dt.datetime.now(dt.timezone.utc) - commit_datetime) < dt.timedelta(hours=19):
                         bt.logging.info(
                             f"{hotkey}: Latest commit for {hf_metadata.repo_name} is less than 17 hours old. Marking HF validation as False."
                         )

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -38,7 +38,8 @@ from vali_utils.hf_utils import (
     get_latest_commit_files,
     get_validation_data,
     decode_dataframe,
-    validate_hf_content
+    validate_hf_content,
+    compare_latest_commits_parquet_files
 )
 
 
@@ -131,77 +132,14 @@ class MinerEvaluator:
             return
 
         ##########
-        # Query HuggingFace metadata
+        # Query HuggingFace metadata and perform enhanced HF validation.
         current_block = int(self.metagraph.block)
         validation_info = self.hf_storage.get_validation_info(hotkey)
         hf_validation_result = None
-        if validation_info is None or (current_block - validation_info['block']) > 5100: # 5100 blocks = 17 hrs
-            hf_metadatas = await self._query_huggingface_metadata(hotkey, uid, axon_info)
-            if hf_metadatas:
-                for hf_metadata in hf_metadatas:
-                    bt.logging.info(f'{hotkey}: Trying to validate {hf_metadata.repo_name}')
-
-                    # Get parquet files
-                    new_parquet_files = get_latest_commit_files(hf_metadata.repo_name)
-                    if not new_parquet_files:
-                        bt.logging.warning(f"No new parquet files found for {hf_metadata.repo_name}")
-                        continue
-
-                    # Get encoded URLs and DataFrame
-                    encoded_urls, encoded_df = get_validation_data(hf_metadata.repo_name, new_parquet_files)
-
-                    if encoded_urls:
-                        # Get decoded URLs from miner
-                        success, decoded_urls = await self._get_decoded_urls(hotkey, uid, axon_info, encoded_urls)
-                        if success:
-                            try:
-                                # Add length check before DataFrame operation
-                                if len(decoded_urls) == 0:
-                                    bt.logging.error(f"{hotkey}: Got empty decoded_urls list")
-                                    hf_validation_result = HFValidationResult(
-                                        is_valid=False,
-                                        reason=f"{hotkey}: Got empty decoded_urls list",
-                                        validation_percentage=0.0
-                                    )
-                                else:
-                                    decoded_df = encoded_df.copy()
-                                    del encoded_df
-                                    decoded_df = decoded_df.head(
-                                        len(decoded_urls))  # Ensure DataFrame matches decoded_urls length
-                                    decoded_df['url'] = decoded_urls
-                                    hf_validation_result = await validate_hf_content(decoded_df, hf_metadata.source)
-                                    bt.logging.info(
-                                        f'{hotkey}: HuggingFace validation result for {hf_metadata.repo_name}: {hf_validation_result}')
-                            except ValueError as e:
-                                bt.logging.error(f"{hotkey}: ValueError in URL decoding: {str(e)}")
-                                hf_validation_result = HFValidationResult(
-                                        is_valid=False,
-                                        reason=f"{hotkey}: ValueError in URL decoding: {str(e)}",
-                                        validation_percentage=0.0
-                                    )
-                            except Exception as e:
-                                bt.logging.error(f"{hotkey}: Unexpected error in URL decoding: {str(e)}")
-                                hf_validation_result = HFValidationResult(
-                                        is_valid=False,
-                                        reason=f"{hotkey}: Unexpected error in URL decoding: {str(e)}",
-                                        validation_percentage=0.0
-                                    )
-
-                    # Store validation result
-                    self.hf_storage.update_validation_info(
-                        hotkey,
-                        str(hf_metadata.repo_name),
-                        current_block,
-                    )
-            else:
-                self.hf_storage.update_validation_info(
-                    hotkey,
-                    'no_dataset_provided',
-                    current_block,
-                )
+        if validation_info is None or (current_block - validation_info['block']) > 5100:  # ~17 hrs
+            hf_validation_result = await self._perform_hf_validation(hotkey, uid, axon_info, current_block)
         ##########
 
-        ##########
         # From that index, find a data entity bucket to sample and get it from the miner.
         chosen_data_entity_bucket: DataEntityBucket = (
             vali_utils.choose_data_entity_bucket_to_query(index)
@@ -319,6 +257,108 @@ class MinerEvaluator:
                 bt.logging.info(f"{hotkey}: Miner {uid} did not pass HF validation, no bonus awarded. Reason: {hf_validation_result.reason}")
 
             self.scorer.update_hf_boost_and_cred(uid, hf_validation_result.validation_percentage)
+
+    async def _perform_hf_validation(
+            self, hotkey: str, uid: int, axon_info: bt.AxonInfo, current_block: int
+    ) -> Optional[HFValidationResult]:
+        """
+        Performs HuggingFace validation for a miner using metadata from the miner.
+        Enhanced logic:
+          - If the two latest commits for the repo are identical, return an invalid result.
+          - If the latest commit is less than 17 hours old, return an invalid result.
+          - Otherwise, proceed with URL decoding and content validation.
+
+        Returns:
+            An HFValidationResult with validation details or None if no metadata is provided.
+        """
+        hf_validation_result = None
+        hf_metadatas = await self._query_huggingface_metadata(hotkey, uid, axon_info)
+        if hf_metadatas:
+            for hf_metadata in hf_metadatas:
+                bt.logging.info(f"{hotkey}: Trying to validate {hf_metadata.repo_name}")
+
+                # Get parquet files and commit date from the latest commit.
+                new_parquet_files, commit_date = get_latest_commit_files(hf_metadata.repo_name)
+                if not new_parquet_files:
+                    bt.logging.warning(f"No new parquet files found for {hf_metadata.repo_name}")
+                    continue
+
+                # Check if the two latest commits are identical.
+                same_commits, _, _ = compare_latest_commits_parquet_files(hf_metadata.repo_name)
+                if same_commits:
+                    bt.logging.info(
+                        f"{hotkey}: Latest commits for {hf_metadata.repo_name} are identical. Marking HF validation as False."
+                    )
+                    hf_validation_result = HFValidationResult(
+                        is_valid=False,
+                        reason="Latest two commits are identical",
+                        validation_percentage=0.0,
+                    )
+                    self.hf_storage.update_validation_info(hotkey, str(hf_metadata.repo_name), current_block)
+                    continue
+
+                # Check if the latest commit is less than 17 hours old.
+                if commit_date:
+                    try:
+                        commit_datetime = dt.datetime.fromisoformat(commit_date)
+                    except Exception as e:
+                        bt.logging.error(f"{hotkey}: Failed to parse commit date: {commit_date}. Error: {str(e)}")
+                        commit_datetime = None
+                    if commit_datetime and (dt.datetime.utcnow() - commit_datetime) < dt.timedelta(hours=17):
+                        bt.logging.info(
+                            f"{hotkey}: Latest commit for {hf_metadata.repo_name} is less than 17 hours old. Marking HF validation as False."
+                        )
+                        hf_validation_result = HFValidationResult(
+                            is_valid=False,
+                            reason="Latest commit is too recent (<17 hours)",
+                            validation_percentage=0.0,
+                        )
+                        self.hf_storage.update_validation_info(hotkey, str(hf_metadata.repo_name), current_block)
+                        continue
+
+                # Get encoded URLs and a DataFrame from the parquet files.
+                encoded_urls, encoded_df = get_validation_data(hf_metadata.repo_name, new_parquet_files)
+                if encoded_urls:
+                    # Retrieve decoded URLs from the miner.
+                    success, decoded_urls = await self._get_decoded_urls(hotkey, uid, axon_info, encoded_urls)
+                    if success:
+                        try:
+                            if len(decoded_urls) == 0:
+                                bt.logging.error(f"{hotkey}: Got empty decoded_urls list")
+                                hf_validation_result = HFValidationResult(
+                                    is_valid=False,
+                                    reason=f"{hotkey}: Got empty decoded_urls list",
+                                    validation_percentage=0.0,
+                                )
+                            else:
+                                decoded_df = encoded_df.copy()
+                                del encoded_df  # free up memory
+                                # Ensure the DataFrame row count matches the decoded URLs count.
+                                decoded_df = decoded_df.head(len(decoded_urls))
+                                decoded_df['url'] = decoded_urls
+                                hf_validation_result = await validate_hf_content(decoded_df, hf_metadata.source)
+                                bt.logging.info(
+                                    f"{hotkey}: HuggingFace validation result for {hf_metadata.repo_name}: {hf_validation_result}"
+                                )
+                        except ValueError as e:
+                            bt.logging.error(f"{hotkey}: ValueError in URL decoding: {str(e)}")
+                            hf_validation_result = HFValidationResult(
+                                is_valid=False,
+                                reason=f"{hotkey}: ValueError in URL decoding: {str(e)}",
+                                validation_percentage=0.0,
+                            )
+                        except Exception as e:
+                            bt.logging.error(f"{hotkey}: Unexpected error in URL decoding: {str(e)}")
+                            hf_validation_result = HFValidationResult(
+                                is_valid=False,
+                                reason=f"{hotkey}: Unexpected error in URL decoding: {str(e)}",
+                                validation_percentage=0.0,
+                            )
+                # Update the HF validation storage with the current block for this repo.
+                self.hf_storage.update_validation_info(hotkey, str(hf_metadata.repo_name), current_block)
+        else:
+            self.hf_storage.update_validation_info(hotkey, "no_dataset_provided", current_block)
+        return hf_validation_result
 
     async def run_next_eval_batch(self) -> int:
         """Asynchronously runs the next batch of miner evaluations and returns the number of seconds to wait until the next batch.


### PR DESCRIPTION
- Fixed small dTAO bugs with OnDemand request
- Ignore deprecated datetime.utcnow() warningto avoid spam of validator logs
- HF validation
-  if miners uploads same HF parquets validation will fails.
 - if miner didn't add any data into HF repo validation fails.
Happy Mining!