### PR TITLE
utils.get_miner_uids(self.metagraph, self.vpermit_rao_limit)

### DIFF
--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -503,7 +503,8 @@ class MinerEvaluator:
                         )
             # Update the iterator. It will keep its current position if possible.
             self.miner_iterator.set_miner_uids(
-                utils.get_miner_uids(self.metagraph, self.vpermit_rao_limit)
+                #utils.get_miner_uids(self.metagraph, self.vpermit_rao_limit) # uses cached/stale self.metagraph --> iterator may miss new miners and keep removed ones.
+                utils.get_miner_uids(metagraph, self.vpermit_rao_limit) # use fresh metagraph --> iterator gets latest eligible UIDs immediately
             )
 
             # Check to see if the metagraph has changed size.


### PR DESCRIPTION
Uses cached/stale self.metagraph --> iterator may miss new miners and keep removed ones.