### PR TITLE
fix_selection

### DIFF
--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -141,7 +141,11 @@ class MinerEvaluator:
 
         # From that index, find a data entity bucket to sample and get it from the miner.
         chosen_data_entity_bucket: DataEntityBucket = (
-            vali_utils.choose_data_entity_bucket_to_query(index)
+            vali_utils.choose_data_entity_bucket_to_query(
+                index,
+                hotkey,
+                current_block,
+            )
         )
         bt.logging.info(
             f"{hotkey} Querying miner for Bucket ID: {chosen_data_entity_bucket.id}."


### PR DESCRIPTION
### :rotating_light: RNG-prediction bug fixed

|                | Details |
|----------------|---------|
| **Bug file**   | `vali_utils/utils.py` |
| **Bug**        | `choose_data_entity_bucket_to_query` called `random.uniform()` from Python’s *global* RNG. Because that RNG is deterministic and shared, a miner running several sybil nodes could observe a few rounds, reverse-engineer the stream, and ensure we always validate the **same single “good” bucket** while the rest of their data is junk. |

There are a few requests from the team. Ewekazoo has agreed to make the necessary changes.