### PR TITLE
 fix: move OD scoring into evaluator, fix credibility decay

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -20,7 +20,6 @@ import warnings
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 import copy
-import random
 import sys
 import torch
 import numpy as np
@@ -37,7 +36,6 @@ from neurons import __spec_version__ as spec_version
 from common.api_client import (
     ListJobsWithSubmissionsForValidationRequest,
     DataUniverseApiClient,
-    OnDemandMinerUpload,
 )
 from vali_utils.validator_s3_access import ValidatorS3Access
 from rewards.data_value_calculator import DataValueCalculator
@@ -50,7 +48,8 @@ from typing import Dict
 from common import constants
 from common import utils
 from vali_utils.miner_evaluator import MinerEvaluator
-from vali_utils.on_demand.on_demand_validation import OnDemandValidator, ValidationContext
+from vali_utils.on_demand.on_demand_validation import OnDemandValidator
+from vali_utils.on_demand.od_job_cache import ODJobCache, CachedMinerODResult
 from vali_utils import metrics
 
 load_dotenv()
@@ -133,7 +132,7 @@ class Validator:
 
         # Add counter for evaluation cycles since startup
         self.evaluation_cycles_since_startup = 0
-        self.processed_job_ids_cache = utils.LRUSet(capacity=10_000)
+        self.od_cache = ODJobCache()
 
         self.on_demand_thread: threading.Thread = None
 
@@ -179,6 +178,10 @@ class Validator:
             bt.logging.warning("Axon off, not serving ip to chain.")
 
         self.on_demand_validator = OnDemandValidator(evaluator=self.evaluator)
+
+        # Wire OD components into the evaluator so eval_miner() can drain and validate
+        self.evaluator.od_cache = self.od_cache
+        self.evaluator.on_demand_validator = self.on_demand_validator
 
         self.is_setup = True
 
@@ -276,24 +279,22 @@ class Validator:
         bt.logging.debug(f"Started a new wandb run: {name}")
 
     async def loop_poll_on_demand_jobs_with_submissions(self):
-        use_cache = True  # change to false for dev testing
-
         while not self.should_exit:
             bt.logging.info("Pulling on demand jobs with submissions")
 
             try:
                 async with self._on_demand_client() as client:
-                    jobs_with_submissions_downloaded_response = (
-                        await client.validator_list_and_download_submission_json(
+                    # Metadata-only call — no S3 downloads.
+                    # We only need submission timestamps and content_length
+                    # to compute speed multipliers and detect empty submissions.
+                    job_list_resp = (
+                        await client.validator_list_jobs_with_submissions(
                             req=ListJobsWithSubmissionsForValidationRequest(
                                 expired_since=dt.datetime.now(dt.timezone.utc)
                                 - dt.timedelta(minutes=45),
                                 expired_until=dt.datetime.now(dt.timezone.utc)
                                 - dt.timedelta(minutes=2),
                                 limit=10,
-                            ),
-                            job_ids_to_skip_downloading=set(
-                                self.processed_job_ids_cache.data.keys()
                             ),
                         )
                     )
@@ -303,304 +304,83 @@ class Validator:
                 continue
 
             try:
-                # co locate each job id and miner hotkey
-                job_list_with_submissions_resp, downloads = (
-                    jobs_with_submissions_downloaded_response
+                total_submissions = sum(
+                    len(jws.submissions)
+                    for jws in job_list_resp.jobs_with_submissions
                 )
-
-                job_data_per_job_id_and_miner_hotkey: Dict[
-                    str, Dict[str, Dict]
-                ] = {}  # d[job id][miner hotkey]{download data}
-
-                for (
-                    job_with_submissions
-                ) in job_list_with_submissions_resp.jobs_with_submissions:
-                    job_data_per_job_id_and_miner_hotkey[
-                        job_with_submissions.job.id
-                    ] = {}  # job id -> hotkey
-
-                for download in downloads:
-                    job_id = download["job_id"]
-                    miner_hotkey = download["miner_hotkey"]
-
-                    job_data_per_job_id_and_miner_hotkey[job_id][miner_hotkey] = (
-                        download
-                    )
-
                 bt.logging.info(
-                    f"Pulled in: {len(job_data_per_job_id_and_miner_hotkey)} jobs with {sum([len(v) for v in job_data_per_job_id_and_miner_hotkey.values()])} total submissions"
+                    f"Pulled {len(job_list_resp.jobs_with_submissions)} jobs "
+                    f"with {total_submissions} total submissions"
                 )
 
-                # validate
                 for (
                     job_with_submission
-                ) in job_list_with_submissions_resp.jobs_with_submissions:
+                ) in job_list_resp.jobs_with_submissions:
                     job = job_with_submission.job
 
-                    if use_cache and job.id in self.processed_job_ids_cache:
+                    if self.od_cache.is_job_processed(job.id):
                         continue
 
                     submissions = job_with_submission.submissions
-                    submissions_with_valid_downloads = [
-                        sub
-                        for sub in submissions
-                        if sub.miner_hotkey
-                        in job_data_per_job_id_and_miner_hotkey[job.id]
-                        and job_data_per_job_id_and_miner_hotkey[job.id][
-                            sub.miner_hotkey
-                        ]["error"]
-                        is None
-                    ]
 
-                    if (
-                        len(submissions_with_valid_downloads) > 5
-                    ):  # amount of miners to validate per job id
-                        random.shuffle(submissions_with_valid_downloads)
-                        submissions_with_valid_downloads = (
-                            submissions_with_valid_downloads[:5]
-                        )
+                    # No validation / downloading — just record who submitted
+                    # and their speed based on submission timestamp.
+                    # S3 validation already catches data quality issues;
+                    # OD just tracks participation and response speed.
+                    cache_results: Dict[str, CachedMinerODResult] = {}
 
-                    # Build validation context from job
-                    usernames = []
-                    if hasattr(job.job, "usernames") and job.job.usernames:
-                        usernames = job.job.usernames
-                    elif hasattr(job.job, "channels") and job.job.channels:
-                        usernames = job.job.channels
+                    for sub in submissions:
+                        hotkey = sub.miner_hotkey
 
-                    keywords = []
-                    if hasattr(job.job, "keywords") and job.job.keywords:
-                        keywords = job.job.keywords
-                    if hasattr(job.job, "subreddit") and job.job.subreddit:
-                        keywords.insert(0, job.job.subreddit)
-
-                    url = None
-                    if hasattr(job.job, "url") and job.job.url:
-                        url = job.job.url
-
-                    validation_context = ValidationContext(
-                        source=job.job.platform,
-                        usernames=usernames,
-                        keywords=keywords,
-                        url=url,
-                        keyword_mode=job.keyword_mode,
-                        start_date=job.start_date.isoformat() if job.start_date else None,
-                        end_date=job.end_date.isoformat() if job.end_date else None,
-                        limit=job.limit,
-                    )
-
-                    # Prepare miner responses in the format expected by validation methods
-                    miner_responses = {}
-                    miner_data_counts = {}
-                    miner_submission_metadata = {}
-
-                    for sub in submissions_with_valid_downloads:
-                        miner_hotkey = sub.miner_hotkey
-
-                        # Convert hotkey to UID
+                        # Skip miners not in metagraph
                         try:
-                            uid = self.metagraph.hotkeys.index(miner_hotkey)
+                            self.metagraph.hotkeys.index(hotkey)
                         except ValueError:
-                            bt.logging.warning(
-                                f"Miner hotkey {miner_hotkey} not found in metagraph"
+                            continue
+
+                        # Empty submission (0 bytes) → penalize
+                        is_empty = (sub.s3_content_length or 0) == 0
+                        if is_empty:
+                            cache_results[hotkey] = CachedMinerODResult(
+                                job_id=job.id,
+                                submitted_at=sub.submitted_at,
+                                returned_count=0,
+                                requested_limit=job.limit,
+                                passed_validation=False,
+                                speed_multiplier=0.0,
+                                volume_multiplier=0.0,
+                                failure_reason="empty_submission",
                             )
                             continue
 
-                        # Get and validate uploaded data
-                        try:
-                            miner_uploaded_raw_json = (
-                                job_data_per_job_id_and_miner_hotkey[job.id][
-                                    miner_hotkey
-                                ]["data"]
-                            )
-                            miner_upload = OnDemandMinerUpload.model_validate(
-                                miner_uploaded_raw_json
-                            )
-                        except Exception as e:
-                            bt.logging.warning(
-                                f"Miner {miner_hotkey} (UID {uid}) data validation failed: {e}"
-                            )
-                            # Treat parse failures as empty — will be penalized as failed validation
-                            miner_responses[uid] = []
-                            miner_data_counts[uid] = 0
-                            miner_submission_metadata[uid] = {
-                                "submitted_at": sub.submitted_at,
-                                "row_count": 0,
-                            }
-                            continue
-
-                        # Empty submissions (0-byte or empty data_entities) are kept
-                        # in miner_responses so they flow through validation as failures
-                        if not miner_upload.data_entities:
-                            bt.logging.info(
-                                f"Miner {uid}:{miner_hotkey} submitted empty data for job {job.id}"
-                            )
-
-                        # Cap to requested limit — miners shouldn't be rewarded
-                        # for returning more rows than the job asked for.
-                        entities = miner_upload.data_entities
-                        if job.limit and len(entities) > job.limit:
-                            bt.logging.info(
-                                f"Miner {uid}:{miner_hotkey} returned {len(entities)} rows "
-                                f"but job limit is {job.limit} — capping"
-                            )
-                            entities = entities[:job.limit]
-
-                        # Store in format expected by validation methods
-                        miner_responses[uid] = entities
-                        miner_data_counts[uid] = len(entities)
-
-                        # Track submission metadata for reward calculation
-                        miner_submission_metadata[uid] = {
-                            "submitted_at": sub.submitted_at,
-                            "row_count": len(miner_upload.data_entities),
-                        }
-
-                    # If no miner returned data, verify independently whether
-                    # the data exists using the validator's own scraper.
-                    if not any(c > 0 for c in miner_data_counts.values()):
-                        data_exists = await self.on_demand_validator.check_data_exists(
-                            validation_context
-                        )
-                        if not data_exists:
-                            bt.logging.info(
-                                f"Job {job.id}: no miner returned data and validator "
-                                f"probe confirms data doesn't exist — skipping job"
-                            )
-                            continue
-                        else:
-                            bt.logging.warning(
-                                f"Job {job.id}: no miner returned data but validator "
-                                f"probe found data — miners failed to scrape"
-                            )
-
-                    # Step 1: Format validation
-                    for uid, data in miner_responses.items():
-                        if (
-                            data
-                            and not self.on_demand_validator._validate_miner_data_format(
-                                validation_context, data, uid
-                            )
-                        ):
-                            bt.logging.info(f"Miner {uid} failed format validation")
-                            miner_responses[uid] = []  # Treat as empty
-                            miner_data_counts[uid] = 0
-
-                    # Step 2: Perform detailed validation on sample posts
-                    validation_results = {}
-                    for uid, posts in miner_responses.items():
-                        if not posts:
-                            continue
-
-                        num_to_validate = min(2, len(posts))
-                        selected_posts = random.sample(posts, num_to_validate)
-
-                        for post in selected_posts:
-                            post_id = self.on_demand_validator._get_post_id(post)
-                            miner_post_key = f"{uid}:{post_id}"
-                            is_valid = await self.on_demand_validator._validate_entity(
-                                validation_context, post, post_id, uid
-                            )
-                            validation_results[miner_post_key] = is_valid
-
-                    # Step 3: Apply validation penalties and get successful miners
-                    miner_scores, failed_miners, successful_miners = (
-                        self.on_demand_validator._apply_validation_penalties(
-                            miner_responses, validation_results
-                        )
-                    )
-
-                    # Step 4: Volume consensus validation
-                    consensus_count = (
-                        self.on_demand_validator._calculate_volume_consensus(
-                            miner_data_counts
-                        )
-                    )
-                    if consensus_count:
-                        penalized_miners = (
-                            self.on_demand_validator._apply_consensus_volume_penalties(
-                                miner_data_counts, job.limit, consensus_count
-                            )
-                        )
-                        bt.logging.info(
-                            f"Applied volume penalties to {len(penalized_miners)} miners"
-                        )
-                        # Remove consensus-penalized miners from successful list
-                        successful_miners = [
-                            uid
-                            for uid in successful_miners
-                            if uid not in penalized_miners
-                        ]
-
-                    # Step 5: Apply rewards to successful miners
-                    for uid in successful_miners:
-                        if uid not in miner_submission_metadata:
-                            bt.logging.warning(
-                                f"Missing metadata for successful miner {uid}"
-                            )
-                            continue
-
-                        metadata = miner_submission_metadata[uid]
-
-                        # Calculate reward multipliers
+                        # Calculate speed multiplier from submission time
                         speed_mult, volume_mult = (
                             self.on_demand_validator.calculate_ondemand_reward_multipliers(
                                 job_created_at=job.created_at,
-                                submission_timestamp=metadata["submitted_at"],
-                                returned_count=metadata["row_count"],
+                                submission_timestamp=sub.submitted_at,
+                                returned_count=job.limit or 100,  # trust they filled the job
                                 requested_limit=job.limit,
-                                consensus_count=consensus_count,
                             )
                         )
 
-                        # Apply reward (scaled by existing credibility internally)
-                        self.evaluator.scorer.apply_ondemand_reward(
-                            uid=uid,
+                        cache_results[hotkey] = CachedMinerODResult(
+                            job_id=job.id,
+                            submitted_at=sub.submitted_at,
+                            returned_count=job.limit or 100,
+                            requested_limit=job.limit,
+                            passed_validation=True,
                             speed_multiplier=speed_mult,
                             volume_multiplier=volume_mult,
                         )
 
+                    # Write all results to the shared OD cache
+                    self.od_cache.add_results(job.id, cache_results)
+
                     bt.logging.info(
-                        f"Job {job.id} validation complete: "
-                        f"{len(successful_miners)} miners rewarded, "
-                        f"{len(failed_miners)} miners failed validation"
+                        f"Job {job.id}: cached {len(cache_results)} submitter results "
+                        f"({sum(1 for r in cache_results.values() if r.passed_validation)} non-empty, "
+                        f"{sum(1 for r in cache_results.values() if not r.passed_validation)} empty)"
                     )
-
-                    # Update on-demand credibility only for miners who submitted NON-EMPTY data.
-                    # Empty submissions (0-byte or empty data_entities) do not earn credibility.
-                    all_submitter_uids = set()
-                    for sub in job_with_submission.submissions:
-                        try:
-                            uid = self.metagraph.hotkeys.index(sub.miner_hotkey)
-                        except ValueError:
-                            continue
-                        # Only grant credibility if miner had actual data
-                        if uid in miner_data_counts and miner_data_counts[uid] > 0:
-                            all_submitter_uids.add(uid)
-
-                    all_miner_uids = utils.get_miner_uids(
-                        self.metagraph, self.evaluator.vpermit_rao_limit
-                    )
-                    self.evaluator.scorer.update_ondemand_credibility(
-                        submitter_uids=all_submitter_uids,
-                        all_miner_uids=all_miner_uids,
-                    )
-
-                if use_cache:
-                    job_ids_processed_in_this_loop_not_already_in_cache = set(
-                        [
-                            job_id
-                            for job_id in set(
-                                job_data_per_job_id_and_miner_hotkey.keys()
-                            )
-                            if job_id not in self.processed_job_ids_cache
-                        ]
-                    )
-                    bt.logging.info(
-                        f"Adding processed on demand job ids to cache: {job_ids_processed_in_this_loop_not_already_in_cache}"
-                    )
-                    for job_id in job_ids_processed_in_this_loop_not_already_in_cache:
-                        if job_id not in self.processed_job_ids_cache:
-                            self.processed_job_ids_cache.add(job_id)
             except:
                 bt.logging.exception(
                     "Error while validating on demand jobs and submissions"

--- a/rewards/miner_scorer.py
+++ b/rewards/miner_scorer.py
@@ -400,22 +400,15 @@ class MinerScorer:
             )
 
     def apply_ondemand_penalty(self, uid: int, mult_factor: float):
-        """Applies a credibility penalty to a given miner based on their ondemand result"""
+        """Applies an OD-only penalty: decays boost and OD credibility.
+
+        Does NOT touch P2P credibility — OD failures should not contaminate
+        P2P scoring. The composite score is recalculated after the update.
+        """
         with self.lock:
-            cred_penalty = MinerScorer.ONDEMAND_MAX_CRED_PENALTY * mult_factor
-            old_cred = float(self.miner_credibility[uid])
-
-            # Apply credibility penalty
-            self.miner_credibility[uid] = max(self.miner_credibility[uid] - cred_penalty, 0)
-            new_cred = float(self.miner_credibility[uid])
-
             # EMA the ondemand boost with 0 reward for failures
             old_boost = float(self.ondemand_boosts[uid])
-            failure_reward = 0
-            self.ondemand_boosts[uid] = (
-                self.ondemand_alpha * failure_reward +
-                (1 - self.ondemand_alpha) * self.ondemand_boosts[uid]
-            )
+            self.ondemand_boosts[uid] = (1 - self.ondemand_alpha) * self.ondemand_boosts[uid]
             new_boost = float(self.ondemand_boosts[uid])
 
             # Direct penalty to on-demand credibility for bad data
@@ -425,36 +418,10 @@ class MinerScorer:
             )
             new_od_cred = float(self.ondemand_credibility[uid])
 
-            # Recalculate composite score with updated credibilities
-            old_score = float(self.scores[uid])
-            p2p_raw = float(self.scorable_bytes[uid])
-            p2p_component = p2p_raw * MinerScorer.P2P_REWARD_SCALE * (new_cred ** MinerScorer._CREDIBILITY_EXP)
-            s3_component = float(self.s3_boosts[uid]) * (float(self.s3_credibility[uid]) ** MinerScorer._CREDIBILITY_EXP)
-            # OD: no exponent — raw credibility, same as on_miner_evaluated and get_scores_for_weights
-            od_component = float(self.ondemand_boosts[uid]) * new_od_cred
-
-            # TEMPORARY: S3 capped at 2x on-demand component.
-            # Prevents fabricators from profiting purely off S3 volume.
-            # Legit miners with real OD participation still get rewarded for S3.
-            # Will be replaced by proper incentive redesign.
-            s3_uncapped = s3_component
-            if od_component > 0:
-                s3_component = min(s3_component, od_component * 2)
-            else:
-                s3_component = 0.0
-
-            self.scores[uid] = p2p_component + s3_component + od_component
-
             bt.logging.info(
                 f"OnDemand penalty for Miner {uid}: "
-                f"P2P Cred {old_cred:.4f} -> {new_cred:.4f}, "
-                f"OnDemand Cred {old_od_cred:.4f} -> {new_od_cred:.4f}, "
-                f"Boost {old_boost:.2f} -> {new_boost:.2f}, "
-                f"P2P={p2p_component:.0f} (raw={float(self.scorable_bytes[uid]):.0f}, cred={float(self.miner_credibility[uid]):.4f}), "
-                f"S3={s3_component:.0f} (boost={float(self.s3_boosts[uid]):.0f}, cred={float(self.s3_credibility[uid]):.4f})"
-                f"{f', capped from {s3_uncapped:.0f}' if s3_uncapped != s3_component else ''}, "
-                f"OD={od_component:.0f} (boost={float(self.ondemand_boosts[uid]):.0f}, cred={new_od_cred:.4f}), "
-                f"Score {old_score:.2f} -> {float(self.scores[uid]):.2f}"
+                f"OD Cred {old_od_cred:.4f} -> {new_od_cred:.4f}, "
+                f"Boost {old_boost:.0f} -> {new_boost:.0f}"
             )
 
     def apply_ondemand_reward(

--- a/rewards/miner_scorer.py
+++ b/rewards/miner_scorer.py
@@ -157,14 +157,16 @@ class MinerScorer:
             for uid in range(len(self.scores)):
                 p2p_cred = float(self.miner_credibility[uid] ** MinerScorer._CREDIBILITY_EXP)
                 s3_cred = float(self.s3_credibility[uid] ** MinerScorer._CREDIBILITY_EXP)
-                od_cred = float(self.ondemand_credibility[uid] ** MinerScorer._CREDIBILITY_EXP)
+                # OD: no exponent — ondemand_boosts EMA already decays non-participants.
+                # The ^2.5 combined with broken per-job credibility polling was destroying
+                # OD scores for all miners.
+                od_cred = float(self.ondemand_credibility[uid])
 
                 p2p_component = float(self.scorable_bytes[uid]) * MinerScorer.P2P_REWARD_SCALE * p2p_cred
                 s3_component = float(self.s3_boosts[uid]) * s3_cred
                 od_component = float(self.ondemand_boosts[uid]) * od_cred
 
                 # S3 cap (existing): S3 <= 2x OD
-                s3_uncapped = s3_component
                 if od_component > 0:
                     s3_component = min(s3_component, od_component * 2)
                 else:
@@ -379,25 +381,6 @@ class MinerScorer:
                 f"Total s3_boosts: {total_boosts:.0f}"
             )
 
-    def update_ondemand_credibility(self, submitter_uids: set, all_miner_uids: list):
-        """Update on-demand credibility for all miners based on job participation.
-
-        Called from validator.py for each expired job processed.
-        For miners who submitted: EMA toward 1.0 (trust builds).
-        For miners who didn't submit: EMA toward 0.0 (trust decays).
-
-        Args:
-            submitter_uids: Set of UIDs that submitted to this job (all, not just validated 5)
-            all_miner_uids: List of all active miner UIDs in the metagraph
-        """
-        with self.lock:
-            alpha = MinerScorer.ONDEMAND_CRED_ALPHA
-            for uid in all_miner_uids:
-                participated = 1.0 if uid in submitter_uids else 0.0
-                self.ondemand_credibility[uid] = (
-                    alpha * participated + (1 - alpha) * self.ondemand_credibility[uid]
-                )
-
     def apply_ondemand_penalty(self, uid: int, mult_factor: float):
         """Applies a credibility penalty to a given miner based on their ondemand result"""
         with self.lock:
@@ -429,7 +412,8 @@ class MinerScorer:
             p2p_raw = float(self.scorable_bytes[uid])
             p2p_component = p2p_raw * MinerScorer.P2P_REWARD_SCALE * (new_cred ** MinerScorer._CREDIBILITY_EXP)
             s3_component = float(self.s3_boosts[uid]) * (float(self.s3_credibility[uid]) ** MinerScorer._CREDIBILITY_EXP)
-            od_component = float(self.ondemand_boosts[uid]) * (new_od_cred ** MinerScorer._CREDIBILITY_EXP)
+            # OD: no exponent — raw credibility, same as on_miner_evaluated and get_scores_for_weights
+            od_component = float(self.ondemand_boosts[uid]) * new_od_cred
 
             # TEMPORARY: S3 capped at 2x on-demand component.
             # Prevents fabricators from profiting purely off S3 volume.
@@ -483,11 +467,40 @@ class MinerScorer:
             )
             new_boost = float(self.ondemand_boosts[uid])
 
+            # Also bump OD credibility toward 1.0 on success (mirrors S3 credibility pattern)
+            old_od_cred = float(self.ondemand_credibility[uid])
+            alpha = MinerScorer.ONDEMAND_CRED_ALPHA
+            self.ondemand_credibility[uid] = min(
+                1.0, alpha * 1.0 + (1 - alpha) * self.ondemand_credibility[uid]
+            )
+            new_od_cred = float(self.ondemand_credibility[uid])
+
             bt.logging.info(
                 f"OnDemand reward for Miner {uid}: "
                 f"Speed={speed_multiplier:.3f}, Volume={volume_multiplier:.3f}, "
                 f"Raw reward={raw_reward:.0f}, "
-                f"OnDemand boost (EMA'd): {old_boost:.0f} -> {new_boost:.0f}"
+                f"OnDemand boost (EMA'd): {old_boost:.0f} -> {new_boost:.0f}, "
+                f"OD cred: {old_od_cred:.4f} -> {new_od_cred:.4f}"
+            )
+
+    def apply_ondemand_credibility_bump(self, uid: int) -> None:
+        """Small credibility bump for miners who submitted to an OD job but weren't sampled.
+
+        They participated (good signal) but we didn't verify their data,
+        so we give a smaller credibility increase than a validated success.
+        """
+        with self.lock:
+            old_od_cred = float(self.ondemand_credibility[uid])
+            # Half the normal alpha — participated but unverified
+            alpha = MinerScorer.ONDEMAND_CRED_ALPHA * 0.5
+            self.ondemand_credibility[uid] = min(
+                1.0, alpha * 1.0 + (1 - alpha) * self.ondemand_credibility[uid]
+            )
+            new_od_cred = float(self.ondemand_credibility[uid])
+
+            bt.logging.trace(
+                f"OnDemand credibility bump (unsampled) for Miner {uid}: "
+                f"OD cred: {old_od_cred:.4f} -> {new_od_cred:.4f}"
             )
 
     def on_miner_evaluated(
@@ -544,7 +557,9 @@ class MinerScorer:
                 # This prevents one bad channel from zeroing out all rewards.
                 p2p_cred = float(self.miner_credibility[uid] ** MinerScorer._CREDIBILITY_EXP)
                 s3_cred = float(self.s3_credibility[uid] ** MinerScorer._CREDIBILITY_EXP)
-                od_cred = float(self.ondemand_credibility[uid] ** MinerScorer._CREDIBILITY_EXP)
+                # OD: no exponent — the EMA-based credibility already decays non-participants.
+                # The ^2.5 was destroying OD scores (near-zero values raised to 2.5 → effectively zero).
+                od_cred = float(self.ondemand_credibility[uid])
 
                 p2p_component = score * MinerScorer.P2P_REWARD_SCALE * p2p_cred
                 s3_component = float(self.s3_boosts[uid]) * s3_cred

--- a/rewards/miner_scorer.py
+++ b/rewards/miner_scorer.py
@@ -22,7 +22,8 @@ class MinerScorer:
     # v4: Reset on-demand again after data existence probe + reddit body fix
     # v5: Full reset — engagement/uniqueness/URL checks reveal widespread exploit
     # v6: Reset S3 — .head() → .sample() fix (scraper sampling bypass)
-    STATE_VERSION = 6
+    # v7: Reset OD — moved scoring to evaluator, dropped ^2.5 exponent, fixed credibility decay
+    STATE_VERSION = 7
 
     # Start new miner's at a credibility of 0.
     STARTING_CREDIBILITY = 0
@@ -141,6 +142,23 @@ class MinerScorer:
                 self.s3_boosts.zero_()
                 self.s3_credibility.fill_(MinerScorer.STARTING_S3_CREDIBILITY)
                 self.effective_sizes.zero_()
+
+            if saved_version < 7:
+                # -> v7: Full reset — OD scoring moved to evaluator, ^2.5 exponent
+                # dropped, credibility decay fixed. P2P cap (min(p2p, s3+od)) means
+                # all scores computed under broken OD are wrong. Clean slate.
+                bt.logging.warning(
+                    f"State migration v{saved_version} -> v7: "
+                    f"Full score reset (OD fix changes all weights)."
+                )
+                self.scores.zero_()
+                self.miner_credibility.fill_(MinerScorer.STARTING_CREDIBILITY)
+                self.scorable_bytes.zero_()
+                self.s3_boosts.zero_()
+                self.s3_credibility.fill_(MinerScorer.STARTING_S3_CREDIBILITY)
+                self.effective_sizes.zero_()
+                self.ondemand_boosts.zero_()
+                self.ondemand_credibility.fill_(MinerScorer.STARTING_ONDEMAND_CREDIBILITY)
 
     def get_scores(self) -> torch.Tensor:
         """Returns the raw scores of all miners."""

--- a/tests/vali_utils/test_od_flow.py
+++ b/tests/vali_utils/test_od_flow.py
@@ -65,11 +65,6 @@ class TestODJobCache(unittest.TestCase):
         self.cache.add_results("job1", {"hk_a": self._make_result()})
         self.assertTrue(self.cache.is_job_processed("job1"))
 
-    def test_get_processed_job_ids(self):
-        self.cache.add_results("job1", {"hk_a": self._make_result("job1")})
-        self.cache.add_results("job2", {"hk_b": self._make_result("job2")})
-        self.assertEqual(self.cache.get_processed_job_ids(), {"job1", "job2"})
-
     def test_drain_unknown_hotkey(self):
         self.assertEqual(self.cache.get_and_drain("unknown"), [])
 

--- a/tests/vali_utils/test_od_flow.py
+++ b/tests/vali_utils/test_od_flow.py
@@ -1,0 +1,309 @@
+"""Tests for the OD job cache + evaluator integration.
+
+Covers:
+- ODJobCache: add, drain, dedup, processed tracking
+- MinerScorer: OD reward/penalty/credibility bump
+- MinerEvaluator._evaluate_od: drains cache, applies scores, triggers spot-check
+"""
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+import datetime as dt
+import torch
+
+from vali_utils.on_demand.od_job_cache import ODJobCache, CachedMinerODResult
+from rewards.miner_scorer import MinerScorer
+from rewards.data_value_calculator import DataValueCalculator
+
+
+class TestODJobCache(unittest.TestCase):
+    def setUp(self):
+        self.cache = ODJobCache()
+
+    def _make_result(self, job_id="job1", passed=True, speed=0.8, volume=0.9):
+        return CachedMinerODResult(
+            job_id=job_id,
+            submitted_at=dt.datetime.now(dt.timezone.utc),
+            returned_count=100,
+            requested_limit=100,
+            passed_validation=passed,
+            speed_multiplier=speed,
+            volume_multiplier=volume,
+        )
+
+    def test_add_and_drain(self):
+        """Results are returned once then gone."""
+        self.cache.add_results("job1", {
+            "hk_a": self._make_result(),
+            "hk_b": self._make_result(passed=False),
+        })
+
+        results_a = self.cache.get_and_drain("hk_a")
+        self.assertEqual(len(results_a), 1)
+        self.assertTrue(results_a[0].passed_validation)
+
+        # Second drain is empty
+        self.assertEqual(self.cache.get_and_drain("hk_a"), [])
+
+        results_b = self.cache.get_and_drain("hk_b")
+        self.assertEqual(len(results_b), 1)
+        self.assertFalse(results_b[0].passed_validation)
+
+    def test_multiple_jobs_accumulate(self):
+        """Multiple jobs accumulate for the same miner."""
+        self.cache.add_results("job1", {"hk_a": self._make_result("job1")})
+        self.cache.add_results("job2", {"hk_a": self._make_result("job2")})
+        self.cache.add_results("job3", {"hk_a": self._make_result("job3")})
+
+        results = self.cache.get_and_drain("hk_a")
+        self.assertEqual(len(results), 3)
+        self.assertEqual({r.job_id for r in results}, {"job1", "job2", "job3"})
+
+    def test_is_job_processed(self):
+        self.assertFalse(self.cache.is_job_processed("job1"))
+        self.cache.add_results("job1", {"hk_a": self._make_result()})
+        self.assertTrue(self.cache.is_job_processed("job1"))
+
+    def test_get_processed_job_ids(self):
+        self.cache.add_results("job1", {"hk_a": self._make_result("job1")})
+        self.cache.add_results("job2", {"hk_b": self._make_result("job2")})
+        self.assertEqual(self.cache.get_processed_job_ids(), {"job1", "job2"})
+
+    def test_drain_unknown_hotkey(self):
+        self.assertEqual(self.cache.get_and_drain("unknown"), [])
+
+    def test_pending_miner_count(self):
+        self.assertEqual(self.cache.get_pending_miner_count(), 0)
+        self.cache.add_results("job1", {
+            "hk_a": self._make_result(),
+            "hk_b": self._make_result(),
+        })
+        self.assertEqual(self.cache.get_pending_miner_count(), 2)
+        self.cache.get_and_drain("hk_a")
+        self.assertEqual(self.cache.get_pending_miner_count(), 1)
+
+
+class TestMinerScorerOD(unittest.TestCase):
+    def setUp(self):
+        self.scorer = MinerScorer(10, DataValueCalculator())
+
+    def test_reward_bumps_credibility(self):
+        """apply_ondemand_reward should increase OD credibility."""
+        old = float(self.scorer.ondemand_credibility[0])
+        self.scorer.apply_ondemand_reward(uid=0, speed_multiplier=1.0, volume_multiplier=1.0)
+        new = float(self.scorer.ondemand_credibility[0])
+        self.assertGreater(new, old)
+
+    def test_reward_bumps_boost(self):
+        """apply_ondemand_reward should increase ondemand_boosts."""
+        old = float(self.scorer.ondemand_boosts[0])
+        self.scorer.apply_ondemand_reward(uid=0, speed_multiplier=1.0, volume_multiplier=1.0)
+        new = float(self.scorer.ondemand_boosts[0])
+        self.assertGreater(new, old)
+
+    def test_penalty_decays_credibility(self):
+        """apply_ondemand_penalty should decrease OD credibility."""
+        old = float(self.scorer.ondemand_credibility[0])
+        self.scorer.apply_ondemand_penalty(uid=0, mult_factor=1.0)
+        new = float(self.scorer.ondemand_credibility[0])
+        self.assertLess(new, old)
+
+    def test_penalty_decays_boost(self):
+        """apply_ondemand_penalty should decay ondemand_boosts toward 0."""
+        self.scorer.apply_ondemand_reward(uid=0, speed_multiplier=1.0, volume_multiplier=1.0)
+        boosted = float(self.scorer.ondemand_boosts[0])
+        self.assertGreater(boosted, 0)
+
+        self.scorer.apply_ondemand_penalty(uid=0, mult_factor=1.0)
+        decayed = float(self.scorer.ondemand_boosts[0])
+        self.assertLess(decayed, boosted)
+
+    def test_credibility_bump_smaller_than_reward(self):
+        """Credibility bump (unsampled) should be smaller than reward bump."""
+        uid_bump = 0
+        uid_reward = 1
+
+        self.scorer.apply_ondemand_credibility_bump(uid=uid_bump)
+        bump_cred = float(self.scorer.ondemand_credibility[uid_bump])
+
+        self.scorer.apply_ondemand_reward(uid=uid_reward, speed_multiplier=1.0, volume_multiplier=1.0)
+        reward_cred = float(self.scorer.ondemand_credibility[uid_reward])
+
+        self.assertGreater(reward_cred, bump_cred)
+
+    def test_od_no_exponent_in_scoring(self):
+        """OD credibility should be used raw (no ^2.5) in on_miner_evaluated."""
+        uid = 0
+        # Set OD credibility to 0.5 and give some OD boost
+        self.scorer.ondemand_credibility[uid] = 0.5
+        self.scorer.apply_ondemand_reward(uid=uid, speed_multiplier=1.0, volume_multiplier=1.0)
+
+        boost = float(self.scorer.ondemand_boosts[uid])
+        cred = float(self.scorer.ondemand_credibility[uid])
+
+        # Raw: boost * 0.51 (approx after bump)
+        # With ^2.5: boost * 0.51^2.5 ≈ boost * 0.186
+        # The raw version should give ~2.7x more OD contribution
+        expected_raw = boost * cred
+        expected_exp = boost * (cred ** 2.5)
+        self.assertGreater(expected_raw, expected_exp * 2)
+
+    def test_get_scores_for_weights_od_no_exponent(self):
+        """get_scores_for_weights should use raw OD cred."""
+        uid = 0
+        self.scorer.ondemand_credibility[uid] = 0.5
+        self.scorer.apply_ondemand_reward(uid=uid, speed_multiplier=1.0, volume_multiplier=1.0)
+
+        scores = self.scorer.get_scores_for_weights()
+        # With zero P2P and S3, the score should be OD only
+        # OD = boost * raw_cred
+        boost = float(self.scorer.ondemand_boosts[uid])
+        cred = float(self.scorer.ondemand_credibility[uid])
+        expected = boost * cred
+        self.assertAlmostEqual(float(scores[uid]), expected, places=0)
+
+
+class TestEvaluateOD(unittest.TestCase):
+    """Test _evaluate_od integration with cache and scorer."""
+
+    def setUp(self):
+        self.cache = ODJobCache()
+        self.scorer = MinerScorer(10, DataValueCalculator())
+
+    def _make_evaluator_mock(self):
+        """Create a minimal mock evaluator with real scorer and cache."""
+        evaluator = MagicMock()
+        evaluator.scorer = self.scorer
+        evaluator.od_cache = self.cache
+        evaluator.on_demand_validator = None  # no spot-check
+        evaluator.config = MagicMock()
+        evaluator.wallet = MagicMock()
+        return evaluator
+
+    def test_drain_and_apply_rewards(self):
+        """Rewards are applied for all passed results."""
+        # Add 3 passed results
+        for i in range(3):
+            self.cache.add_results(f"job{i}", {
+                "hk_miner": CachedMinerODResult(
+                    job_id=f"job{i}",
+                    submitted_at=dt.datetime.now(dt.timezone.utc),
+                    returned_count=100,
+                    requested_limit=100,
+                    passed_validation=True,
+                    speed_multiplier=0.9,
+                    volume_multiplier=0.8,
+                ),
+            })
+
+        old_boost = float(self.scorer.ondemand_boosts[0])
+        old_cred = float(self.scorer.ondemand_credibility[0])
+
+        # Call _evaluate_od directly using the real method
+        from vali_utils.miner_evaluator import MinerEvaluator
+        # We need to call the unbound method with our mock
+        evaluator = self._make_evaluator_mock()
+
+        async def run():
+            await MinerEvaluator._evaluate_od(evaluator, uid=0, hotkey="hk_miner")
+
+        asyncio.run(run())
+
+        # Boost and cred should have increased (3 rewards applied)
+        self.assertGreater(float(self.scorer.ondemand_boosts[0]), old_boost)
+        self.assertGreater(float(self.scorer.ondemand_credibility[0]), old_cred)
+
+        # Cache should be empty now
+        self.assertEqual(self.cache.get_and_drain("hk_miner"), [])
+
+    def test_drain_and_apply_penalties(self):
+        """Penalties are applied for failed results."""
+        self.cache.add_results("job1", {
+            "hk_miner": CachedMinerODResult(
+                job_id="job1",
+                submitted_at=dt.datetime.now(dt.timezone.utc),
+                returned_count=0,
+                requested_limit=100,
+                passed_validation=False,
+                speed_multiplier=0.0,
+                volume_multiplier=0.0,
+                failure_reason="empty_submission",
+            ),
+        })
+
+        old_cred = float(self.scorer.ondemand_credibility[0])
+
+        from vali_utils.miner_evaluator import MinerEvaluator
+        evaluator = self._make_evaluator_mock()
+
+        async def run():
+            await MinerEvaluator._evaluate_od(evaluator, uid=0, hotkey="hk_miner")
+
+        asyncio.run(run())
+
+        self.assertLess(float(self.scorer.ondemand_credibility[0]), old_cred)
+
+    def test_no_cache_is_noop(self):
+        """If od_cache is None, _evaluate_od does nothing."""
+        from vali_utils.miner_evaluator import MinerEvaluator
+        evaluator = self._make_evaluator_mock()
+        evaluator.od_cache = None
+
+        old_boost = float(self.scorer.ondemand_boosts[0])
+
+        async def run():
+            await MinerEvaluator._evaluate_od(evaluator, uid=0, hotkey="hk_miner")
+
+        asyncio.run(run())
+
+        self.assertEqual(float(self.scorer.ondemand_boosts[0]), old_boost)
+
+    def test_empty_drain_is_noop(self):
+        """If no results for this miner, nothing changes."""
+        from vali_utils.miner_evaluator import MinerEvaluator
+        evaluator = self._make_evaluator_mock()
+
+        old_boost = float(self.scorer.ondemand_boosts[0])
+
+        async def run():
+            await MinerEvaluator._evaluate_od(evaluator, uid=0, hotkey="hk_nonexistent")
+
+        asyncio.run(run())
+
+        self.assertEqual(float(self.scorer.ondemand_boosts[0]), old_boost)
+
+    def test_mixed_results(self):
+        """Mix of passed and failed results applies both rewards and penalties."""
+        self.cache.add_results("job1", {
+            "hk_miner": CachedMinerODResult(
+                job_id="job1", submitted_at=dt.datetime.now(dt.timezone.utc),
+                returned_count=100, requested_limit=100,
+                passed_validation=True, speed_multiplier=1.0, volume_multiplier=1.0,
+            ),
+        })
+        self.cache.add_results("job2", {
+            "hk_miner": CachedMinerODResult(
+                job_id="job2", submitted_at=dt.datetime.now(dt.timezone.utc),
+                returned_count=0, requested_limit=100,
+                passed_validation=False, speed_multiplier=0.0, volume_multiplier=0.0,
+                failure_reason="empty",
+            ),
+        })
+
+        from vali_utils.miner_evaluator import MinerEvaluator
+        evaluator = self._make_evaluator_mock()
+
+        async def run():
+            await MinerEvaluator._evaluate_od(evaluator, uid=0, hotkey="hk_miner")
+
+        asyncio.run(run())
+
+        # Boost should be non-zero (reward applied then decayed by penalty)
+        self.assertGreater(float(self.scorer.ondemand_boosts[0]), 0)
+        # Cache drained
+        self.assertEqual(self.cache.get_and_drain("hk_miner"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -3,6 +3,7 @@ import gc
 import copy
 import asyncio
 import datetime
+import random
 import traceback
 import threading
 import time
@@ -37,6 +38,7 @@ from vali_utils.s3_utils import validate_s3_miner_data, get_s3_validation_summar
 from vali_utils.s3_logging_utils import log_s3_validation_table
 
 from rewards.miner_scorer import MinerScorer
+from vali_utils.on_demand.od_job_cache import ODJobCache
 
 
 class MinerEvaluator:
@@ -72,6 +74,13 @@ class MinerEvaluator:
         self.storage = SqliteMemoryValidatorStorage()
         self.s3_storage = S3ValidationStorage(self.config.s3_results_path)
         self.s3_reader = s3_reader
+        # OD job cache — set by validator.py after construction.
+        # eval_miner() drains cached OD results per-miner.
+        self.od_cache: Optional[ODJobCache] = None
+        # OD validator — set by validator.py after construction.
+        # Used for spot-check validation at eval time.
+        self.on_demand_validator = None
+
         # Instantiate runners
         self.should_exit: bool = False
         self.is_running: bool = False
@@ -85,6 +94,158 @@ class MinerEvaluator:
     def eval_miner_sync(self, uid: int) -> None:
         """Synchronous version of eval_miner."""
         asyncio.run(self.eval_miner(uid))
+
+    async def _evaluate_od(self, uid: int, hotkey: str) -> None:
+        """Drain cached OD results for this miner and apply scores.
+
+        Called at the start of eval_miner() so OD rewards/penalties are applied
+        in the same per-miner evaluation flow as P2P and S3.
+
+        1. Apply rewards/penalties for all cached results (speed-based).
+        2. Spot-check: pick one result, fetch the actual submission from the API,
+           download it, and validate a sample entity with the scraper.
+           If validation fails → apply penalty and flip the reward.
+        """
+        if self.od_cache is None:
+            return
+
+        results = self.od_cache.get_and_drain(hotkey)
+        if not results:
+            return
+
+        # Apply all cached results optimistically
+        passed_results = [r for r in results if r.passed_validation is True]
+        failed_results = [r for r in results if r.passed_validation is False]
+
+        for r in passed_results:
+            self.scorer.apply_ondemand_reward(
+                uid=uid,
+                speed_multiplier=r.speed_multiplier,
+                volume_multiplier=r.volume_multiplier,
+            )
+        for r in failed_results:
+            self.scorer.apply_ondemand_penalty(uid=uid, mult_factor=1.0)
+
+        bt.logging.info(
+            f"UID:{uid} - HOTKEY:{hotkey}: Applied {len(results)} cached OD results "
+            f"(rewarded={len(passed_results)}, penalized={len(failed_results)})"
+        )
+
+        # Spot-check: validate one submission to catch fake data
+        if passed_results and self.on_demand_validator is not None:
+            await self._spot_check_od_submission(uid, hotkey, random.choice(passed_results))
+
+    async def _spot_check_od_submission(self, uid: int, hotkey: str, result) -> None:
+        """Download one OD submission and validate a sample entity.
+
+        Fetches the job from the API to get the presigned URL, downloads it,
+        and runs scraper validation on a sample. If it fails, apply a penalty.
+        """
+        from common.api_client import (
+            DataUniverseApiClient,
+            ListJobsWithSubmissionsForValidationRequest,
+            OnDemandMinerUpload,
+        )
+        from vali_utils.on_demand.on_demand_validation import ValidationContext
+
+        try:
+            base_url = self.config.s3_auth_url
+            verify_ssl = "localhost" not in base_url
+
+            async with DataUniverseApiClient(
+                base_url=base_url,
+                verify_ssl=verify_ssl,
+                keypair=self.wallet.hotkey,
+                timeout=60,
+            ) as client:
+                # Fetch the specific job — use a narrow time window
+                resp = await client.validator_list_jobs_with_submissions(
+                    req=ListJobsWithSubmissionsForValidationRequest(
+                        expired_since=dt.datetime.now(dt.timezone.utc) - dt.timedelta(minutes=60),
+                        expired_until=dt.datetime.now(dt.timezone.utc),
+                        limit=20,
+                    ),
+                )
+
+            # Find this miner's submission for this job
+            submission = None
+            job = None
+            for jws in resp.jobs_with_submissions:
+                if jws.job.id == result.job_id:
+                    job = jws.job
+                    for sub in jws.submissions:
+                        if sub.miner_hotkey == hotkey and sub.s3_presigned_url:
+                            submission = sub
+                            break
+                    break
+
+            if not submission or not job:
+                bt.logging.debug(
+                    f"UID:{uid} - OD spot-check: job {result.job_id} not found or expired"
+                )
+                return
+
+            # Download the submission data
+            import httpx
+            async with httpx.AsyncClient(timeout=30.0) as http:
+                dl_resp = await http.get(submission.s3_presigned_url, follow_redirects=True)
+                if dl_resp.status_code != 200:
+                    bt.logging.debug(f"UID:{uid} - OD spot-check: download failed ({dl_resp.status_code})")
+                    return
+
+                import json
+                miner_upload = OnDemandMinerUpload.model_validate(dl_resp.json())
+
+            if not miner_upload.data_entities:
+                bt.logging.info(f"UID:{uid} - OD spot-check: empty submission for job {result.job_id}")
+                self.scorer.apply_ondemand_penalty(uid=uid, mult_factor=1.0)
+                return
+
+            # Build validation context from the job
+            usernames = []
+            if hasattr(job.job, "usernames") and job.job.usernames:
+                usernames = job.job.usernames
+            elif hasattr(job.job, "channels") and job.job.channels:
+                usernames = job.job.channels
+
+            keywords = []
+            if hasattr(job.job, "keywords") and job.job.keywords:
+                keywords = job.job.keywords
+            if hasattr(job.job, "subreddit") and job.job.subreddit:
+                keywords.insert(0, job.job.subreddit)
+
+            url = None
+            if hasattr(job.job, "url") and job.job.url:
+                url = job.job.url
+
+            ctx = ValidationContext(
+                source=job.job.platform,
+                usernames=usernames,
+                keywords=keywords,
+                url=url,
+                keyword_mode=job.keyword_mode,
+                start_date=job.start_date.isoformat() if job.start_date else None,
+                end_date=job.end_date.isoformat() if job.end_date else None,
+                limit=job.limit,
+            )
+
+            # Validate one random entity
+            entity = random.choice(miner_upload.data_entities)
+            post_id = self.on_demand_validator._get_post_id(entity)
+            is_valid = await self.on_demand_validator._validate_entity(ctx, entity, post_id, uid)
+
+            if not is_valid:
+                bt.logging.warning(
+                    f"UID:{uid} - HOTKEY:{hotkey}: OD spot-check FAILED for job {result.job_id}, post {post_id}"
+                )
+                self.scorer.apply_ondemand_penalty(uid=uid, mult_factor=1.0)
+            else:
+                bt.logging.info(
+                    f"UID:{uid} - HOTKEY:{hotkey}: OD spot-check passed for job {result.job_id}"
+                )
+
+        except Exception as e:
+            bt.logging.debug(f"UID:{uid} - OD spot-check error (non-fatal): {e}")
 
     async def eval_miner(self, uid: int) -> None:
         """Evaluates a miner and updates their score.
@@ -105,6 +266,9 @@ class MinerEvaluator:
             hotkey = self.metagraph.hotkeys[uid]
 
         bt.logging.info(f"UID:{uid} - HOTKEY:{hotkey}: Evaluating miner.")
+
+        # Apply any cached OD results before the main P2P/S3 evaluation
+        await self._evaluate_od(uid, hotkey)
 
         # Query the miner for the latest index.
         index = await self._update_and_get_miner_index(hotkey, uid, axon_info)

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -169,7 +169,7 @@ class MinerEvaluator:
                     req=ListJobsWithSubmissionsForValidationRequest(
                         expired_since=dt.datetime.now(dt.timezone.utc) - dt.timedelta(minutes=60),
                         expired_until=dt.datetime.now(dt.timezone.utc),
-                        limit=20,
+                        limit=10,
                     ),
                 )
 

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -37,8 +37,16 @@ from vali_utils.validator_s3_access import ValidatorS3Access
 from vali_utils.s3_utils import validate_s3_miner_data, get_s3_validation_summary, S3ValidationResult
 from vali_utils.s3_logging_utils import log_s3_validation_table
 
+import httpx
+
+from common.api_client import (
+    DataUniverseApiClient,
+    ListJobsWithSubmissionsForValidationRequest,
+    OnDemandMinerUpload,
+)
 from rewards.miner_scorer import MinerScorer
 from vali_utils.on_demand.od_job_cache import ODJobCache
+from vali_utils.on_demand.on_demand_validation import OnDemandValidator
 
 
 class MinerEvaluator:
@@ -113,27 +121,32 @@ class MinerEvaluator:
         if not results:
             return
 
-        # Apply all cached results optimistically
-        passed_results = [r for r in results if r.passed_validation is True]
-        failed_results = [r for r in results if r.passed_validation is False]
+        # Apply all cached results in a single pass
+        passed_count = 0
+        failed_count = 0
+        spot_check_candidate = None
 
-        for r in passed_results:
-            self.scorer.apply_ondemand_reward(
-                uid=uid,
-                speed_multiplier=r.speed_multiplier,
-                volume_multiplier=r.volume_multiplier,
-            )
-        for r in failed_results:
-            self.scorer.apply_ondemand_penalty(uid=uid, mult_factor=1.0)
+        for r in results:
+            if r.passed_validation is True:
+                self.scorer.apply_ondemand_reward(
+                    uid=uid,
+                    speed_multiplier=r.speed_multiplier,
+                    volume_multiplier=r.volume_multiplier,
+                )
+                passed_count += 1
+                spot_check_candidate = r
+            elif r.passed_validation is False:
+                self.scorer.apply_ondemand_penalty(uid=uid, mult_factor=1.0)
+                failed_count += 1
 
         bt.logging.info(
             f"UID:{uid} - HOTKEY:{hotkey}: Applied {len(results)} cached OD results "
-            f"(rewarded={len(passed_results)}, penalized={len(failed_results)})"
+            f"(rewarded={passed_count}, penalized={failed_count})"
         )
 
         # Spot-check: validate one submission to catch fake data
-        if passed_results and self.on_demand_validator is not None:
-            await self._spot_check_od_submission(uid, hotkey, random.choice(passed_results))
+        if spot_check_candidate and self.on_demand_validator is not None:
+            await self._spot_check_od_submission(uid, hotkey, spot_check_candidate)
 
     async def _spot_check_od_submission(self, uid: int, hotkey: str, result) -> None:
         """Download one OD submission and validate a sample entity.
@@ -141,13 +154,6 @@ class MinerEvaluator:
         Fetches the job from the API to get the presigned URL, downloads it,
         and runs scraper validation on a sample. If it fails, apply a penalty.
         """
-        from common.api_client import (
-            DataUniverseApiClient,
-            ListJobsWithSubmissionsForValidationRequest,
-            OnDemandMinerUpload,
-        )
-        from vali_utils.on_demand.on_demand_validation import ValidationContext
-
         try:
             base_url = self.config.s3_auth_url
             verify_ssl = "localhost" not in base_url
@@ -186,14 +192,12 @@ class MinerEvaluator:
                 return
 
             # Download the submission data
-            import httpx
             async with httpx.AsyncClient(timeout=30.0) as http:
                 dl_resp = await http.get(submission.s3_presigned_url, follow_redirects=True)
                 if dl_resp.status_code != 200:
                     bt.logging.debug(f"UID:{uid} - OD spot-check: download failed ({dl_resp.status_code})")
                     return
 
-                import json
                 miner_upload = OnDemandMinerUpload.model_validate(dl_resp.json())
 
             if not miner_upload.data_entities:
@@ -201,33 +205,7 @@ class MinerEvaluator:
                 self.scorer.apply_ondemand_penalty(uid=uid, mult_factor=1.0)
                 return
 
-            # Build validation context from the job
-            usernames = []
-            if hasattr(job.job, "usernames") and job.job.usernames:
-                usernames = job.job.usernames
-            elif hasattr(job.job, "channels") and job.job.channels:
-                usernames = job.job.channels
-
-            keywords = []
-            if hasattr(job.job, "keywords") and job.job.keywords:
-                keywords = job.job.keywords
-            if hasattr(job.job, "subreddit") and job.job.subreddit:
-                keywords.insert(0, job.job.subreddit)
-
-            url = None
-            if hasattr(job.job, "url") and job.job.url:
-                url = job.job.url
-
-            ctx = ValidationContext(
-                source=job.job.platform,
-                usernames=usernames,
-                keywords=keywords,
-                url=url,
-                keyword_mode=job.keyword_mode,
-                start_date=job.start_date.isoformat() if job.start_date else None,
-                end_date=job.end_date.isoformat() if job.end_date else None,
-                limit=job.limit,
-            )
+            ctx = OnDemandValidator.build_validation_context(job)
 
             # Validate one random entity
             entity = random.choice(miner_upload.data_entities)

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -201,14 +201,49 @@ class MinerEvaluator:
                 miner_upload = OnDemandMinerUpload.model_validate(dl_resp.json())
 
             if not miner_upload.data_entities:
-                bt.logging.info(f"UID:{uid} - OD spot-check: empty submission for job {result.job_id}")
-                self.scorer.apply_ondemand_penalty(uid=uid, mult_factor=1.0)
+                # Before penalizing, check if data actually exists for this query.
+                # If the job asks for something that doesn't exist, empty is correct.
+                ctx = OnDemandValidator.build_validation_context(job)
+                data_exists = await self.on_demand_validator.check_data_exists(ctx)
+                if data_exists:
+                    bt.logging.info(
+                        f"UID:{uid} - OD spot-check: empty submission but data exists for job {result.job_id}"
+                    )
+                    self.scorer.apply_ondemand_penalty(uid=uid, mult_factor=1.0)
+                else:
+                    bt.logging.info(
+                        f"UID:{uid} - OD spot-check: empty submission, data doesn't exist — no penalty for job {result.job_id}"
+                    )
                 return
+
+            # Cap entities to job limit — don't reward more than requested
+            entities = miner_upload.data_entities
+            if job.limit and len(entities) > job.limit:
+                bt.logging.info(
+                    f"UID:{uid} - OD spot-check: {hotkey[:16]} returned {len(entities)} "
+                    f"but limit is {job.limit} — capping"
+                )
+                entities = entities[:job.limit]
+
+            # Recalculate actual volume multiplier from real row count.
+            # The poller trusted volume_mult=1.0; if actual count is lower,
+            # apply a corrective penalty proportional to the shortfall.
+            actual_count = len(entities)
+            if job.limit and actual_count < job.limit:
+                actual_volume = actual_count / job.limit
+                shortfall = 1.0 - actual_volume  # e.g. 0.4 if they returned 60%
+                if shortfall > 0.2:
+                    # Significant shortfall — penalize proportionally
+                    self.scorer.apply_ondemand_penalty(uid=uid, mult_factor=shortfall)
+                    bt.logging.info(
+                        f"UID:{uid} - OD spot-check: volume shortfall {actual_count}/{job.limit} "
+                        f"({shortfall:.0%}), penalty applied"
+                    )
 
             ctx = OnDemandValidator.build_validation_context(job)
 
             # Validate one random entity
-            entity = random.choice(miner_upload.data_entities)
+            entity = random.choice(entities)
             post_id = self.on_demand_validator._get_post_id(entity)
             is_valid = await self.on_demand_validator._validate_entity(ctx, entity, post_id, uid)
 

--- a/vali_utils/on_demand/od_job_cache.py
+++ b/vali_utils/on_demand/od_job_cache.py
@@ -62,7 +62,7 @@ class ODJobCache:
                 for jid in to_remove:
                     self._processed_jobs.discard(jid)
 
-            bt.logging.info(
+            bt.logging.trace(
                 f"ODJobCache: cached {len(results)} miner results for job {job_id}"
             )
 
@@ -81,7 +81,7 @@ class ODJobCache:
         with self._lock:
             results = self._results.pop(hotkey, [])
             if results:
-                bt.logging.info(
+                bt.logging.trace(
                     f"ODJobCache: drained {len(results)} results for {hotkey[:16]}..."
                 )
             return results
@@ -90,11 +90,6 @@ class ODJobCache:
         """Check if a job has already been cached."""
         with self._lock:
             return job_id in self._processed_jobs
-
-    def get_processed_job_ids(self) -> set:
-        """Return a copy of processed job IDs (for skip-download optimization)."""
-        with self._lock:
-            return set(self._processed_jobs)
 
     def get_pending_miner_count(self) -> int:
         """Return the number of miners with pending results (for monitoring)."""

--- a/vali_utils/on_demand/od_job_cache.py
+++ b/vali_utils/on_demand/od_job_cache.py
@@ -1,0 +1,102 @@
+import threading
+import datetime as dt
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+import bittensor as bt
+
+
+@dataclass
+class CachedMinerODResult:
+    """A single OD job result for one miner, stored in the cache."""
+    job_id: str
+    submitted_at: Optional[dt.datetime]
+    returned_count: int
+    requested_limit: Optional[int]
+    passed_validation: Optional[bool]  # True=passed, False=failed, None=not sampled
+    speed_multiplier: float
+    volume_multiplier: float
+    failure_reason: Optional[str] = None
+
+
+class ODJobCache:
+    """Thread-safe cache for on-demand job results.
+
+    The OD poller (validator.py) writes results here for ALL submitters per job.
+    The evaluator (miner_evaluator.py) reads and drains results per-miner when
+    eval_miner() runs.
+
+    This decouples OD scoring from the polling loop: the poller validates and
+    caches, the evaluator applies scores at eval time.
+    """
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        # hotkey -> list of pending results
+        self._results: Dict[str, List[CachedMinerODResult]] = {}
+        # Set of job IDs already processed (replaces processed_job_ids_cache in validator)
+        self._processed_jobs: set = set()
+        # Max processed jobs to keep (LRU-style cap)
+        self._max_processed_jobs = 10_000
+
+    def add_results(self, job_id: str, results: Dict[str, CachedMinerODResult]) -> None:
+        """Add OD results for multiple miners from a single job.
+
+        Args:
+            job_id: The OD job ID.
+            results: Mapping of hotkey -> CachedMinerODResult for all submitters.
+        """
+        with self._lock:
+            for hotkey, result in results.items():
+                if hotkey not in self._results:
+                    self._results[hotkey] = []
+                self._results[hotkey].append(result)
+
+            self._processed_jobs.add(job_id)
+
+            # Cap the processed jobs set
+            if len(self._processed_jobs) > self._max_processed_jobs:
+                # Remove oldest entries (set is unordered, but for LRU-style we just trim)
+                excess = len(self._processed_jobs) - self._max_processed_jobs
+                to_remove = list(self._processed_jobs)[:excess]
+                for jid in to_remove:
+                    self._processed_jobs.discard(jid)
+
+            bt.logging.info(
+                f"ODJobCache: cached {len(results)} miner results for job {job_id}"
+            )
+
+    def get_and_drain(self, hotkey: str) -> List[CachedMinerODResult]:
+        """Return all pending results for a miner and remove them from the cache.
+
+        Drain semantics prevent double-counting: once eval_miner() processes
+        results, they're gone.
+
+        Args:
+            hotkey: The miner's hotkey.
+
+        Returns:
+            List of cached results (empty if none pending).
+        """
+        with self._lock:
+            results = self._results.pop(hotkey, [])
+            if results:
+                bt.logging.info(
+                    f"ODJobCache: drained {len(results)} results for {hotkey[:16]}..."
+                )
+            return results
+
+    def is_job_processed(self, job_id: str) -> bool:
+        """Check if a job has already been cached."""
+        with self._lock:
+            return job_id in self._processed_jobs
+
+    def get_processed_job_ids(self) -> set:
+        """Return a copy of processed job IDs (for skip-download optimization)."""
+        with self._lock:
+            return set(self._processed_jobs)
+
+    def get_pending_miner_count(self) -> int:
+        """Return the number of miners with pending results (for monitoring)."""
+        with self._lock:
+            return sum(1 for results in self._results.values() if results)

--- a/vali_utils/on_demand/on_demand_validation.py
+++ b/vali_utils/on_demand/on_demand_validation.py
@@ -410,6 +410,12 @@ class OnDemandValidator:
         miner_responses: Dict[int, List],
         validation_results: Dict[str, bool],
     ) -> Tuple[Dict[int, int], List[int], List[int]]:
+        """Classify sampled miners as successful or failed based on validation.
+
+        Returns (miner_scores, failed_miners, successful_miners) — does NOT
+        call the scorer directly.  The caller is responsible for writing
+        results into the OD job cache.
+        """
         miner_scores = {}
         failed_miners = []
         successful_miners = []
@@ -418,7 +424,6 @@ class OnDemandValidator:
             if not miner_responses[uid]:
                 miner_scores[uid] = 0
                 failed_miners.append(uid)
-                self.evaluator.scorer.apply_ondemand_penalty(uid=uid, mult_factor=1.0)
                 ORGANIC_MINER_RESULTS.labels(
                     miner_uid=uid, result_type="failure_empty_submission"
                 ).inc()
@@ -439,7 +444,6 @@ class OnDemandValidator:
             if miner_failed_validation:
                 miner_scores[uid] = 0
                 failed_miners.append(uid)
-                self.evaluator.scorer.apply_ondemand_penalty(uid=uid, mult_factor=1.0)
                 ORGANIC_MINER_RESULTS.labels(
                     miner_uid=uid, result_type="failure_content_validation"
                 ).inc()
@@ -480,12 +484,17 @@ class OnDemandValidator:
         miner_data_counts: Dict[int, int],
         requested_limit: Optional[int],
         consensus_count: Optional[float],
-    ) -> List[int]:
+    ) -> Dict[int, float]:
+        """Identify miners with volume underperformance relative to consensus.
+
+        Returns dict of uid -> penalty_mult_factor for penalized miners.
+        Does NOT call the scorer directly — the caller writes to the OD cache.
+        """
         if consensus_count is None:
             bt.logging.info(
                 "Not enough miners with data for consensus - skipping volume penalties"
             )
-            return []
+            return {}
 
         if requested_limit is not None:
             min_consensus_threshold = requested_limit * self.MIN_CONSENSUS
@@ -493,22 +502,19 @@ class OnDemandValidator:
                 bt.logging.info(
                     "Consensus shows limited data available - skipping volume penalties"
                 )
-                return []
+                return {}
 
-        penalized_miners = []
+        penalized_miners = {}
 
         for uid, post_count in miner_data_counts.items():
             if post_count > 0 and post_count < consensus_count:
                 underperformance_ratio = 1.0 - (post_count / consensus_count)
                 if underperformance_ratio > 0.2:
                     mult_factor = min((underperformance_ratio - 0.2) / 0.8, 1.0)
-                    penalized_miners.append(uid)
+                    penalized_miners[uid] = mult_factor
                     bt.logging.info(
                         f"Miner {uid}:{self.metagraph.hotkeys[uid]}: {post_count} posts vs consensus {consensus_count:.1f} "
                         f"({underperformance_ratio:.1%} underperformance, {mult_factor:.2f} penalty)"
-                    )
-                    self.evaluator.scorer.apply_ondemand_penalty(
-                        uid=uid, mult_factor=mult_factor
                     )
                     ORGANIC_MINER_RESULTS.labels(
                         miner_uid=uid,

--- a/vali_utils/on_demand/on_demand_validation.py
+++ b/vali_utils/on_demand/on_demand_validation.py
@@ -46,6 +46,36 @@ class OnDemandValidator:
     PER_MINER_VALIDATION_SAMPLE_SIZE = 2
     MIN_CONSENSUS = 0.3
 
+    @staticmethod
+    def build_validation_context(job) -> "ValidationContext":
+        """Build a ValidationContext from an OD API job object."""
+        usernames = []
+        if hasattr(job.job, "usernames") and job.job.usernames:
+            usernames = job.job.usernames
+        elif hasattr(job.job, "channels") and job.job.channels:
+            usernames = job.job.channels
+
+        keywords = []
+        if hasattr(job.job, "keywords") and job.job.keywords:
+            keywords = job.job.keywords
+        if hasattr(job.job, "subreddit") and job.job.subreddit:
+            keywords.insert(0, job.job.subreddit)
+
+        url = None
+        if hasattr(job.job, "url") and job.job.url:
+            url = job.job.url
+
+        return ValidationContext(
+            source=job.job.platform,
+            usernames=usernames,
+            keywords=keywords,
+            url=url,
+            keyword_mode=job.keyword_mode,
+            start_date=job.start_date.isoformat() if job.start_date else None,
+            end_date=job.end_date.isoformat() if job.end_date else None,
+            limit=job.limit,
+        )
+
     def __init__(self, evaluator):
         self.evaluator = evaluator
 


### PR DESCRIPTION
## Summary

- **Move OD scoring from poller to evaluator** — poller now does metadata-only API call (no S3 downloads, no scraper validation). Results cached in `ODJobCache`, drained per-miner in `eval_miner()`
- **Fix OD credibility decay** — removed `update_ondemand_credibility()` which was decaying all ~185 non-sampled miners per job cycle, destroying OD credibility for everyone
- **Fix P2P contamination** — `apply_ondemand_penalty()` no longer hits P2P credibility. OD failures only affect OD state
- **Drop `^2.5` exponent on OD credibility** — near-zero values raised to 2.5 made OD scores effectively zero
- **Add spot-check validation** — evaluator downloads 1 submission per miner eval, validates 1 entity with scraper. Checks empty submissions against data existence probe, caps volume to job limit
- **STATE_VERSION 7** — full score reset (P2P cap depends on OD, all old scores are wrong)

## What was broken

1. Poller downloaded ALL submissions and validated 5 random miners per job every 20s — expensive
2. `update_ondemand_credibility()` ran EMA toward 0.0 for all miners not in the sampled 5 — ~185 miners penalized per job
3. `^2.5` exponent on OD credibility in `on_miner_evaluated()` — 0.5^2.5 = 0.18, 0.3^2.5 = 0.05 — OD was effectively zero
4. OD penalty hit P2P credibility — cross-channel contamination
5. P2P was 93% of rewards; miners had no incentive for S3/OD

## Architecture

```
Poller (every 20s)          Evaluator (every evaluation)       Weight Setting
─────────────────           ────────────────────────────        ──────────────
metadata-only API  ──►  ODJobCache  ──►  _evaluate_od()  ──►  get_scores_for_weights()
 s3_content_length       {hotkey: [      apply rewards         P2P cap: min(p2p, s3+od)
 submitted_at             results]}     apply penalties         S3 cap: min(s3, 2×od)
 speed multiplier                       spot-check 1 entity
```

## Files changed

| File | Change |
|------|--------|
| `vali_utils/on_demand/od_job_cache.py` | **NEW** — thread-safe cache with drain semantics |
| `neurons/validator.py` | Poller: metadata-only, writes to cache |
| `vali_utils/miner_evaluator.py` | `_evaluate_od()`, `_spot_check_od_submission()` |
| `rewards/miner_scorer.py` | Remove dead code, fix penalty, drop ^2.5, v7 reset |
| `vali_utils/on_demand/on_demand_validation.py` | Decouple from scorer, add `build_validation_context()` |
| `tests/vali_utils/test_od_flow.py` | **NEW** — 17 tests covering cache, scorer, evaluator |

## Test plan

- [x] Unit tests: 17 tests pass (cache, scorer, evaluator integration)
- [x] Live test: `scripts/test_od_flow_live.py` — pulls real jobs, caches, drains, spot-checks