### PR TITLE
Fix Reddit on-demand routing for keyword-only requests

### DIFF
--- a/docs/on_demand.md
+++ b/docs/on_demand.md
@@ -63,6 +63,17 @@ The implementation uses the standard `ApiDojoTwitterScraper` with the unified `X
 ### Reddit Scraping (Unchanged)
 The Reddit implementation remains the same, using the Reddit API.
 
+For Reddit request routing, miners and validators should accept both of these
+shapes:
+
+- explicit subreddit plus optional search keywords
+- keyword-only queries with no subreddit
+
+If a Reddit keyword token is actually subreddit-shaped (for example
+`r/CryptoCurrency`), it should be promoted back into the subreddit slot instead
+of being treated like a plain keyword. Keyword-only Reddit requests should use
+global Reddit search rather than forcing the first keyword into `/r/<keyword>`.
+
 ## Implementation Options
 
 You can:

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -624,6 +624,38 @@ class Miner:
         )
         bt.logging.info(log)
 
+    @staticmethod
+    def _normalize_reddit_subreddit(
+        value: typing.Optional[str],
+    ) -> typing.Optional[str]:
+        if not value:
+            return None
+        normalized = value.strip().lower()
+        if not normalized:
+            return None
+        return normalized if normalized.startswith("r/") else f"r/{normalized}"
+
+    @staticmethod
+    def _normalize_reddit_request(
+        subreddit: typing.Optional[str],
+        keywords: typing.Optional[typing.List[str]],
+    ) -> typing.Tuple[typing.Optional[str], typing.List[str]]:
+        normalized_subreddit = Miner._normalize_reddit_subreddit(subreddit)
+        normalized_keywords: typing.List[str] = []
+
+        for keyword in keywords or []:
+            value = (keyword or "").strip()
+            if not value:
+                continue
+
+            if normalized_subreddit is None and value.lower().startswith(("r/", "/r/")):
+                normalized_subreddit = Miner._normalize_reddit_subreddit(value)
+                continue
+
+            normalized_keywords.append(value)
+
+        return normalized_subreddit, normalized_keywords
+
     async def get_index(self, synapse: GetMinerIndex) -> GetMinerIndex:
         """Runs after the GetMinerIndex synapse has been deserialized (i.e. after synapse.data is available)."""
         bt.logging.info(
@@ -749,12 +781,15 @@ class Miner:
                     synapse.data = []
                     return synapse
 
+                reddit_subreddit, reddit_keywords = self._normalize_reddit_request(
+                    subreddit=getattr(synapse, "subreddit", None),
+                    keywords=synapse.keywords,
+                )
+
                 data = await scraper.on_demand_scrape(
                     usernames=synapse.usernames,
-                    subreddit=synapse.keywords[0] if synapse.keywords else None,
-                    keywords=(
-                        synapse.keywords[1:] if len(synapse.keywords) > 1 else None
-                    ),
+                    subreddit=reddit_subreddit,
+                    keywords=reddit_keywords or None,
                     keyword_mode=synapse.keyword_mode,
                     start_datetime=start_dt,
                     end_datetime=end_dt,

--- a/scraping/reddit/reddit_custom_scraper.py
+++ b/scraping/reddit/reddit_custom_scraper.py
@@ -24,7 +24,7 @@ from scraping.reddit import model
 from scraping.scraper import ScrapeConfig, Scraper, ValidationResult
 from common.protocol import KeywordMode
 from scraping.reddit.model import RedditContent, RedditDataType
-from typing import List
+from typing import List, Optional
 from dotenv import load_dotenv
 
 
@@ -37,6 +37,35 @@ class RedditCustomScraper(Scraper):
     """
 
     USER_AGENT = f"User-Agent: python: {os.getenv('REDDIT_USERNAME')}"
+
+    @staticmethod
+    def _normalize_ondemand_subreddit(subreddit: Optional[str]) -> Optional[str]:
+        value = (subreddit or "").strip()
+        if not value or value.lower() == "all":
+            return None
+        if value.lower().startswith("/r/"):
+            value = value[1:]
+        return value[2:] if value.lower().startswith("r/") else value
+
+    @classmethod
+    def _split_ondemand_subreddit_and_keywords(
+        cls,
+        subreddit: Optional[str],
+        keywords: Optional[List[str]],
+    ) -> tuple[Optional[str], List[str]]:
+        normalized_subreddit = cls._normalize_ondemand_subreddit(subreddit)
+        normalized_keywords: List[str] = []
+
+        for keyword in keywords or []:
+            value = (keyword or "").strip()
+            if not value:
+                continue
+            if normalized_subreddit is None and value.lower().startswith(("r/", "/r/")):
+                normalized_subreddit = cls._normalize_ondemand_subreddit(value)
+                continue
+            normalized_keywords.append(value)
+
+        return normalized_subreddit, normalized_keywords
 
     async def validate(self, entities: List[DataEntity]) -> List[ValidationResult]:
         """
@@ -263,15 +292,24 @@ class RedditCustomScraper(Scraper):
         Returns:
             List of DataEntity objects matching the criteria
         """
+
+        subreddit_name, normalized_keywords = self._split_ondemand_subreddit_and_keywords(
+            subreddit,
+            keywords,
+        )
         
         # Return empty list if all key search parameters are None
-        if all(param is None for param in [usernames, keywords, start_datetime, end_datetime]) and subreddit == "all":
+        if (
+            all(param is None for param in [usernames, start_datetime, end_datetime])
+            and subreddit_name is None
+            and not normalized_keywords
+        ):
             bt.logging.trace("All search parameters are None, returning empty list")
             return []
         
         bt.logging.trace(
-            f"On-demand scrape with usernames={usernames}, subreddit={subreddit}, "
-            f"keywords={keywords}, keyword_mode={keyword_mode}, start={start_datetime}, end={end_datetime}"
+            f"On-demand scrape with usernames={usernames}, subreddit={subreddit_name}, "
+            f"keywords={normalized_keywords}, keyword_mode={keyword_mode}, start={start_datetime}, end={end_datetime}"
         )
         
         contents = []
@@ -294,13 +332,13 @@ class RedditCustomScraper(Scraper):
                             # Get user's posts (submissions)
                             async for submission in user.submissions.new(limit=limit):
                                 content = self._best_effort_parse_submission(submission)
-                                if content and self._matches_criteria(content, keywords, keyword_mode, start_datetime, end_datetime):
+                                if content and self._matches_criteria(content, normalized_keywords, keyword_mode, start_datetime, end_datetime):
                                     contents.append(content)
                             
                             # Get user's comments
                             async for comment in user.comments.new(limit=limit):
                                 content = self._best_effort_parse_comment(comment)
-                                if content and self._matches_criteria(content, keywords, keyword_mode, start_datetime, end_datetime):
+                                if content and self._matches_criteria(content, normalized_keywords, keyword_mode, start_datetime, end_datetime):
                                     contents.append(content)
                         except Exception as e:
                             bt.logging.warning(f"Failed to scrape user '{username}': {e}")
@@ -308,15 +346,22 @@ class RedditCustomScraper(Scraper):
                 
                 # Case 2: Search by subreddit (with optional keywords)
                 else:
-                    subreddit_name = subreddit.removeprefix("r/") if subreddit.startswith('r/') else subreddit
-                    sub = await reddit.subreddit(subreddit_name)
+                    if subreddit_name:
+                        sub = await reddit.subreddit(subreddit_name)
+                    else:
+                        if not normalized_keywords:
+                            bt.logging.trace(
+                                "Reddit on-demand scrape has no subreddit and no keywords, returning empty list."
+                            )
+                            return []
+                        sub = await reddit.subreddit("all")
                     
                     # If we have keywords, use Reddit's search functionality
-                    if keywords:
+                    if normalized_keywords:
                         if keyword_mode == "all":
-                            search_query = ' AND '.join(f'"{keyword}"' for keyword in keywords)
+                            search_query = ' AND '.join(f'"{keyword}"' for keyword in normalized_keywords)
                         else:  # keyword_mode == "any"
-                            search_query = ' OR '.join(f'"{keyword}"' for keyword in keywords)
+                            search_query = ' OR '.join(f'"{keyword}"' for keyword in normalized_keywords)
                         search_results = sub.search(search_query, sort='new', limit=limit)
                         
                         async for item in search_results:
@@ -325,7 +370,7 @@ class RedditCustomScraper(Scraper):
                             else: 
                                 content = self._best_effort_parse_comment(item)
                             
-                            if content and self._matches_criteria(content, keywords, keyword_mode, start_datetime, end_datetime):
+                            if content and self._matches_criteria(content, normalized_keywords, keyword_mode, start_datetime, end_datetime):
                                 contents.append(content)
                     else:
                         # No keywords, just get recent posts

--- a/scraping/reddit/reddit_json_scraper.py
+++ b/scraping/reddit/reddit_json_scraper.py
@@ -32,6 +32,35 @@ class RedditJsonScraper(Scraper):
     MAX_RETRIES = 3
     RETRY_DELAY = 2  # seconds
 
+    @staticmethod
+    def _normalize_ondemand_subreddit(subreddit: Optional[str]) -> Optional[str]:
+        value = (subreddit or "").strip()
+        if not value or value.lower() == "all":
+            return None
+        if value.lower().startswith("/r/"):
+            value = value[1:]
+        return value[2:] if value.lower().startswith("r/") else value
+
+    @classmethod
+    def _split_ondemand_subreddit_and_keywords(
+        cls,
+        subreddit: Optional[str],
+        keywords: Optional[List[str]],
+    ) -> tuple[Optional[str], List[str]]:
+        normalized_subreddit = cls._normalize_ondemand_subreddit(subreddit)
+        normalized_keywords: List[str] = []
+
+        for keyword in keywords or []:
+            value = (keyword or "").strip()
+            if not value:
+                continue
+            if normalized_subreddit is None and value.lower().startswith(("r/", "/r/")):
+                normalized_subreddit = cls._normalize_ondemand_subreddit(value)
+                continue
+            normalized_keywords.append(value)
+
+        return normalized_subreddit, normalized_keywords
+
     async def validate(self, entities: List[DataEntity]) -> List[ValidationResult]:
         """
         Validate a list of DataEntity objects using Reddit's public JSON API.
@@ -191,14 +220,23 @@ class RedditJsonScraper(Scraper):
             List of DataEntity objects matching the criteria
         """
 
+        subreddit_name, normalized_keywords = self._split_ondemand_subreddit_and_keywords(
+            subreddit,
+            keywords,
+        )
+
         # Return empty list if all key search parameters are None
-        if all(param is None for param in [usernames, keywords, start_datetime, end_datetime]) and subreddit == "all":
+        if (
+            all(param is None for param in [usernames, start_datetime, end_datetime])
+            and subreddit_name is None
+            and not normalized_keywords
+        ):
             bt.logging.trace("All search parameters are None, returning empty list")
             return []
 
         bt.logging.trace(
-            f"On-demand scrape with usernames={usernames}, subreddit={subreddit}, "
-            f"keywords={keywords}, keyword_mode={keyword_mode}, start={start_datetime}, end={end_datetime}"
+            f"On-demand scrape with usernames={usernames}, subreddit={subreddit_name}, "
+            f"keywords={normalized_keywords}, keyword_mode={keyword_mode}, start={start_datetime}, end={end_datetime}"
         )
 
         contents = []
@@ -218,7 +256,7 @@ class RedditJsonScraper(Scraper):
 
                             for post_data in posts:
                                 content = self._parse_post(post_data)
-                                if content and self._matches_criteria(content, keywords, keyword_mode, start_datetime, end_datetime):
+                                if content and self._matches_criteria(content, normalized_keywords, keyword_mode, start_datetime, end_datetime):
                                     contents.append(content)
 
                             # Get user's comments
@@ -227,7 +265,7 @@ class RedditJsonScraper(Scraper):
 
                             for comment_data in comments:
                                 content = self._parse_comment(comment_data)
-                                if content and self._matches_criteria(content, keywords, keyword_mode, start_datetime, end_datetime):
+                                if content and self._matches_criteria(content, normalized_keywords, keyword_mode, start_datetime, end_datetime):
                                     contents.append(content)
                         except Exception as e:
                             bt.logging.warning(f"Failed to scrape user '{username}': {e}")
@@ -235,20 +273,30 @@ class RedditJsonScraper(Scraper):
 
                 # Case 2: Search by subreddit (with optional keywords)
                 else:
-                    subreddit_name = subreddit.removeprefix("r/") if subreddit.startswith('r/') else subreddit
+                    if subreddit_name:
+                        # If we have keywords, use Reddit's search functionality
+                        # raw_json=1 returns unescaped text to match PRAW output
+                        if normalized_keywords:
+                            if keyword_mode == "all":
+                                search_query = ' AND '.join(f'"{keyword}"' for keyword in normalized_keywords)
+                            else:  # keyword_mode == "any"
+                                search_query = ' OR '.join(f'"{keyword}"' for keyword in normalized_keywords)
 
-                    # If we have keywords, use Reddit's search functionality
-                    # raw_json=1 returns unescaped text to match PRAW output
-                    if keywords:
-                        if keyword_mode == "all":
-                            search_query = ' AND '.join(f'"{keyword}"' for keyword in keywords)
-                        else:  # keyword_mode == "any"
-                            search_query = ' OR '.join(f'"{keyword}"' for keyword in keywords)
-
-                        url = f"{self.BASE_URL}/r/{subreddit_name}/search.json?q={search_query}&restrict_sr=1&limit={limit}&sort=new&raw_json=1"
+                            url = f"{self.BASE_URL}/r/{subreddit_name}/search.json?q={search_query}&restrict_sr=1&limit={limit}&sort=new&raw_json=1"
+                        else:
+                            # No keywords, just get recent posts
+                            url = f"{self.BASE_URL}/r/{subreddit_name}/new.json?limit={limit}&raw_json=1"
                     else:
-                        # No keywords, just get recent posts
-                        url = f"{self.BASE_URL}/r/{subreddit_name}/new.json?limit={limit}&raw_json=1"
+                        if not normalized_keywords:
+                            bt.logging.trace(
+                                "Reddit on-demand scrape has no subreddit and no keywords, returning empty list."
+                            )
+                            return []
+                        if keyword_mode == "all":
+                            search_query = ' AND '.join(f'"{keyword}"' for keyword in normalized_keywords)
+                        else:  # keyword_mode == "any"
+                            search_query = ' OR '.join(f'"{keyword}"' for keyword in normalized_keywords)
+                        url = f"{self.BASE_URL}/search.json?q={search_query}&limit={limit}&sort=new&raw_json=1"
 
                     posts = await self._fetch_posts(session, url)
 
@@ -262,7 +310,7 @@ class RedditJsonScraper(Scraper):
                         else:
                             content = self._parse_post(post_data)  # Default to post parsing
 
-                        if content and self._matches_criteria(content, keywords, keyword_mode, start_datetime, end_datetime):
+                        if content and self._matches_criteria(content, normalized_keywords, keyword_mode, start_datetime, end_datetime):
                             contents.append(content)
 
         except Exception as e:

--- a/tests/integration/test_on_demand.py
+++ b/tests/integration/test_on_demand.py
@@ -65,8 +65,8 @@ class TestOnDemandProtocol(unittest.TestCase):
         """Test the complete on-demand data flow for Reddit"""
 
         async def run_test():
-            # Create OnDemand request for Reddit
-            # First keyword is the subreddit, remaining keywords are search terms
+            # Create OnDemand request for Reddit.
+            # This legacy packed form remains supported for backward compatibility.
             test_request = OnDemandRequest(
                 source=DataSource.REDDIT,
                 keywords=["cryptocurrency", "bitcoin"],  # First: subreddit, rest: search terms
@@ -79,8 +79,8 @@ class TestOnDemandProtocol(unittest.TestCase):
             scraper = RedditJsonScraper()
 
             try:
-                # Use on_demand_scrape method for Reddit
-                # First keyword is subreddit, remaining are search keywords
+                # Use on_demand_scrape method for Reddit.
+                # New callers may also send keyword-only Reddit queries without a subreddit.
                 subreddit = test_request.keywords[0]
                 search_keywords = test_request.keywords[1:] if len(test_request.keywords) > 1 else None
                 

--- a/tests/neurons/test_miner_on_demand_reddit.py
+++ b/tests/neurons/test_miner_on_demand_reddit.py
@@ -1,0 +1,73 @@
+import asyncio
+import unittest
+from unittest import mock
+
+from common.data import DataSource
+from common.protocol import OnDemandRequest
+from neurons.miner import Miner
+
+
+class TestMinerOnDemandReddit(unittest.TestCase):
+    def test_keyword_only_reddit_job_keeps_keywords(self):
+        miner = Miner.__new__(Miner)
+
+        async def run():
+            synapse = OnDemandRequest(
+                source=DataSource.REDDIT,
+                usernames=[],
+                keywords=["hustle culture"],
+                keyword_mode="any",
+                start_date="2026-04-05T00:00:00+00:00",
+                end_date="2026-04-06T00:00:00+00:00",
+                limit=50,
+                data=[],
+            )
+            with mock.patch("neurons.miner.RedditJsonScraper") as scraper_cls:
+                scraper = scraper_cls.return_value
+                scraper.on_demand_scrape = mock.AsyncMock(return_value=[])
+                await miner.loop_poll_on_demand_active_jobs(synapse)
+                scraper.on_demand_scrape.assert_awaited_once_with(
+                    usernames=[],
+                    subreddit=None,
+                    keywords=["hustle culture"],
+                    keyword_mode="any",
+                    start_datetime=mock.ANY,
+                    end_datetime=mock.ANY,
+                    limit=50,
+                )
+
+        asyncio.run(run())
+
+    def test_subreddit_like_keyword_is_promoted_to_subreddit(self):
+        miner = Miner.__new__(Miner)
+
+        async def run():
+            synapse = OnDemandRequest(
+                source=DataSource.REDDIT,
+                usernames=[],
+                keywords=["r/CryptoCurrency"],
+                keyword_mode="any",
+                start_date="2026-04-05T00:00:00+00:00",
+                end_date="2026-04-06T00:00:00+00:00",
+                limit=50,
+                data=[],
+            )
+            with mock.patch("neurons.miner.RedditJsonScraper") as scraper_cls:
+                scraper = scraper_cls.return_value
+                scraper.on_demand_scrape = mock.AsyncMock(return_value=[])
+                await miner.loop_poll_on_demand_active_jobs(synapse)
+                scraper.on_demand_scrape.assert_awaited_once_with(
+                    usernames=[],
+                    subreddit="r/cryptocurrency",
+                    keywords=None,
+                    keyword_mode="any",
+                    start_datetime=mock.ANY,
+                    end_datetime=mock.ANY,
+                    limit=50,
+                )
+
+        asyncio.run(run())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scraping/reddit/test_json_scraper_on_demand.py
+++ b/tests/scraping/reddit/test_json_scraper_on_demand.py
@@ -1,0 +1,46 @@
+import asyncio
+import unittest
+from unittest import mock
+
+from scraping.reddit.reddit_json_scraper import RedditJsonScraper
+
+
+class TestRedditJsonScraperOnDemand(unittest.TestCase):
+    def test_subreddit_keyword_is_promoted_from_keywords(self):
+        subreddit, keywords = RedditJsonScraper._split_ondemand_subreddit_and_keywords(
+            None,
+            ["r/CryptoCurrency"],
+        )
+
+        self.assertEqual("CryptoCurrency", subreddit)
+        self.assertEqual([], keywords)
+
+    def test_keyword_only_search_uses_global_search(self):
+        scraper = RedditJsonScraper()
+
+        async def run():
+            with mock.patch("aiohttp.ClientSession") as session_cls:
+                session = mock.AsyncMock()
+                session.__aenter__.return_value = session
+                session.__aexit__.return_value = False
+                session_cls.return_value = session
+
+                scraper._fetch_posts = mock.AsyncMock(return_value=[])
+
+                data = await scraper.on_demand_scrape(
+                    subreddit=None,
+                    keywords=["hustle culture"],
+                    keyword_mode="any",
+                    limit=25,
+                )
+
+                self.assertEqual([], data)
+                called_url = scraper._fetch_posts.await_args.args[1]
+                self.assertIn("/search.json?", called_url)
+                self.assertNotIn("/r/", called_url)
+
+        asyncio.run(run())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/vali_utils/test_on_demand_validation.py
+++ b/tests/vali_utils/test_on_demand_validation.py
@@ -1,0 +1,48 @@
+import asyncio
+import unittest
+from unittest import mock
+
+from vali_utils.on_demand.on_demand_validation import (
+    OnDemandValidator,
+    ValidationContext,
+)
+
+
+class TestOnDemandValidation(unittest.TestCase):
+    def test_reddit_data_exists_probe_handles_keyword_only_query(self):
+        evaluator = mock.Mock()
+        evaluator.PREFERRED_SCRAPERS = {}
+        validator = OnDemandValidator(evaluator)
+
+        scraper = mock.Mock()
+        scraper.on_demand_scrape = mock.AsyncMock(return_value=[object()])
+        validator._get_scraper = mock.Mock(return_value=scraper)
+
+        async def run():
+            exists = await validator.check_data_exists(
+                ValidationContext(
+                    source="reddit",
+                    usernames=[],
+                    keywords=["hustle culture"],
+                    keyword_mode="any",
+                    start_date="2026-04-05T00:00:00+00:00",
+                    end_date="2026-04-06T00:00:00+00:00",
+                    limit=10,
+                )
+            )
+            self.assertTrue(exists)
+            scraper.on_demand_scrape.assert_awaited_once_with(
+                usernames=[],
+                subreddit=None,
+                keywords=["hustle culture"],
+                keyword_mode="any",
+                start_datetime=mock.ANY,
+                end_datetime=mock.ANY,
+                limit=1,
+            )
+
+        asyncio.run(run())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vali_utils/on_demand/on_demand_validation.py
+++ b/vali_utils/on_demand/on_demand_validation.py
@@ -559,10 +559,14 @@ class OnDemandValidator:
                     limit=1,
                 )
             elif ctx.source.upper() == "REDDIT":
+                subreddit, keywords = RedditJsonScraper._split_ondemand_subreddit_and_keywords(
+                    None,
+                    ctx.keywords,
+                )
                 results = await scraper.on_demand_scrape(
                     usernames=ctx.usernames or [],
-                    subreddit=ctx.keywords[0] if ctx.keywords else None,
-                    keywords=ctx.keywords[1:] if len(ctx.keywords) > 1 else None,
+                    subreddit=subreddit,
+                    keywords=keywords or None,
                     keyword_mode=ctx.keyword_mode,
                     start_datetime=start_dt,
                     end_datetime=end_dt,


### PR DESCRIPTION
## Summary
- fix Reddit on-demand routing when a request is keyword-only and has no explicit subreddit
- promote subreddit-shaped keyword tokens like `r/CryptoCurrency` back into the subreddit slot
- apply the same normalization in the validator data-existence probe to avoid false empty probes

## Problem
New Reddit on-demand jobs can arrive in two shapes:
- explicit `subreddit` plus optional `keywords`
- keyword-only requests with no subreddit

The existing miner path assumed the first Reddit keyword was always a subreddit. That breaks two real cases:
- true keyword-only requests were forced into `/r/<keyword>` lookups
- subreddit-shaped keyword tokens could be left in the keyword list and treated inconsistently

In our live miner this surfaced as valid Reddit OD jobs returning empty results or crashing when `subreddit=None` reached the scraper.

## Changes
- normalize Reddit request routing inside `neurons/miner.py`
- support global Reddit search in `reddit_json_scraper.py` when no subreddit is provided
- make `reddit_custom_scraper.py` follow the same normalization rules
- normalize the validator's Reddit data-existence probe in `vali_utils/on_demand/on_demand_validation.py`
- add focused regression tests for miner routing, scraper behavior, and validator probing
- clarify the supported Reddit on-demand request shapes in `docs/on_demand.md`

## Validation
- `python -m py_compile` on changed files
- `python -m unittest tests.neurons.test_miner_on_demand_reddit tests.scraping.reddit.test_json_scraper_on_demand tests.vali_utils.test_on_demand_validation`
