### PR TITLE
fromisoformat issue fix

### DIFF
--- a/vali_utils/hf_utils.py
+++ b/vali_utils/hf_utils.py
@@ -21,7 +21,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
-def get_latest_commit_files(repo_id: str) -> Tuple[List[str], Optional[str]]:
+def get_latest_commit_files(repo_id: str) -> Tuple[List[str], Optional[dt.datetime]]:
     """
     Retrieve new or modified parquet files from the latest commit along with its commit date.
 

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -300,23 +300,24 @@ class MinerEvaluator:
                 #     continue
 
                 # Check if the latest commit is greater than 19 hours old.
-                if commit_date:
+                if isinstance(commit_date, str):
                     try:
-                        commit_datetime = dt.datetime.fromisoformat(commit_date)
+                        bt.logging.info(f"{hotkey}: Commit date is in string format, converting to datetime.datetime.")
+                        commit_date = dt.datetime.fromisoformat(commit_date)
                     except Exception as e:
-                        bt.logging.error(f"{hotkey}: Failed to parse commit date: {commit_date}. Error: {str(e)}")
-                        commit_datetime = None
-                    if commit_datetime and (dt.datetime.now(dt.timezone.utc) - commit_datetime) > dt.timedelta(hours=19):
-                        bt.logging.info(
-                            f"{hotkey}: Latest commit for {hf_metadata.repo_name} is greater than 19 hours old. Marking HF validation as False."
-                        )
-                        hf_validation_result = HFValidationResult(
-                            is_valid=False,
-                            reason="Latest commit is too recent (<17 hours)",
-                            validation_percentage=0.0,
-                        )
-                        self.hf_storage.update_validation_info(hotkey, str(hf_metadata.repo_name), current_block)
-                        continue
+                        bt.logging.error(f"{hotkey}: Failed to parse commit date: {commit_date}. Error: {str(e)}") 
+                     
+                if commit_date and (dt.datetime.now(dt.timezone.utc) - commit_date) > dt.timedelta(hours=19):
+                    bt.logging.info(
+                        f"{hotkey}: Latest commit for {hf_metadata.repo_name} is greater than 19 hours old. Marking HF validation as False."
+                    )
+                    hf_validation_result = HFValidationResult(
+                        is_valid=False,
+                        reason="Latest commit is too old (>19 hours)",
+                        validation_percentage=0.0,
+                    )
+                    self.hf_storage.update_validation_info(hotkey, str(hf_metadata.repo_name), current_block)
+                    continue
 
                 # Get encoded URLs and a DataFrame from the parquet files.
                 encoded_urls, encoded_df = get_validation_data(hf_metadata.repo_name, new_parquet_files)


### PR DESCRIPTION
Fixes error where HF validation resulted in a fromisoformat error because commit_date was not a string but a datetime.datetime instead.