### PR TITLE
Prefix all miner logs with UID:{uid} - HOTKEY:{hotkey}

### DIFF
--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -103,14 +103,14 @@ class MinerEvaluator:
             axon_info = self.metagraph.axons[uid]
             hotkey = self.metagraph.hotkeys[uid]
 
-        bt.logging.info(f"{hotkey}: Evaluating miner.")
+        bt.logging.info(f"UID:{uid} - HOTKEY:{hotkey}: Evaluating miner.")
 
         # Query the miner for the latest index.
         index = await self._update_and_get_miner_index(hotkey, uid, axon_info)
         if not index:
             # The miner hasn't provided an index yet, so we can't validate them. Count as a failed validation.
             bt.logging.info(
-                f"{hotkey}: Failed to get an index for miner. Counting as a failed validation."
+                f"UID:{uid} - HOTKEY:{hotkey}: Failed to get an index for miner. Counting as a failed validation."
             )
             self.scorer.on_miner_evaluated(
                 uid,
@@ -134,7 +134,7 @@ class MinerEvaluator:
         s3_validation_result = None
 
         if s3_validation_info is None or (current_block - s3_validation_info['block']) > 2550:  # ~8.5 hrs
-            s3_validation_result = await self._perform_s3_validation(hotkey, current_block)
+            s3_validation_result = await self._perform_s3_validation(uid, hotkey, current_block)
         ##########
 
         # From that index, find a data entity bucket to sample and get it from the miner.
@@ -142,7 +142,7 @@ class MinerEvaluator:
             vali_utils.choose_data_entity_bucket_to_query(index)
         )
         bt.logging.info(
-            f"{hotkey} Querying miner for Bucket ID: {chosen_data_entity_bucket.id}."
+            f"UID:{uid} - HOTKEY:{hotkey}: Querying miner for Bucket ID: {chosen_data_entity_bucket.id}."
         )
 
         responses = None
@@ -164,7 +164,7 @@ class MinerEvaluator:
         # If we didn't, the miner could just not respond to queries for data entity buckets it doesn't have.
         if data_entity_bucket is None:
             bt.logging.info(
-                f"{hotkey}: Miner returned an invalid/failed response for Bucket ID: {chosen_data_entity_bucket.id}."
+                f"UID:{uid} - HOTKEY:{hotkey}: Miner returned an invalid/failed response for Bucket ID: {chosen_data_entity_bucket.id}."
             )
             self.scorer.on_miner_evaluated(
                 uid,
@@ -183,8 +183,8 @@ class MinerEvaluator:
 
         # Perform basic validation on the entities.
         bt.logging.info(
-            f"{hotkey}: Performing basic validation on Bucket ID: {chosen_data_entity_bucket.id} containing "
-            + f"{chosen_data_entity_bucket.size_bytes} bytes across {len(data_entity_bucket.data_entities)} entities."
+            f"UID:{uid} - HOTKEY:{hotkey}: Performing basic validation on Bucket ID: {chosen_data_entity_bucket.id} containing "
+            f"{chosen_data_entity_bucket.size_bytes} bytes across {len(data_entity_bucket.data_entities)} entities."
         )
 
         data_entities: List[DataEntity] = data_entity_bucket.data_entities
@@ -193,7 +193,7 @@ class MinerEvaluator:
         )
         if not valid:
             bt.logging.info(
-                f"{hotkey}: Failed basic entity validation on Bucket ID: {chosen_data_entity_bucket.id} with reason: {reason}"
+                f"UID:{uid} - HOTKEY:{hotkey}: Failed basic entity validation on Bucket ID: {chosen_data_entity_bucket.id} with reason: {reason}"
             )
             self.scorer.on_miner_evaluated(
                 uid,
@@ -215,7 +215,7 @@ class MinerEvaluator:
         unique = vali_utils.are_entities_unique(data_entities)
         if not unique:
             bt.logging.info(
-                f"{hotkey}: Failed enitity uniqueness checks on Bucket ID: {chosen_data_entity_bucket.id}."
+                f"UID:{uid} - HOTKEY:{hotkey}: Failed enitity uniqueness checks on Bucket ID: {chosen_data_entity_bucket.id}."
             )
             self.scorer.on_miner_evaluated(
                 uid,
@@ -240,7 +240,7 @@ class MinerEvaluator:
         entity_uris = [entity.uri for entity in entities_to_validate]
 
         bt.logging.info(
-            f"{hotkey}: Basic validation on Bucket ID: {chosen_data_entity_bucket.id} passed. Validating uris: {entity_uris}."
+            f"UID:{uid} - HOTKEY:{hotkey}: Basic validation on Bucket ID: {chosen_data_entity_bucket.id} passed. Validating uris: {entity_uris}."
         )
 
         scraper = self.scraper_provider.get(
@@ -249,7 +249,7 @@ class MinerEvaluator:
         validation_results = await scraper.validate(entities_to_validate)
 
         bt.logging.success(
-            f"{hotkey}: Data validation on selected entities finished with results: {validation_results}"
+            f"UID:{uid} - HOTKEY:{hotkey}: Data validation on selected entities finished with results: {validation_results}"
         )
 
         self.scorer.on_miner_evaluated(uid, index, validation_results)
@@ -259,14 +259,17 @@ class MinerEvaluator:
         if s3_validation_result:
             if s3_validation_result.is_valid:
                 bt.logging.info(
-                    f"{hotkey}: Miner {uid} passed S3 validation. Validation: {s3_validation_result.validation_percentage:.1f}%, Jobs: {s3_validation_result.job_count}, Files: {s3_validation_result.total_files}")
+                    f"UID:{uid} - HOTKEY:{hotkey}: Miner {uid} passed S3 validation. "
+                    f"Validation: {s3_validation_result.validation_percentage:.1f}%, "
+                    f"Jobs: {s3_validation_result.job_count}, Files: {s3_validation_result.total_files}"
+                )
             else:
-                bt.logging.info(f"{hotkey}: Miner {uid} did not pass S3 validation. Reason: {s3_validation_result.reason}")
+                bt.logging.info(f"UID:{uid} - HOTKEY:{hotkey}: Miner {uid} did not pass S3 validation. Reason: {s3_validation_result.reason}")
 
             self.scorer.update_s3_boost_and_cred(uid, s3_validation_result.validation_percentage)
 
     async def _perform_s3_validation(
-            self, hotkey: str, current_block: int
+        self, uid: int, hotkey: str, current_block: int
     ) -> Optional[S3ValidationResult]:
         """
         Performs comprehensive S3 validation using metadata analysis and statistical methods.
@@ -277,7 +280,7 @@ class MinerEvaluator:
         Returns:
             An S3ValidationResult with validation details or None if no S3 data is found.
         """
-        bt.logging.info(f"{hotkey}: Starting comprehensive S3 validation")
+        bt.logging.info(f"UID:{uid} - HOTKEY:{hotkey}: Starting comprehensive S3 validation")
 
         try:
             # Use S3 auth URL from config
@@ -420,7 +423,7 @@ class MinerEvaluator:
     ) -> Optional[ScorableMinerIndex]:
         """Updates the index for the specified miner, and returns the latest known index or None if the miner hasn't yet provided an index."""
 
-        bt.logging.info(f"{hotkey}: Getting MinerIndex from miner.")
+        bt.logging.info(f"UID:{uid} - HOTKEY:{hotkey}: Getting MinerIndex from miner.")
 
         try:
             responses: List[GetMinerIndex] = None
@@ -436,7 +439,7 @@ class MinerEvaluator:
             )
             if not response:
                 bt.logging.info(
-                    f"{hotkey}: Miner failed to respond with an index. Using last known index if present."
+                    f"UID:{uid} - HOTKEY:{hotkey}: Miner failed to respond with an index. Using last known index if present."
                 )
                 # Miner failed to update the index. Use the latest index, if present.
                 return self.storage.read_miner_index(hotkey)
@@ -447,7 +450,7 @@ class MinerEvaluator:
                 miner_index = vali_utils.get_miner_index_from_response(response)
             except ValueError as e:
                 bt.logging.info(
-                    f"{hotkey}: Miner returned an invalid index. Reason: {e}. Using last known index if present."
+                    f"UID:{uid} - HOTKEY:{hotkey}: Miner returned an invalid index. Reason: {e}. Using last known index if present."
                 )
                 # Miner returned an invalid index. Use the latest index, if present.
                 return self.storage.read_miner_index(hotkey)
@@ -457,8 +460,8 @@ class MinerEvaluator:
             # Miner replied with a valid index. Store it and return it.
             miner_credibility = self.scorer.get_miner_credibility(uid)
             bt.logging.success(
-                f"{hotkey}: Got new compressed miner index of {CompressedMinerIndex.size_bytes(miner_index)} bytes "
-                + f"across {CompressedMinerIndex.bucket_count(miner_index)} buckets."
+                f"UID:{uid} - HOTKEY:{hotkey}: Got new compressed miner index of {CompressedMinerIndex.size_bytes(miner_index)} bytes "
+                f"across {CompressedMinerIndex.bucket_count(miner_index)} buckets."
             )
             self.storage.upsert_compressed_miner_index(
                 miner_index, hotkey, miner_credibility
@@ -467,8 +470,7 @@ class MinerEvaluator:
             return self.storage.read_miner_index(hotkey)
         except Exception:
             bt.logging.error(
-                f"{hotkey} Failed to update and get miner index.",
-                traceback.format_exc(),
+                f"UID:{uid} - HOTKEY:{hotkey}: Failed to update and get miner index.\n{traceback.format_exc()}"
             )
             return None
 


### PR DESCRIPTION
Prefix all miner logs with UID:{uid} - HOTKEY:{hotkey} for clearer traceability; replaced existing messages accordingly. Updated _perform_s3_validation to accept uid and adjusted its call site. No functional changes—logging only.