### PR TITLE
Set "get_yt_original_metadata": True

### DIFF
--- a/scraping/youtube/invideoiq_transcript_scraper.py
+++ b/scraping/youtube/invideoiq_transcript_scraper.py
@@ -305,7 +305,8 @@ class YouTubeChannelTranscriptScraper(Scraper):
 
             run_input = {
                 "video_url": video_url,
-                "best_effort": True
+                "best_effort": True,
+                "get_yt_original_metadata": True
             }
 
             run_config = RunConfig(
@@ -345,7 +346,8 @@ class YouTubeChannelTranscriptScraper(Scraper):
             run_input = {
                 "video_url": video_url,
                 "language": language,
-                "best_effort": True
+                "best_effort": True,
+                "get_yt_original_metadata": True
             }
 
             run_config = RunConfig(


### PR DESCRIPTION
From Actor dev -- ""I’ve added a new boolean parameter called get_yt_original_metadata (default is false). If you call the Actor with this parameter set to true, it will return the original YouTube title and description.""