### PR TITLE
Fix empty string, fix dynamic-data validation outlier

### DIFF
--- a/scraping/x/apidojo_scraper.py
+++ b/scraping/x/apidojo_scraper.py
@@ -410,9 +410,9 @@ class ApiDojoTwitterScraper(Scraper):
                         in_reply_to_user_id=data.get("inReplyToUserId"),
                         # ===== NEW FIELDS =====
                         # Static tweet metadata
-                        language=data.get("lang"),
-                        in_reply_to_username=data.get("inReplyToUsername"),
-                        quoted_tweet_id=data.get("quoteId"),
+                        language=data.get("lang") if data.get("lang") else None,
+                        in_reply_to_username=data.get("inReplyToUsername") if data.get("inReplyToUsername") else None,
+                        quoted_tweet_id=data.get("quoteId") if data.get("quoteId") else None,
                         # Dynamic engagement metrics
                         like_count=engagement_metrics["like_count"],
                         retweet_count=engagement_metrics["retweet_count"],
@@ -498,10 +498,10 @@ class ApiDojoTwitterScraper(Scraper):
         author = data.get("author", {})
         return {
             "user_blue_verified": author.get("isBlueVerified"),
-            "user_description": author.get("description"),
-            "user_location": author.get("location"),
-            "profile_image_url": author.get("profilePicture"),
-            "cover_picture_url": author.get("coverPicture"),
+            "user_description": author.get("description") if author.get("description") else None,
+            "user_location": author.get("location") if author.get("location") else None,
+            "profile_image_url": author.get("profilePicture") if author.get("profilePicture") else None,
+            "cover_picture_url": author.get("coverPicture") if author.get("coverPicture") else None,
             "user_followers_count": author.get("followers"),
             "user_following_count": author.get("following"),
         }

--- a/scraping/x/utils.py
+++ b/scraping/x/utils.py
@@ -590,7 +590,7 @@ def _validate_engagement_field(
 
     # Calculate tolerance first to determine what small decreases are acceptable
     tolerance = _calculate_engagement_tolerance(field_name, submitted_value, tweet_age)
-    small_tolerance = min(tolerance // 10, 3)
+    small_tolerance = max(min(tolerance // 10, 5), 2)
 
     # Allow small decreases for edge cases (spam removal, deleted retweets, etc.)
     # The submitted value is what miner scraped (older, potentially lower)


### PR DESCRIPTION
# Fix X scraper empty string handling and engagement metrics tolerance

## Summary
- Convert empty strings to None values in X scraper data extraction to ensure proper data entity serialization
- Increase minimum tolerance for decreasing engagement metrics to handle natural fluctuations

## Changes Made

**1. Empty String Handling (`scraping/x/apidojo_scraper.py`)**
- Fixed `_extract_user_profile_data()` to convert empty strings to `None` for:
  - `user_description`
  - `user_location`
  - `profile_image_url`
  - `cover_picture_url`
- Fixed main data extraction to convert empty strings to `None` for:
  - `language`
  - `in_reply_to_username`
  - `quoted_tweet_id`

**2. Engagement Metrics Tolerance (`scraping/x/utils.py`)**
- Updated `small_tolerance` calculation from `min(tolerance // 10, 3)` to `max(min(tolerance // 10, 5), 2)`
- Ensures minimum tolerance of 2 for decreasing engagement metrics (bookmark_count, like_count, etc.)
- Allows for natural decreases due to un-bookmarking, spam removal, etc.
