### PR TITLE
Bucket selection: time-based seed

### DIFF
--- a/tests/vali_utils/test_vali_utils.py
+++ b/tests/vali_utils/test_vali_utils.py
@@ -21,9 +21,10 @@ from common import utils
 
 class TestValiUtils(unittest.TestCase):
     def test_choose_data_entity_bucket_to_query(self):
-        """Distribution should match scorable-byte weights 100:200:300 → 1:2:3."""
+        """Calls choose_data_entity_bucket_to_query 10000 times and ensures the distribution of buckets chosen is as expected."""
+        # We use scorable bytes when selecting, so keep size bytes identical.
         index = ScorableMinerIndex(
-            hotkey="ignore",   # not used for sampling
+            hotkey="abc123",
             scorable_data_entity_buckets=[
                 ScorableDataEntityBucket(
                     time_bucket_id=utils.time_bucket_id_from_datetime(
@@ -56,18 +57,15 @@ class TestValiUtils(unittest.TestCase):
             last_updated=dt.datetime.now(tz=dt.timezone.utc),
         )
 
+        # Sample the buckets, counting how often each is chosen
         counts = [0, 0, 0]
-        for i in range(10_000):
-            # vary hotkey so each draw uses a different deterministic seed
-            chosen = vali_utils.choose_data_entity_bucket_to_query(
-                index,
-                f"miner_{i}",
-                123456,          # block number fixed for reproducibility
-            )
-            counts[int(chosen.id.label.value)] += 1
+        for _ in range(10000):
+            chosen_bucket = vali_utils.choose_data_entity_bucket_to_query(index)
+            self.assertIsInstance(chosen_bucket, DataEntityBucket)
+            counts[int(chosen_bucket.id.label.value)] += 1
 
         total = sum(counts)
-        ratios = [c / total for c in counts]
+        ratios = [count / total for count in counts]
         self.assertAlmostEqual(ratios[0], 1 / 6, delta=0.05)
         self.assertAlmostEqual(ratios[1], 1 / 3, delta=0.05)
         self.assertAlmostEqual(ratios[2], 0.5,   delta=0.05)
@@ -495,7 +493,7 @@ class TestValiUtils(unittest.TestCase):
                 content_size_bytes=482,
             ),
             DataEntity(
-                uri="https://x.com/DorisCeciliaCa6/status/1773902901280129234",
+                uri="https://twitter.com/DorisCeciliaCa6/status/1773902901280129234",
                 datetime=datetime,
                 source=DataSource.X,
                 label=label,

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -141,11 +141,7 @@ class MinerEvaluator:
 
         # From that index, find a data entity bucket to sample and get it from the miner.
         chosen_data_entity_bucket: DataEntityBucket = (
-            vali_utils.choose_data_entity_bucket_to_query(
-                index,
-                hotkey,
-                current_block,
-            )
+            vali_utils.choose_data_entity_bucket_to_query(index)
         )
         bt.logging.info(
             f"{hotkey} Querying miner for Bucket ID: {chosen_data_entity_bucket.id}."

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -141,7 +141,11 @@ class MinerEvaluator:
 
         # From that index, find a data entity bucket to sample and get it from the miner.
         chosen_data_entity_bucket: DataEntityBucket = (
-            vali_utils.choose_data_entity_bucket_to_query(index)
+            vali_utils.choose_data_entity_bucket_to_query(
+                index,
+                hotkey,
+                current_block,
+            )
         )
         bt.logging.info(
             f"{hotkey} Querying miner for Bucket ID: {chosen_data_entity_bucket.id}."

--- a/vali_utils/utils.py
+++ b/vali_utils/utils.py
@@ -18,9 +18,7 @@ from scraping.x import utils as x_utils
 
 from random import Random
 
-def choose_data_entity_bucket_to_query(
-    index: ScorableMinerIndex,
-) -> DataEntityBucket:
+def choose_data_entity_bucket_to_query(index: ScorableMinerIndex) -> DataEntityBucket:
     """Securely pick one DataEntityBucket to validate.
     Uses a seed based on system time.
     """

--- a/vali_utils/utils.py
+++ b/vali_utils/utils.py
@@ -22,8 +22,7 @@ def choose_data_entity_bucket_to_query(
     index: ScorableMinerIndex,
 ) -> DataEntityBucket:
     """Securely pick one DataEntityBucket to validate.
-    Uses a deterministic seed based on system time (SHA256(current_timestamp)),
-    so the choice is deterministic for a given time period.
+    Uses a seed based on system time (SHA256(current_timestamp))
     """
     total_size = sum(
         scorable_bucket.scorable_bytes 

--- a/vali_utils/utils.py
+++ b/vali_utils/utils.py
@@ -22,16 +22,15 @@ def choose_data_entity_bucket_to_query(
     index: ScorableMinerIndex,
 ) -> DataEntityBucket:
     """Securely pick one DataEntityBucket to validate.
-    Uses a seed based on system time (SHA256(current_timestamp))
+    Uses a seed based on system time.
     """
     total_size = sum(
         scorable_bucket.scorable_bytes 
         for scorable_bucket in index.scorable_data_entity_buckets
     )
     
-    # Use current system time as seed input
-    current_time = time.time()
-    seed = int(hashlib.sha256(str(current_time).encode()).hexdigest(), 16) % (2**32)
+    # Use nanosecond precision timestamp as seed
+    seed = time.time_ns()
     rng = Random(seed)
     chosen_byte = rng.uniform(0, total_size)
     


### PR DESCRIPTION
Big thanks to contributor:
@sniper-noob 

https://github.com/macrocosm-os/data-universe/pull/450#issue-3097604202

### :rotating_light: RNG-prediction bug fixed

|                | Details |
|----------------|---------|
| **Bug file**   | `vali_utils/utils.py` |
| **Bug**        | `choose_data_entity_bucket_to_query` called `random.uniform()` from Python’s *global* RNG. Because that RNG is deterministic and shared, a miner running several sybil nodes could observe a few rounds, reverse-engineer the stream, and ensure we always validate the **same single “good” bucket** while the rest of their data is junk. |

There are a few requests from the team. Ewekazoo has agreed to make the necessary changes.