### PR TITLE
Release v1.18.51

### DIFF
--- a/vali_utils/api/server.py
+++ b/vali_utils/api/server.py
@@ -179,7 +179,7 @@ class ValidatorAPI:
         def run_server():
             try:
                 bt.logging.info(f"Starting API server on port {self.port}")
-                uvicorn.run(self.app, host="0.0.0.0", port=self.port, log_level="info")
+                uvicorn.run(self.app, host="0.0.0.0", port=self.port, log_level="warning")
             except Exception as e:
                 bt.logging.error(f"API server error: {str(e)}")
 

--- a/vali_utils/on_demand/od_job_cache.py
+++ b/vali_utils/on_demand/od_job_cache.py
@@ -17,6 +17,7 @@ class CachedMinerODResult:
     speed_multiplier: float
     volume_multiplier: float
     failure_reason: Optional[str] = None
+    s3_presigned_url: Optional[str] = None  # stored at poll time so evaluator can download directly
 
 
 class ODJobCache:
@@ -62,7 +63,7 @@ class ODJobCache:
                 for jid in to_remove:
                     self._processed_jobs.discard(jid)
 
-            bt.logging.trace(
+            bt.logging.debug(
                 f"ODJobCache: cached {len(results)} miner results for job {job_id}"
             )
 
@@ -81,7 +82,7 @@ class ODJobCache:
         with self._lock:
             results = self._results.pop(hotkey, [])
             if results:
-                bt.logging.trace(
+                bt.logging.debug(
                     f"ODJobCache: drained {len(results)} results for {hotkey[:16]}..."
                 )
             return results

--- a/vali_utils/on_demand/od_job_cache.py
+++ b/vali_utils/on_demand/od_job_cache.py
@@ -17,7 +17,6 @@ class CachedMinerODResult:
     speed_multiplier: float
     volume_multiplier: float
     failure_reason: Optional[str] = None
-    s3_presigned_url: Optional[str] = None  # stored at poll time so evaluator can download directly
 
 
 class ODJobCache:

--- a/vali_utils/on_demand/on_demand_validation.py
+++ b/vali_utils/on_demand/on_demand_validation.py
@@ -644,36 +644,16 @@ class OnDemandValidator:
             ).total_seconds()
             decay_rate = 0.05
             speed_multiplier = max(0.1, math.exp(-decay_rate * upload_time_seconds))
-            bt.logging.trace(
-                f"Upload time: {upload_time_seconds:.0f}s "
-                f"-> speed multiplier (exponential): {speed_multiplier:.3f}"
-            )
 
         # Volume multiplier
         if requested_limit is None:
             if consensus_count and consensus_count > 0:
                 volume_multiplier = min(1.0, returned_count / consensus_count)
-                bt.logging.trace(
-                    f"Returned {returned_count} rows vs consensus {consensus_count:.0f} (no limit) "
-                    f"-> volume multiplier: {volume_multiplier:.3f}"
-                )
             else:
                 volume_multiplier = 1.0
-                bt.logging.trace(
-                    f"Returned {returned_count} rows (no limit, no consensus) "
-                    f"-> volume multiplier: {volume_multiplier:.3f}"
-                )
         elif returned_count == 0:
             volume_multiplier = 0.0
-            bt.logging.trace(
-                f"Returned {returned_count}/{requested_limit} rows "
-                f"-> volume multiplier: {volume_multiplier:.3f}"
-            )
         else:
             volume_multiplier = min(1.0, returned_count / requested_limit)
-            bt.logging.trace(
-                f"Returned {returned_count}/{requested_limit} rows "
-                f"-> volume multiplier: {volume_multiplier:.3f}"
-            )
 
         return speed_multiplier, volume_multiplier


### PR DESCRIPTION
The OD speed/volume multiplier TRACE logs account for ~83% of all WandB log output (~205k out of 247k lines per run). These per-miner-per-job logs provide no actionable insight — the per-job summary INFO log already exists.

Changes:
  - Remove 5 TRACE logs for speed/volume multipliers in on_demand_validation.py (107k + 97k lines/run)
  - Downgrade ODJobCache trace logs to DEBUG in od_job_cache.py (redundant with the INFO summary in validator.py)
  - Set uvicorn access log level to warning to suppress /metrics endpoint spam