### PR TITLE
Enhanced On-Demand Data Requests

### DIFF
--- a/vali_utils/api/routes.py
+++ b/vali_utils/api/routes.py
@@ -68,7 +68,7 @@ async def query_data(request: QueryRequest,
         selected_miners = []
         selected_coldkeys = set()
 
-        # First, try to get a diverse set from top 30%
+        # First, try to get a diverse set from top miners
         while len(selected_miners) < NUM_MINERS_TO_QUERY and top_miners:
             idx = random.randint(0, len(top_miners) - 1)
             uid, _ = top_miners.pop(idx)
@@ -80,15 +80,14 @@ async def query_data(request: QueryRequest,
                 selected_coldkeys.add(coldkey)
 
         # If we couldn't get enough diverse miners, just take what we have
-        if len(selected_miners) < 2:
+        if len(selected_miners) < 1:
             bt.logging.warning(f"Could only select {len(selected_miners)} diverse miners")
             # Get any miners to make up the numbers
-            while len(selected_miners) < min(NUM_MINERS_TO_QUERY, len(miner_uids)):
-                for uid in miner_uids:
-                    if uid not in selected_miners:
-                        selected_miners.append(uid)
-                        if len(selected_miners) >= NUM_MINERS_TO_QUERY:
-                            break
+            for uid in miner_uids:
+                if uid not in selected_miners:
+                    selected_miners.append(uid)
+                    if len(selected_miners) >= NUM_MINERS_TO_QUERY:
+                        break
 
         bt.logging.info(f"Selected {len(selected_miners)} miners for on-demand query")
 
@@ -334,7 +333,6 @@ async def query_data(request: QueryRequest,
     except Exception as e:
         bt.logging.error(f"Error processing request: {str(e)}")
         raise HTTPException(500, str(e))
-
 
 @router.get("/query_bucket/{source}")
 @endpoint_error_handler

--- a/vali_utils/api/routes.py
+++ b/vali_utils/api/routes.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException, Depends
 import bittensor as bt
 import datetime as dt
+import random
 from common.data import DataSource, TimeBucket, DataEntityBucketId, DataLabel
 from common import constants
 from common.protocol import OnDemandRequest, GetDataEntityBucket
@@ -9,13 +10,13 @@ from vali_utils.api.models import QueryRequest, QueryResponse, HealthResponse, L
     DesirabilityRequest
 from vali_utils.api.auth.auth import require_master_key, verify_api_key
 from vali_utils.api.utils import endpoint_error_handler, select_validation_samples
+from scraping.provider import ScraperProvider
+from scraping.scraper import ValidationResult
+from vali_utils.miner_evaluator import MinerEvaluator
 
 from dynamic_desirability.desirability_uploader import run_uploader_from_gravity
-
 from dynamic_desirability.desirability_retrieval import get_hotkey_json_submission
 from typing import List, Optional
-import random
-
 router = APIRouter()
 
 
@@ -31,22 +32,65 @@ def get_validator():
 async def query_data(request: QueryRequest,
                      validator=Depends(get_validator),
                      api_key: str = Depends(verify_api_key)):
-    """Handle data queries targeting test miner"""
+    """
+    Handle data queries targeting multiple miners with validation and incentives.
+
+    1. Selects multiple miners from top performers
+    2. Queries them with the same request
+    3. Validates data with a small probability
+    4. Rewards/penalizes miners based on data quality
+    5. Returns the best data to the user
+    """
     try:
+        # Constants for miner selection and validation
+        NUM_MINERS_TO_QUERY = 5  # Number of miners to query
+        VALIDATION_PROBABILITY = 0.05  # 5% chance to validate (to minimize API usage)
+        MIN_PENALTY = 0.01  # Minimum credibility penalty for bad data
+        MAX_PENALTY = 0.05  # Maximum credibility penalty for bad data
 
         # Get all miner UIDs and sort by incentive
         miner_uids = utils.get_miner_uids(validator.metagraph, validator.uid, 10_000)
         miner_scores = [(uid, float(validator.metagraph.I[uid])) for uid in miner_uids]
         miner_scores.sort(key=lambda x: x[1], reverse=True)
 
-        # Take top 50%
-        top_miners = miner_scores[:len(miner_scores) // 2]
+        # Take top 60% of miners (but at least 5 if available)
+        top_count = max(5, int(len(miner_scores) * 0.6))
+        top_miners = miner_scores[:top_count]
 
-        # Select random miner from top 50%
-        uid, _ = random.choice(top_miners)
-        hotkey = validator.metagraph.hotkeys[uid]
+        if len(top_miners) < 2:
+            return {
+                "status": "error",
+                "meta": {"error": "Not enough miners available to service request"},
+                "data": []
+            }
 
-        bt.logging.info(f"Selected miner {uid} from top {len(top_miners)} miners")
+        # Select a diverse set of miners (don't pick all from the same hotkey owner if possible)
+        selected_miners = []
+        selected_coldkeys = set()
+
+        # First, try to get a diverse set from top 30%
+        while len(selected_miners) < NUM_MINERS_TO_QUERY and top_miners:
+            idx = random.randint(0, len(top_miners) - 1)
+            uid, _ = top_miners.pop(idx)
+            coldkey = validator.metagraph.coldkeys[uid]
+
+            # Only add if we haven't selected too many miners from this coldkey
+            if coldkey not in selected_coldkeys or len(selected_coldkeys) < 2:
+                selected_miners.append(uid)
+                selected_coldkeys.add(coldkey)
+
+        # If we couldn't get enough diverse miners, just take what we have
+        if len(selected_miners) < 2:
+            bt.logging.warning(f"Could only select {len(selected_miners)} diverse miners")
+            # Get any miners to make up the numbers
+            while len(selected_miners) < min(NUM_MINERS_TO_QUERY, len(miner_uids)):
+                for uid in miner_uids:
+                    if uid not in selected_miners:
+                        selected_miners.append(uid)
+                        if len(selected_miners) >= NUM_MINERS_TO_QUERY:
+                            break
+
+        bt.logging.info(f"Selected {len(selected_miners)} miners for on-demand query")
 
         # Create request synapse
         synapse = OnDemandRequest(
@@ -58,62 +102,239 @@ async def query_data(request: QueryRequest,
             limit=request.limit
         )
 
-        # Query test miner
+        # Query selected miners
+        bt.logging.info(f"Querying miners: {selected_miners}")
+        miner_responses = {}
+        miner_data_counts = {}
+
         async with bt.dendrite(wallet=validator.wallet) as dendrite:
-            axon = validator.metagraph.axons[uid]
+            axons = [validator.metagraph.axons[uid] for uid in selected_miners]
             responses = await dendrite.forward(
-                axons=[axon],
+                axons=axons,
                 synapse=synapse,
                 timeout=30
             )
 
-            # Get first response
-            if not responses:
-                raise HTTPException(503, "No response received from miner")
+            # Process responses
+            for i, response in enumerate(responses):
+                if i < len(selected_miners) and response is not None:
+                    uid = selected_miners[i]
+                    hotkey = validator.metagraph.hotkeys[uid]
 
-            bt.logging.info(f"Raw response from miner: {responses}")
+                    # Check if response has data
+                    data = getattr(response, 'data', [])
+                    data_count = len(data) if data else 0
 
-            response = responses[0]  # This is the synapse
-            bt.logging.info(f"Raw response from miner: {response}")
+                    miner_responses[uid] = response
+                    miner_data_counts[uid] = data_count
 
-            # Access the data directly from the synapse data field
-            all_data = response.data if response.data else []
+                    bt.logging.info(f"Miner {uid} ({hotkey}) returned {data_count} items")
 
-            # Convert DataEntity objects to dictionaries
-            processed_data = []
-            for item in all_data:
-                # Convert DataEntity to dict
-                item_dict = {
-                    'uri': item.uri,
-                    'datetime': item.datetime.isoformat(),
-                    'source': DataSource(item.source).name,
-                    'label': item.label.value if item.label else None,
-                    'content': item.content.decode('utf-8') if isinstance(item.content, bytes) else item.content
-                }
-                processed_data.append(item_dict)
+        if not miner_responses:
+            return {
+                "status": "error",
+                "meta": {"error": "No miners responded to the query"},
+                "data": []
+            }
 
-            # Remove duplicates by converting to string representation
-            seen = set()
-            unique_data = []
-            for item in processed_data:
-                item_str = str(sorted(item.items()))
-                if item_str not in seen:
-                    seen.add(item_str)
-                    unique_data.append(item)
-
+        # Step 1: Check if we have a consensus on "no data"
+        no_data_consensus = all(count == 0 for count in miner_data_counts.values())
+        if no_data_consensus:
+            bt.logging.info("All miners returned no data - likely a valid empty result")
             return {
                 "status": "success",
-                "data": unique_data[:request.limit],
+                "data": [],
                 "meta": {
-                    "miner_hotkey": hotkey,
-                    "miner_uid": uid,
-                    "items_returned": len(unique_data)
+                    "miners_queried": len(selected_miners),
+                    "consensus": "no_data"
                 }
             }
+
+        # Step 2: Check consistency of responses from miners that returned data
+        miners_with_data = [uid for uid, count in miner_data_counts.items() if count > 0]
+
+        if not miners_with_data:
+            return {
+                "status": "error",
+                "meta": {"error": "No miners returned valid data"},
+                "data": []
+            }
+
+        # Get the median data count as a reference point
+        data_counts = [count for count in miner_data_counts.values() if count > 0]
+        median_count = sorted(data_counts)[len(data_counts) // 2]
+
+        # Define consistency threshold (within 30% of median is considered consistent)
+        consistency_threshold = 0.3
+
+        consistent_miners = {}
+        inconsistent_miners = {}
+
+        for uid in miners_with_data:
+            count = miner_data_counts[uid]
+            # Check if count is within threshold of median
+            if median_count > 0 and abs(count - median_count) / median_count <= consistency_threshold:
+                consistent_miners[uid] = miner_responses[uid]
+            else:
+                inconsistent_miners[uid] = miner_responses[uid]
+
+        bt.logging.info(
+            f"Found {len(consistent_miners)} consistent miners and {len(inconsistent_miners)} inconsistent miners")
+
+        # Step 3: Should we validate? (random chance or if consistency is poor)
+        should_validate = random.random() < VALIDATION_PROBABILITY or len(consistent_miners) < len(
+            miners_with_data) // 2
+
+        # Step 4: Validation and penalties
+        validated_miners = {}
+
+        if should_validate:
+            bt.logging.info("Performing validation on returned data")
+            # We'll only validate a subset of data to minimize API usage
+            for uid, response in list(consistent_miners.items()) + list(inconsistent_miners.items()):
+                try:
+                    # Only validate up to 2 items per miner to reduce API cost
+                    data_to_validate = response.data[:2] if hasattr(response, 'data') and response.data else []
+
+                    if not data_to_validate:
+                        continue
+
+                    # Use scraper to validate data
+                    scraper_id = MinerEvaluator.PREFERRED_SCRAPERS.get(synapse.source)
+                    if not scraper_id:
+                        bt.logging.warning(f"No preferred scraper for source {synapse.source}")
+                        continue
+
+                    scraper = ScraperProvider().get(scraper_id)
+                    if not scraper:
+                        bt.logging.warning(f"Could not initialize scraper {scraper_id}")
+                        continue
+
+                    # Validate the data
+                    validation_results = await scraper.validate(data_to_validate)
+
+                    # Calculate validation success rate
+                    valid_count = sum(1 for r in validation_results if r.is_valid)
+                    validation_rate = valid_count / len(validation_results) if validation_results else 0
+
+                    validated_miners[uid] = validation_rate
+
+                    bt.logging.info(f"Miner {uid} validation rate: {validation_rate:.2f}")
+
+                    # Apply penalty to miners with poor validation
+                    if validation_rate < 0.5:  # Less than 50% valid
+                        # This is a soft penalty - calculated based on how bad the data is
+                        # Scale from MIN_PENALTY to MAX_PENALTY based on validation_rate
+                        penalty = MIN_PENALTY + (0.5 - validation_rate) * 2 * (MAX_PENALTY - MIN_PENALTY)
+
+                        # Ensure penalty doesn't make credibility negative
+                        current_cred = validator.evaluator.scorer.get_miner_credibility(uid)
+                        safe_penalty = min(current_cred * 0.2, penalty)  # Never reduce by more than 20%
+
+                        bt.logging.info(f"Applying penalty of {safe_penalty:.4f} to miner {uid}")
+
+                        # Create a validation result for the scorer
+                        validation_result = ValidationResult(
+                            is_valid=False,
+                            reason="Failed on-demand data validation",
+                            content_size_bytes_validated=sum(e.content_size_bytes for e in data_to_validate)
+                        )
+
+                        # Update the miner's score with this result
+                        index = validator.storage.read_miner_index(validator.metagraph.hotkeys[uid])
+                        validator.evaluator.scorer.on_miner_evaluated(uid, index, [validation_result])
+
+                        # Remove this miner from consistent miners if it was there
+                        if uid in consistent_miners:
+                            del consistent_miners[uid]
+                            inconsistent_miners[uid] = response
+
+                except Exception as e:
+                    bt.logging.error(f"Error validating data from miner {uid}: {str(e)}")
+
+        # Step 5: Select best data to return to user
+        best_data = []
+        best_meta = {}
+
+        # First preference: data from validated miners with high validation rates
+        if validated_miners:
+            # Find the miner with the highest validation rate
+            best_uid = max(validated_miners.items(), key=lambda x: x[1])[0]
+            best_miner_response = miner_responses[best_uid]
+            best_data = best_miner_response.data if hasattr(best_miner_response, 'data') else []
+            best_meta = {
+                "source": "validated",
+                "miner_uid": best_uid,
+                "miner_hotkey": validator.metagraph.hotkeys[best_uid],
+                "validation_rate": validated_miners[best_uid]
+            }
+
+        # Second preference: data from consistent miners (if no validation was done or no miners passed validation)
+        elif consistent_miners:
+            # Pick the miner with the most data (but within reason)
+            best_uid = max(consistent_miners.keys(), key=lambda uid: miner_data_counts[uid])
+            best_miner_response = consistent_miners[best_uid]
+            best_data = best_miner_response.data if hasattr(best_miner_response, 'data') else []
+            best_meta = {
+                "source": "consistent",
+                "miner_uid": best_uid,
+                "miner_hotkey": validator.metagraph.hotkeys[best_uid]
+            }
+
+        # Last resort: take data from any miner that returned something
+        elif miners_with_data:
+            # Take the miner with median data count
+            median_uid = sorted(miners_with_data, key=lambda uid: miner_data_counts[uid])[len(miners_with_data) // 2]
+            best_miner_response = miner_responses[median_uid]
+            best_data = best_miner_response.data if hasattr(best_miner_response, 'data') else []
+            best_meta = {
+                "source": "inconsistent",
+                "miner_uid": median_uid,
+                "miner_hotkey": validator.metagraph.hotkeys[median_uid]
+            }
+
+        # Process the data for return
+        processed_data = []
+        for item in best_data:
+            # Convert DataEntity to dict
+            item_dict = {
+                'uri': item.uri,
+                'datetime': item.datetime.isoformat(),
+                'source': DataSource(item.source).name,
+                'label': item.label.value if item.label else None,
+                'content': item.content.decode('utf-8') if isinstance(item.content, bytes) else item.content
+            }
+            processed_data.append(item_dict)
+
+        # Remove duplicates by converting to string representation
+        seen = set()
+        unique_data = []
+        for item in processed_data:
+            item_str = str(sorted(item.items()))
+            if item_str not in seen:
+                seen.add(item_str)
+                unique_data.append(item)
+
+        # Add summary info to meta
+        best_meta.update({
+            "miners_queried": len(selected_miners),
+            "miners_responded": len(miner_responses),
+            "consistent_miners": len(consistent_miners),
+            "inconsistent_miners": len(inconsistent_miners),
+            "validated_miners": len(validated_miners) if should_validate else 0,
+            "items_returned": len(unique_data)
+        })
+
+        return {
+            "status": "success",
+            "data": unique_data[:request.limit],
+            "meta": best_meta
+        }
 
     except Exception as e:
         bt.logging.error(f"Error processing request: {str(e)}")
         raise HTTPException(500, str(e))
+
 
 @router.get("/query_bucket/{source}")
 @endpoint_error_handler


### PR DESCRIPTION
This PR improves the data request functionality by querying multiple miners instead of just one, which helps deliver better results to API users.


**What's Changed**
- Now queries 5 miners instead of just 1 for each request ( random coldkeys). 
- Added consistency checks between miner responses
- Implemented occasional validation of returned data (5% of requests)
- Added small credibility penalties for miners who return bad data
- Improved handling of empty results and non-existent data queries
- Better selection logic to return the most reliable data to users

**Implementation Details**

The function now compares responses between miners to identify consistent data. When data looks suspicious or during random checks, it validates a small sample to confirm quality without overusing our APIfy credits.

Miners returning bad data receive a small credibility reduction (max 5%), while making sure we never reduce credibility too drastically at once.

Overall, this change should improve data quality for API users while maintaining a fair system for miners.
