### PR TITLE
Fix - got an unexpected keyword argument 'evaluation_start_time'

### DIFF
--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -226,8 +226,7 @@ class MinerEvaluator:
                         reason="Duplicate entities found.",
                         content_size_bytes_validated=0,  # Since there is just one failed result size doesn't matter.
                     )
-                ],
-                evaluation_start_time=t_start
+                ]
             )
 
             metrics.MINER_EVALUATOR_EVAL_MINER_DURATION.labels(hotkey=self.wallet.hotkey.ss58_address, miner_hotkey=hotkey, status='duplicate entities').observe(time.perf_counter() - t_start)


### PR DESCRIPTION
solve


Failed enitity uniqueness checks on Bucket ID: time_bucket=TimeBucket(id=487675) source=2 label=None. 2025-08-25 21:07:43
Exception in thread Thread-1269 (eval_miner_sync): 2025-08-25 21:07:43
Traceback (most recent call last):
2025-08-25 21:07:43
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
2025-08-25 21:07:43
    self.run()
2025-08-25 21:07:43
  File "/usr/lib/python3.10/threading.py", line 953, in run
2025-08-25 21:07:43
    self._target(*self._args, **self._kwargs)
2025-08-25 21:07:43
  Filedata-universe/vali_utils/miner_evaluator.py", line 86, in eval_miner_sync
2025-08-25 21:07:43
    asyncio.run(self.eval_miner(uid))
2025-08-25 21:07:43
  File "/usr/lib/python3.10/asyncio/runners.py", line 44, in run
2025-08-25 21:07:43
    return loop.run_until_complete(main)
2025-08-25 21:07:43
  File "/usr/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
2025-08-25 21:07:43
    return future.result()
2025-08-25 21:07:43
  File "data-universe/vali_utils/miner_evaluator.py", line 220, in eval_miner
2025-08-25 21:07:43
    self.scorer.on_miner_evaluated(
2025-08-25 21:07:43
TypeError: MinerScorer.on_miner_evaluated() got an unexpected keyword argument 'evaluation_start_time'