### PR TITLE
chore: add time job time range validaiton and keywords for YT

### DIFF
--- a/vali_utils/s3_utils.py
+++ b/vali_utils/s3_utils.py
@@ -606,11 +606,23 @@ class S3Validator:
             'sample_duplicates': duplicate_uris[:10]
         }
 
+    def _parse_job_datetime(self, raw, miner_hotkey: str) -> Optional[dt.datetime]:
+        """Parse job datetime from Gravity; treat null-ish values as no constraint."""
+        if raw is None:
+            return None
+        if isinstance(raw, str) and raw.strip().lower() in ("", "null", "none"):
+            return None
+        try:
+            return pd.to_datetime(raw, utc=True)
+        except Exception as e:
+            bt.logging.warning(f"{miner_hotkey}: Failed to parse job datetime '{raw}': {e}")
+            return None
+
     async def _check_job_content_match(
         self, wallet, s3_auth_url: str, miner_hotkey: str,
         recent_job_files: Dict, expected_jobs: Dict
     ) -> Dict:
-        """Validate that uploaded data actually matches the job requirements (labels/keywords)"""
+        """Validate that uploaded data matches job requirements (label/keyword AND time window via DataEntity.datetime)."""
         total_checked = 0
         total_matched = 0
         mismatch_samples = []
@@ -630,6 +642,11 @@ class S3Validator:
             job_keyword = params.get('keyword')
             job_start_date = params.get('post_start_datetime')
             job_end_date = params.get('post_end_datetime')
+
+            # Parse job time window (UTC)
+            job_start_dt = self._parse_job_datetime(job_start_date, miner_hotkey)
+            job_end_dt = self._parse_job_datetime(job_end_date, miner_hotkey)
+            has_time_requirement = bool(job_start_dt or job_end_dt)
 
             # Sample files to check (2 files per job)
             sample_files = random.sample(files, min(2, len(files)))
@@ -659,11 +676,10 @@ class S3Validator:
                         total_checked += 1
                         matches_job = False
 
-                        # Check if data matches job requirements
-                        # If BOTH label and keyword are specified, BOTH must match (AND logic)
-                        # If only one is specified, only that one must match
-                        label_matches = None  # None = not checked, True/False = checked result
+                        label_matches = None
                         keyword_matches = None
+                        time_matches = None
+                        entity_dt_str = None
 
                         has_label_requirement = bool(job_label and job_label.strip())
                         has_keyword_requirement = bool(job_keyword and job_keyword.strip())
@@ -742,26 +758,51 @@ class S3Validator:
                                 title = str(row.get('title', '')).lower()
                                 keyword_matches = (job_keyword_normalized in body or job_keyword_normalized in title)
                             elif platform == 'youtube':
-                                title = str(row.get('title', '')).lower()
-                                keyword_matches = job_keyword_normalized in title
+                                # IMPORTANT: match miner behavior -> title OR description
+                                title_val = row.get('title', '')
+                                desc_val = row.get('description', '')
+
+                                if isinstance(title_val, float) and pd.isna(title_val):
+                                    title = ''
+                                else:
+                                    title = str(title_val).lower()
+
+                                if isinstance(desc_val, float) and pd.isna(desc_val):
+                                    description = ''
+                                else:
+                                    description = str(desc_val).lower()
+
+                                keyword_matches = (
+                                    job_keyword_normalized in title or
+                                    job_keyword_normalized in description
+                                )
                             else:  # X/Twitter
                                 text = str(row.get('text', '')).lower()
                                 keyword_matches = job_keyword_normalized in text
 
-                        # Determine if job requirements are met
-                        # If BOTH label and keyword required: BOTH must pass (AND logic)
-                        # If only one required: that one must pass
-                        if has_label_requirement and has_keyword_requirement:
-                            # BOTH required - use AND logic
-                            matches_job = (label_matches is True) and (keyword_matches is True)
-                        elif has_label_requirement:
-                            # Only label required
-                            matches_job = (label_matches is True)
-                        elif has_keyword_requirement:
-                            # Only keyword required
-                            matches_job = (keyword_matches is True)
+                        # Time window validation
+                        if has_time_requirement:
+                            entity_dt = row.get('datetime')
+                            if entity_dt is not None and not pd.isna(entity_dt):
+                                entity_dt = pd.to_datetime(entity_dt, utc=True)
+                                entity_dt_str = entity_dt.isoformat()
+                                time_matches = True
+                                if job_start_dt and entity_dt < job_start_dt:
+                                    time_matches = False
+                                if job_end_dt and entity_dt > job_end_dt:
+                                    time_matches = False
+                            else:
+                                time_matches = False
                         else:
-                            # No requirements (shouldn't happen, but handle gracefully)
+                            time_matches = True
+
+                        # Combine all requirements
+                        matches_job = True
+                        if has_label_requirement and not label_matches:
+                            matches_job = False
+                        if has_keyword_requirement and not keyword_matches:
+                            matches_job = False
+                        if has_time_requirement and not time_matches:
                             matches_job = False
 
                         uri = self._get_uri_value(row)
@@ -771,14 +812,16 @@ class S3Validator:
                         if matches_job:
                             total_matched += 1
                         else:
-                            # Record mismatch sample
+                            # Record mismatch sample with time window info
                             if len(mismatch_samples) < 10:
-                                mismatch_samples.append(
-                                    f"Job {job_id[:8]}: Required label={job_label or 'any'} "
-                                    f"keyword={job_keyword or 'any'}, "
-                                    f"label_matched={label_matches} keyword_matched={keyword_matches} "
-                                    f"- {uri or 'unknown'}"
-                                )
+                                msg = f"Job {job_id[:8]}: label={job_label or 'any'} keyword={job_keyword or 'any'}"
+                                if has_time_requirement:
+                                    msg += f" time=[{job_start_dt.isoformat() if job_start_dt else 'any'} to {job_end_dt.isoformat() if job_end_dt else 'any'}]"
+                                msg += f" | matched: label={label_matches} keyword={keyword_matches} time={time_matches}"
+                                if entity_dt_str:
+                                    msg += f" entity_dt={entity_dt_str}"
+                                msg += f" - {uri or 'unknown'}"
+                                mismatch_samples.append(msg)
 
                 except Exception as e:
                     bt.logging.debug(f"Error checking job content match: {str(e)}")


### PR DESCRIPTION
## Enforce Gravity job time windows and align YouTube keyword matching

  This PR implements time window enforcement for Gravity jobs and fixes YouTube keyword matching to align with miner behavior.

  **Changes:**

  1. Time Window Enforcement: Validates DataEntity.datetime against post_start_datetime and post_end_datetime from Gravity job parameters. Entities outside the job's time window are rejected.
  2. Null Handling: Jobs without time constraints (both start/end are null) skip time validation, maintaining backward compatibility.
  3. YouTube Keyword Matching: Expands keyword search to check both video title AND description fields, matching the miner uploader behavior (upload_utils/s3_uploader.py:258-259).
  4. Enhanced Logging: Mismatch samples now include time window details for easier debugging.

  Key Implementation:

  - Added _parse_job_datetime() helper to parse Gravity job time parameters with null handling
  - Time validation uses simple AND logic: all requirements (label + keyword + time) must pass
  - YouTube description field properly handles NaN values
  - Backward compatible: existing jobs without time windows continue to work

  Testing:

  - Time window logic validated with 7 edge case scenarios
  - Requirement combination tested with 16 scenarios
  - Confirmed YouTube description field exists in data model
  - Verified datetime field is always present in parquet files

based on: https://github.com/macrocosm-os/data-universe/pull/699