### PR TITLE
Release v1.18.52

### DIFF
--- a/common/api_client.py
+++ b/common/api_client.py
@@ -197,7 +197,7 @@ class ListMinerJobsForValidationRequest(BaseModel):
     expired_until: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc)
     )
-    limit: int = Field(default=50, ge=1, le=100)
+    limit: int = Field(default=500, ge=1, le=1000)
 
 
 class MinerJobForValidation(BaseModel):

--- a/common/api_client.py
+++ b/common/api_client.py
@@ -188,6 +188,28 @@ class ListJobsWithSubmissionForValidationResponse(BaseModel):
     jobs_with_submissions: List[JobWithSubmissions]
 
 
+class ListMinerJobsForValidationRequest(BaseModel):
+    """Request to list OD jobs that a specific miner submitted to."""
+    miner_hotkey: str
+    expired_since: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc) - timedelta(hours=2)
+    )
+    expired_until: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+    limit: int = Field(default=50, ge=1, le=100)
+
+
+class MinerJobForValidation(BaseModel):
+    """A single job + this miner's submission."""
+    job: OnDemandJob
+    submission: OnDemandJobSubmission
+
+
+class ListMinerJobsForValidationResponse(BaseModel):
+    jobs: List[MinerJobForValidation]
+
+
 def _sha256_hex(data: bytes) -> str:
     return sha256(data).hexdigest()
 
@@ -426,6 +448,20 @@ class DataUniverseApiClient:
         return ListJobsWithSubmissionForValidationResponse.model_validate_json(
             resp.text
         )
+
+    async def validator_list_miner_jobs(
+        self, req: ListMinerJobsForValidationRequest
+    ) -> ListMinerJobsForValidationResponse:
+        """List OD jobs that a specific miner submitted to, with fresh presigned URLs."""
+        if not self._signer:
+            raise RuntimeError("validator_keypair was not provided.")
+
+        payload_json = req.model_dump_json()
+        resp = await self._post_signed_json(
+            "/on-demand/validator/miner-jobs", self._signer, payload_json
+        )
+        _raise_for_status(resp)
+        return ListMinerJobsForValidationResponse.model_validate_json(resp.text)
 
     async def validator_list_and_download_submission_json(
         self,

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -33,10 +33,7 @@ from common.metagraph_syncer import MetagraphSyncer
 from neurons.config import NeuronType, check_config, create_config
 from dynamic_desirability.desirability_retrieval import run_retrieval_from_api
 from neurons import __spec_version__ as spec_version
-from common.api_client import (
-    ListJobsWithSubmissionsForValidationRequest,
-    DataUniverseApiClient,
-)
+from common.api_client import DataUniverseApiClient
 from vali_utils.validator_s3_access import ValidatorS3Access
 from rewards.data_value_calculator import DataValueCalculator
 from rich.table import Table
@@ -44,12 +41,10 @@ from rich.console import Console
 import requests
 from dotenv import load_dotenv
 import bittensor as bt
-from typing import Dict
 from common import constants
 from common import utils
 from vali_utils.miner_evaluator import MinerEvaluator
 from vali_utils.on_demand.on_demand_validation import OnDemandValidator
-from vali_utils.on_demand.od_job_cache import ODJobCache, CachedMinerODResult
 from vali_utils import metrics
 
 load_dotenv()
@@ -132,9 +127,6 @@ class Validator:
 
         # Add counter for evaluation cycles since startup
         self.evaluation_cycles_since_startup = 0
-        self.od_cache = ODJobCache()
-
-        self.on_demand_thread: threading.Thread = None
 
     def setup(self):
         """A one-time setup method that must be called before the Validator starts its main loop."""
@@ -179,8 +171,7 @@ class Validator:
 
         self.on_demand_validator = OnDemandValidator(evaluator=self.evaluator)
 
-        # Wire OD components into the evaluator so eval_miner() can drain and validate
-        self.evaluator.od_cache = self.od_cache
+        # Wire OD validator into the evaluator for inline OD evaluation
         self.evaluator.on_demand_validator = self.on_demand_validator
 
         self.is_setup = True
@@ -277,130 +268,6 @@ class Validator:
         self.wandb_run_start = now
 
         bt.logging.debug(f"Started a new wandb run: {name}")
-
-    async def loop_poll_on_demand_jobs_with_submissions(self):
-        while not self.should_exit:
-            bt.logging.info("Pulling on demand jobs with submissions")
-
-            try:
-                async with self._on_demand_client() as client:
-                    # Metadata-only call — no S3 downloads.
-                    # We only need submission timestamps and content_length
-                    # to compute speed multipliers and detect empty submissions.
-                    job_list_resp = (
-                        await client.validator_list_jobs_with_submissions(
-                            req=ListJobsWithSubmissionsForValidationRequest(
-                                expired_since=dt.datetime.now(dt.timezone.utc)
-                                - dt.timedelta(minutes=45),
-                                expired_until=dt.datetime.now(dt.timezone.utc)
-                                - dt.timedelta(minutes=2),
-                                limit=10,
-                            ),
-                        )
-                    )
-            except:
-                bt.logging.exception("Failed to pull on demand jobs with submissions")
-                await asyncio.sleep(20.0)
-                continue
-
-            try:
-                total_submissions = sum(
-                    len(jws.submissions)
-                    for jws in job_list_resp.jobs_with_submissions
-                )
-                bt.logging.info(
-                    f"Pulled {len(job_list_resp.jobs_with_submissions)} jobs "
-                    f"with {total_submissions} total submissions"
-                )
-
-                for (
-                    job_with_submission
-                ) in job_list_resp.jobs_with_submissions:
-                    job = job_with_submission.job
-
-                    if self.od_cache.is_job_processed(job.id):
-                        continue
-
-                    submissions = job_with_submission.submissions
-
-                    # Cache metadata only — the evaluator will download and
-                    # validate content before rewarding.  The poller only
-                    # records who submitted and how fast.
-                    cache_results: Dict[str, CachedMinerODResult] = {}
-
-                    for sub in submissions:
-                        hotkey = sub.miner_hotkey
-
-                        # Skip miners not in metagraph
-                        try:
-                            self.metagraph.hotkeys.index(hotkey)
-                        except ValueError:
-                            continue
-
-                        # Empty submission (0 bytes) → mark as failed
-                        is_empty = (sub.s3_content_length or 0) == 0
-                        if is_empty:
-                            cache_results[hotkey] = CachedMinerODResult(
-                                job_id=job.id,
-                                submitted_at=sub.submitted_at,
-                                returned_count=0,
-                                requested_limit=job.limit,
-                                passed_validation=False,
-                                speed_multiplier=0.0,
-                                volume_multiplier=0.0,
-                                failure_reason="empty_submission",
-                            )
-                            continue
-
-                        # Calculate speed multiplier from submission time
-                        speed_mult, volume_mult = (
-                            self.on_demand_validator.calculate_ondemand_reward_multipliers(
-                                job_created_at=job.created_at,
-                                submission_timestamp=sub.submitted_at,
-                                returned_count=job.limit or 100,
-                                requested_limit=job.limit,
-                            )
-                        )
-
-                        # passed_validation=None means "pending — evaluator
-                        # must download and validate before rewarding"
-                        cache_results[hotkey] = CachedMinerODResult(
-                            job_id=job.id,
-                            submitted_at=sub.submitted_at,
-                            returned_count=job.limit or 100,
-                            requested_limit=job.limit,
-                            passed_validation=None,
-                            speed_multiplier=speed_mult,
-                            volume_multiplier=volume_mult,
-                        )
-
-                    # Write all results to the shared OD cache
-                    self.od_cache.add_results(job.id, cache_results)
-
-                    pending = sum(1 for r in cache_results.values() if r.passed_validation is None)
-                    empty = sum(1 for r in cache_results.values() if r.passed_validation is False)
-                    bt.logging.info(
-                        f"Job {job.id}: cached {len(cache_results)} submitter results "
-                        f"({pending} pending validation, {empty} empty)"
-                    )
-            except:
-                bt.logging.exception(
-                    "Error while validating on demand jobs and submissions"
-                )
-
-            await asyncio.sleep(20.0)
-
-    def run_on_demand(self):
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-
-        poll_task = loop.create_task(self.loop_poll_on_demand_jobs_with_submissions())
-
-        try:
-            loop.run_forever()
-        finally:
-            loop.close()
-            loop = None
 
     def run(self):
         """
@@ -520,11 +387,6 @@ class Validator:
             self.should_exit = False
             self.thread = threading.Thread(target=self.run, daemon=True)
             self.thread.start()
-
-            self.on_demand_thread = threading.Thread(
-                target=self.run_on_demand, daemon=True
-            )
-            self.on_demand_thread.start()
             self.is_running = True
             bt.logging.debug("Started.")
 
@@ -536,7 +398,6 @@ class Validator:
             bt.logging.debug("Stopping validator in background thread.")
             self.should_exit = True
             self.thread.join(5)
-            self.on_demand_thread.join(5)
             self.is_running = False
             bt.logging.debug("Stopped.")
 
@@ -561,7 +422,6 @@ class Validator:
             bt.logging.debug("Stopping validator in background thread.")
             self.should_exit = True
             self.thread.join(5)
-            self.on_demand_thread.join(5)
             self.is_running = False
 
             # Cleanup loggers

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -106,8 +106,6 @@ class Validator:
         )
         bt.logging.info(f"Metagraph: {self.metagraph}.")
 
-        self.on_demand_validator = None
-
         # Event loop is thread-affine; will be created inside the validator run thread.
         self.loop = None
         self.axon = None
@@ -169,10 +167,8 @@ class Validator:
         else:
             bt.logging.warning("Axon off, not serving ip to chain.")
 
-        self.on_demand_validator = OnDemandValidator(evaluator=self.evaluator)
-
         # Wire OD validator into the evaluator for inline OD evaluation
-        self.evaluator.on_demand_validator = self.on_demand_validator
+        self.evaluator.on_demand_validator = OnDemandValidator(evaluator=self.evaluator)
 
         self.is_setup = True
 

--- a/rewards/miner_scorer.py
+++ b/rewards/miner_scorer.py
@@ -486,23 +486,27 @@ class MinerScorer:
                 f"OD cred: {old_od_cred:.4f} -> {new_od_cred:.4f}"
             )
 
-    def apply_ondemand_credibility_bump(self, uid: int) -> None:
-        """Small credibility bump for miners who submitted to an OD job but weren't sampled.
+    def apply_ondemand_credibility_bump(self, uid: int, count: int = 1) -> None:
+        """Small credibility bump for miners who submitted to OD jobs but weren't sampled.
 
         They participated (good signal) but we didn't verify their data,
         so we give a smaller credibility increase than a validated success.
+
+        Args:
+            uid: Miner UID.
+            count: Number of unsampled submissions to apply (batched, single lock).
         """
         with self.lock:
             old_od_cred = float(self.ondemand_credibility[uid])
-            # Half the normal alpha — participated but unverified
             alpha = MinerScorer.ONDEMAND_CRED_ALPHA * 0.5
-            self.ondemand_credibility[uid] = min(
-                1.0, alpha * 1.0 + (1 - alpha) * self.ondemand_credibility[uid]
-            )
+            for _ in range(count):
+                self.ondemand_credibility[uid] = min(
+                    1.0, alpha * 1.0 + (1 - alpha) * self.ondemand_credibility[uid]
+                )
             new_od_cred = float(self.ondemand_credibility[uid])
 
             bt.logging.trace(
-                f"OnDemand credibility bump (unsampled) for Miner {uid}: "
+                f"OnDemand credibility bump (unsampled ×{count}) for Miner {uid}: "
                 f"OD cred: {old_od_cred:.4f} -> {new_od_cred:.4f}"
             )
 

--- a/rewards/miner_scorer.py
+++ b/rewards/miner_scorer.py
@@ -24,7 +24,8 @@ class MinerScorer:
     # v6: Reset S3 — .head() → .sample() fix (scraper sampling bypass)
     # v7: Reset OD — moved scoring to evaluator, dropped ^2.5 exponent, fixed credibility decay
     # v8: Reset S3 — strict schema check catches fabricated data; old inflated scores are invalid
-    STATE_VERSION = 8
+    # v9: Reset OD — per-miner endpoint replaces poller; old boost/credibility based on broken lottery
+    STATE_VERSION = 9
 
     # Start new miner's at a credibility of 0.
     STARTING_CREDIBILITY = 0
@@ -175,6 +176,17 @@ class MinerScorer:
                 self.s3_boosts.zero_()
                 self.s3_credibility.fill_(MinerScorer.STARTING_S3_CREDIBILITY)
                 self.effective_sizes.zero_()
+                self.ondemand_boosts.zero_()
+                self.ondemand_credibility.fill_(MinerScorer.STARTING_ONDEMAND_CREDIBILITY)
+
+            if saved_version < 9:
+                # -> v9: Reset OD only. Per-miner endpoint replaces poller; old
+                # boost/credibility reflect the broken lottery scoring, not
+                # real miner OD behavior. S3/P2P state is still valid.
+                bt.logging.warning(
+                    f"State migration v{saved_version} -> v9: "
+                    f"OD boost/credibility reset (new per-miner scoring)."
+                )
                 self.ondemand_boosts.zero_()
                 self.ondemand_credibility.fill_(MinerScorer.STARTING_ONDEMAND_CREDIBILITY)
 

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -32,7 +32,7 @@ from storage.validator.s3_validator_storage import S3ValidationStorage
 from vali_utils.miner_iterator import MinerIterator
 from vali_utils import metrics, utils as vali_utils
 
-from typing import List, Optional
+from typing import Dict, List, Optional, Tuple
 from vali_utils.validator_s3_access import ValidatorS3Access
 from vali_utils.s3_utils import validate_s3_miner_data, get_s3_validation_summary, S3ValidationResult
 from vali_utils.s3_logging_utils import log_s3_validation_table
@@ -42,6 +42,8 @@ import httpx
 from common.api_client import (
     DataUniverseApiClient,
     ListMinerJobsForValidationRequest,
+    OnDemandJob,
+    OnDemandJobSubmission,
     OnDemandMinerUpload,
 )
 from rewards.miner_scorer import MinerScorer
@@ -86,13 +88,24 @@ class MinerEvaluator:
         self.on_demand_validator: Optional[OnDemandValidator] = None
         # Track last OD eval time per miner to query only new jobs each cycle.
         # Not persisted — on restart defaults to a 2h lookback window.
-        self._last_od_eval_at: dict = {}
+        self._last_od_eval_at: Dict[str, dt.datetime] = {}
+        # Cache API client construction params (derived once, reused every eval).
+        self._api_base_url = self.config.s3_auth_url
+        self._api_verify_ssl = "localhost" not in self._api_base_url
 
         # Instantiate runners
         self.should_exit: bool = False
         self.is_running: bool = False
         self.lock = threading.RLock()
         self.is_setup = False
+
+    def _on_demand_client(self) -> DataUniverseApiClient:
+        return DataUniverseApiClient(
+            base_url=self._api_base_url,
+            verify_ssl=self._api_verify_ssl,
+            keypair=self.wallet.hotkey,
+            timeout=60,
+        )
 
     def get_scorer(self) -> MinerScorer:
         """Returns the scorer used by the evaluator."""
@@ -125,20 +138,13 @@ class MinerEvaluator:
         )
 
         try:
-            base_url = self.config.s3_auth_url
-            verify_ssl = "localhost" not in base_url
-            async with DataUniverseApiClient(
-                base_url=base_url,
-                verify_ssl=verify_ssl,
-                keypair=self.wallet.hotkey,
-                timeout=60,
-            ) as client:
+            async with self._on_demand_client() as client:
                 resp = await client.validator_list_miner_jobs(
                     ListMinerJobsForValidationRequest(
                         miner_hotkey=hotkey,
                         expired_since=expired_since,
                         expired_until=now,
-                        limit=50,
+                        limit=500,
                     )
                 )
         except Exception as e:
@@ -151,11 +157,14 @@ class MinerEvaluator:
         if not jobs:
             return
 
-        # Separate empty (0-byte) submissions from real ones
-        empty = [j for j in jobs if (j.submission.s3_content_length or 0) == 0]
-        non_empty = [j for j in jobs if (j.submission.s3_content_length or 0) > 0]
+        # Single-pass partition into empty vs non-empty submissions
+        empty, non_empty = [], []
+        for j in jobs:
+            if (j.submission.s3_content_length or 0) > 0:
+                non_empty.append(j)
+            else:
+                empty.append(j)
 
-        # Penalize empty submissions
         for j in empty:
             self.scorer.apply_ondemand_penalty(uid=uid, mult_factor=1.0)
 
@@ -171,26 +180,30 @@ class MinerEvaluator:
         to_validate = random.sample(
             non_empty, min(self.OD_MAX_JOBS_TO_VALIDATE, len(non_empty))
         )
-        to_validate_set = set(id(j) for j in to_validate)
-        not_sampled = [j for j in non_empty if id(j) not in to_validate_set]
+        not_sampled_count = len(non_empty) - len(to_validate)
 
-        # Validate each sampled job — per-job scoring
+        # Validate sampled jobs concurrently
+        validation_results: List[Tuple[bool, int]] = await asyncio.gather(*[
+            self._validate_od_submission(
+                uid, hotkey, j.job, j.submission, j.submission.job_id
+            )
+            for j in to_validate
+        ])
+
+        # Apply per-job rewards/penalties based on validation results
         validated_pass = 0
         validated_fail = 0
 
-        for j in to_validate:
+        for j, (passed, entity_count) in zip(to_validate, validation_results):
             speed_mult, vol_mult = (
                 self.on_demand_validator.calculate_ondemand_reward_multipliers(
                     job_created_at=j.job.created_at,
                     submission_timestamp=j.submission.submitted_at,
-                    returned_count=j.job.limit or 100,
+                    returned_count=entity_count,
                     requested_limit=j.job.limit,
                 )
             )
 
-            passed = await self._validate_od_submission(
-                uid, hotkey, j.job, j.submission, j.submission.job_id
-            )
             if passed:
                 self.scorer.apply_ondemand_reward(uid, speed_mult, vol_mult)
                 validated_pass += 1
@@ -198,31 +211,30 @@ class MinerEvaluator:
                 self.scorer.apply_ondemand_penalty(uid, mult_factor=1.0)
                 validated_fail += 1
 
-        # Credibility bump for non-sampled but participating submissions
-        for _ in not_sampled:
-            self.scorer.apply_ondemand_credibility_bump(uid)
+        # Batch credibility bump for non-sampled but participating submissions
+        if not_sampled_count > 0:
+            self.scorer.apply_ondemand_credibility_bump(uid, count=not_sampled_count)
 
         bt.logging.info(
             f"UID:{uid} - HOTKEY:{hotkey}: OD summary — "
             f"{len(non_empty)} non-empty (validated: {validated_pass} pass, {validated_fail} fail, "
-            f"{len(not_sampled)} credibility-bumped), {len(empty)} empty penalized"
+            f"{not_sampled_count} credibility-bumped), {len(empty)} empty penalized"
         )
 
     async def _validate_od_submission(
-        self, uid: int, hotkey: str, job, submission, job_id: str
-    ) -> bool:
+        self,
+        uid: int,
+        hotkey: str,
+        job: OnDemandJob,
+        submission: OnDemandJobSubmission,
+        job_id: str,
+    ) -> Tuple[bool, int]:
         """Download and validate a single OD submission.
 
-        Returns True if the submission passes all checks, False otherwise.
-
-        Validation phases:
-        1. Download the submission from S3
-        2. Schema check — XContent.from_data_entity() on a sample of entities
-        3. Job match — check username/keyword/date from job params
-        4. Scraper validation — verify 1 entity is real via external API
+        Returns (passed, entity_count) — entity_count is the number of
+        entities the miner actually returned (used for volume_multiplier).
         """
         try:
-            # Phase 0: Download
             async with httpx.AsyncClient(timeout=30.0) as http:
                 dl_resp = await http.get(submission.s3_presigned_url, follow_redirects=True)
                 if dl_resp.status_code != 200:
@@ -230,14 +242,12 @@ class MinerEvaluator:
                         f"UID:{uid} - OD validate: download failed ({dl_resp.status_code}) "
                         f"for job {job_id}"
                     )
-                    return False
+                    return False, 0
 
                 miner_upload = OnDemandMinerUpload.model_validate(dl_resp.json())
 
             entities = miner_upload.data_entities
 
-            # Empty submission — check if data actually exists for this query.
-            # If the job asks for something that doesn't exist, empty is correct.
             if not entities:
                 ctx = OnDemandValidator.build_validation_context(job)
                 data_exists = await self.on_demand_validator.check_data_exists(ctx)
@@ -246,16 +256,18 @@ class MinerEvaluator:
                         f"UID:{uid} - OD validate: empty submission but data exists "
                         f"for job {job_id}"
                     )
-                    return False
+                    return False, 0
                 else:
                     bt.logging.info(
                         f"UID:{uid} - OD validate: empty submission, data doesn't exist "
                         f"for job {job_id} — acceptable"
                     )
-                    return True
+                    return True, 0
+
+            entity_count = len(entities)
 
             # Cap to job limit
-            if job.limit and len(entities) > job.limit:
+            if job.limit and entity_count > job.limit:
                 entities = entities[:job.limit]
 
             # Phase 1: Schema validation on a sample
@@ -270,7 +282,7 @@ class MinerEvaluator:
                     f"UID:{uid} - OD validate: SCHEMA FAILED for job {job_id} "
                     f"(wrong XContent format)"
                 )
-                return False
+                return False, entity_count
 
             # Phase 2: Job match — check request fields on a sample
             for entity in schema_sample:
@@ -280,7 +292,7 @@ class MinerEvaluator:
                         f"UID:{uid} - OD validate: JOB MATCH FAILED for job {job_id}, "
                         f"post {post_id} (wrong username/keyword/date)"
                     )
-                    return False
+                    return False, entity_count
 
             # Phase 3: Scraper validation on 1 entity from the schema-validated sample
             entity = random.choice(schema_sample)
@@ -293,19 +305,19 @@ class MinerEvaluator:
                     f"UID:{uid} - OD validate: SCRAPER FAILED for job {job_id}, "
                     f"post {post_id}"
                 )
-                return False
+                return False, entity_count
 
             bt.logging.info(
                 f"UID:{uid} - OD validate: PASSED job {job_id} "
-                f"({len(entities)} entities, schema OK, job match OK, scraper OK)"
+                f"({entity_count} entities, schema OK, job match OK, scraper OK)"
             )
-            return True
+            return True, entity_count
 
         except Exception as e:
             bt.logging.warning(
                 f"UID:{uid} - OD validate: error for job {job_id}: {e}"
             )
-            return False
+            return False, 0
 
     async def eval_miner(self, uid: int) -> None:
         """Evaluates a miner and updates their score.
@@ -749,6 +761,7 @@ class MinerEvaluator:
                         f"Hotkey {hotkey} w/ UID {uid} has been unregistered or does not qualify to mine/validate."
                     )
                     self.scorer.reset(uid)  # hotkey has been replaced
+                    self._last_od_eval_at.pop(hotkey, None)
                     try:
                         self.storage.delete_miner(hotkey)
                     except Exception:

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -41,11 +41,9 @@ import httpx
 
 from common.api_client import (
     DataUniverseApiClient,
-    ListJobsWithSubmissionsForValidationRequest,
     OnDemandMinerUpload,
 )
 from rewards.miner_scorer import MinerScorer
-from vali_utils.on_demand.od_job_cache import ODJobCache
 from vali_utils.on_demand.on_demand_validation import OnDemandValidator
 
 
@@ -82,12 +80,9 @@ class MinerEvaluator:
         self.storage = SqliteMemoryValidatorStorage()
         self.s3_storage = S3ValidationStorage(self.config.s3_results_path)
         self.s3_reader = s3_reader
-        # OD job cache — set by validator.py after construction.
-        # eval_miner() drains cached OD results per-miner.
-        self.od_cache: Optional[ODJobCache] = None
         # OD validator — set by validator.py after construction.
-        # Used for spot-check validation at eval time.
-        self.on_demand_validator = None
+        # Used for inline OD evaluation during eval_miner().
+        self.on_demand_validator: Optional[OnDemandValidator] = None
 
         # Instantiate runners
         self.should_exit: bool = False
@@ -105,147 +100,23 @@ class MinerEvaluator:
 
     # Maximum OD jobs to validate per miner per eval cycle.
     # Each validation downloads ~1MB + 1 scraper API call, so keep this bounded.
-    OD_MAX_JOBS_TO_VALIDATE = 5
+    OD_MAX_JOBS_TO_VALIDATE = 3
     # Number of entities to schema-check per downloaded submission.
     OD_SCHEMA_SAMPLE_SIZE = 5
 
     async def _evaluate_od(self, uid: int, hotkey: str) -> None:
-        """Drain cached OD results and validate before rewarding.
+        """Evaluate a miner's on-demand submissions by querying the API directly.
 
-        The poller caches metadata only (passed_validation=None for non-empty
-        submissions).  This method downloads a sample of submissions, runs
-        schema + job-match + scraper validation, then rewards or penalizes.
+        Calls the per-miner jobs endpoint to get this miner's recent OD
+        submissions with fresh presigned URLs, then validates a random
+        sample and applies per-job rewards/penalties.
 
-        Results that were already marked False by the poller (empty 0-byte
-        submissions) are penalized immediately without downloading.
+        TODO: implement after new API endpoint is ready.
         """
-        if self.od_cache is None:
-            return
-
-        results = self.od_cache.get_and_drain(hotkey)
-        if not results:
-            return
-
-        # Separate already-failed (empty) from pending (need validation)
-        failed_results = [r for r in results if r.passed_validation is False]
-        pending_results = [r for r in results if r.passed_validation is None]
-
-        # Penalize empty submissions immediately
-        for r in failed_results:
-            self.scorer.apply_ondemand_penalty(uid=uid, mult_factor=1.0)
-
-        if not pending_results:
-            bt.logging.info(
-                f"UID:{uid} - HOTKEY:{hotkey}: {len(failed_results)} empty OD submissions penalized, "
-                f"0 pending"
-            )
-            return
-
-        # Pick a sample of pending jobs to validate (download is expensive)
-        jobs_to_validate = random.sample(
-            pending_results,
-            min(self.OD_MAX_JOBS_TO_VALIDATE, len(pending_results)),
-        )
-
         if self.on_demand_validator is None:
-            bt.logging.debug(f"UID:{uid} - OD validation: no validator configured, skipping")
             return
 
-        # Fetch recent jobs from API to get presigned URLs.
-        # Use a wide window (3h) to cover the full eval rotation.
-        jobs_map = {}  # job_id → (job, {hotkey: submission})
-        try:
-            base_url = self.config.s3_auth_url
-            verify_ssl = "localhost" not in base_url
-            async with DataUniverseApiClient(
-                base_url=base_url,
-                verify_ssl=verify_ssl,
-                keypair=self.wallet.hotkey,
-                timeout=60,
-            ) as client:
-                resp = await client.validator_list_jobs_with_submissions(
-                    req=ListJobsWithSubmissionsForValidationRequest(
-                        expired_since=dt.datetime.now(dt.timezone.utc) - dt.timedelta(hours=3),
-                        expired_until=dt.datetime.now(dt.timezone.utc),
-                        limit=10,
-                    ),
-                )
-            for jws in resp.jobs_with_submissions:
-                subs_by_hk = {s.miner_hotkey: s for s in jws.submissions if s.s3_presigned_url}
-                jobs_map[jws.job.id] = (jws.job, subs_by_hk)
-        except Exception as e:
-            bt.logging.warning(f"UID:{uid} - OD validation: API fetch failed: {e}")
-            # Can't validate — don't reward blindly, don't penalize unfairly.
-            # Results are drained and lost; miner misses these rewards but
-            # isn't penalized.  Next cycle will validate fresh jobs.
-            return
-
-        validated_pass = 0
-        validated_fail = 0
-        skipped = 0
-
-        for r in jobs_to_validate:
-            job_data = jobs_map.get(r.job_id)
-            if not job_data:
-                skipped += 1
-                continue
-
-            job, subs_by_hk = job_data
-            submission = subs_by_hk.get(hotkey)
-            if not submission or not submission.s3_presigned_url:
-                skipped += 1
-                continue
-
-            passed = await self._validate_od_submission(uid, hotkey, job, submission, r)
-            if passed:
-                validated_pass += 1
-            else:
-                validated_fail += 1
-
-        # Apply rewards/penalties for ALL pending results based on validation outcome.
-        # If we validated a sample and ALL passed → reward everything.
-        # If ANY failed → penalize everything (miner is submitting garbage).
-        # If we couldn't validate any (all skipped) → give benefit of doubt,
-        # reward with reduced credibility bump.
-        actually_validated = validated_pass + validated_fail
-
-        if actually_validated > 0 and validated_fail > 0:
-            # At least one validation failed — penalize all pending
-            for r in pending_results:
-                self.scorer.apply_ondemand_penalty(uid=uid, mult_factor=1.0)
-            bt.logging.warning(
-                f"UID:{uid} - HOTKEY:{hotkey}: OD validation FAILED "
-                f"({validated_fail}/{actually_validated} checked failed) — "
-                f"penalizing all {len(pending_results)} pending results"
-            )
-        elif actually_validated > 0 and validated_fail == 0:
-            # All validated submissions passed — reward everything
-            for r in pending_results:
-                self.scorer.apply_ondemand_reward(
-                    uid=uid,
-                    speed_multiplier=r.speed_multiplier,
-                    volume_multiplier=r.volume_multiplier,
-                )
-            bt.logging.info(
-                f"UID:{uid} - HOTKEY:{hotkey}: OD validation PASSED "
-                f"({validated_pass}/{actually_validated} checked) — "
-                f"rewarding all {len(pending_results)} pending results"
-            )
-        else:
-            # Couldn't validate any (jobs expired, presigned URLs gone, etc.)
-            # Don't reward blindly — results are lost.  The miner misses
-            # these rewards but will get validated on fresh jobs next cycle.
-            bt.logging.info(
-                f"UID:{uid} - HOTKEY:{hotkey}: OD validation skipped "
-                f"(0/{len(jobs_to_validate)} jobs available) — "
-                f"dropping {len(pending_results)} unvalidated results"
-            )
-
-        bt.logging.info(
-            f"UID:{uid} - HOTKEY:{hotkey}: OD summary — "
-            f"{len(pending_results)} pending (pass={validated_pass}, fail={validated_fail}, skip={skipped}), "
-            f"{len(failed_results)} empty penalized"
-        )
+        bt.logging.debug(f"UID:{uid} - HOTKEY:{hotkey}: OD evaluation placeholder (pending new API endpoint)")
 
     async def _validate_od_submission(
         self, uid: int, hotkey: str, job, submission, cached_result

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -41,6 +41,7 @@ import httpx
 
 from common.api_client import (
     DataUniverseApiClient,
+    ListMinerJobsForValidationRequest,
     OnDemandMinerUpload,
 )
 from rewards.miner_scorer import MinerScorer
@@ -83,6 +84,9 @@ class MinerEvaluator:
         # OD validator — set by validator.py after construction.
         # Used for inline OD evaluation during eval_miner().
         self.on_demand_validator: Optional[OnDemandValidator] = None
+        # Track last OD eval time per miner to query only new jobs each cycle.
+        # Not persisted — on restart defaults to a 2h lookback window.
+        self._last_od_eval_at: dict = {}
 
         # Instantiate runners
         self.should_exit: bool = False
@@ -110,16 +114,102 @@ class MinerEvaluator:
         Calls the per-miner jobs endpoint to get this miner's recent OD
         submissions with fresh presigned URLs, then validates a random
         sample and applies per-job rewards/penalties.
-
-        TODO: implement after new API endpoint is ready.
         """
         if self.on_demand_validator is None:
             return
 
-        bt.logging.debug(f"UID:{uid} - HOTKEY:{hotkey}: OD evaluation placeholder (pending new API endpoint)")
+        # Determine time window: since last eval, or 2h on first run
+        now = dt.datetime.now(dt.timezone.utc)
+        expired_since = self._last_od_eval_at.get(
+            hotkey, now - dt.timedelta(hours=2)
+        )
+
+        try:
+            base_url = self.config.s3_auth_url
+            verify_ssl = "localhost" not in base_url
+            async with DataUniverseApiClient(
+                base_url=base_url,
+                verify_ssl=verify_ssl,
+                keypair=self.wallet.hotkey,
+                timeout=60,
+            ) as client:
+                resp = await client.validator_list_miner_jobs(
+                    ListMinerJobsForValidationRequest(
+                        miner_hotkey=hotkey,
+                        expired_since=expired_since,
+                        expired_until=now,
+                        limit=50,
+                    )
+                )
+        except Exception as e:
+            bt.logging.warning(f"UID:{uid} - HOTKEY:{hotkey}: OD API fetch failed: {e}")
+            return
+
+        self._last_od_eval_at[hotkey] = now
+
+        jobs = resp.jobs
+        if not jobs:
+            return
+
+        # Separate empty (0-byte) submissions from real ones
+        empty = [j for j in jobs if (j.submission.s3_content_length or 0) == 0]
+        non_empty = [j for j in jobs if (j.submission.s3_content_length or 0) > 0]
+
+        # Penalize empty submissions
+        for j in empty:
+            self.scorer.apply_ondemand_penalty(uid=uid, mult_factor=1.0)
+
+        if not non_empty:
+            if empty:
+                bt.logging.info(
+                    f"UID:{uid} - HOTKEY:{hotkey}: OD — {len(empty)} empty submissions penalized, "
+                    f"0 non-empty"
+                )
+            return
+
+        # Sample up to OD_MAX_JOBS_TO_VALIDATE for deep validation
+        to_validate = random.sample(
+            non_empty, min(self.OD_MAX_JOBS_TO_VALIDATE, len(non_empty))
+        )
+        to_validate_set = set(id(j) for j in to_validate)
+        not_sampled = [j for j in non_empty if id(j) not in to_validate_set]
+
+        # Validate each sampled job — per-job scoring
+        validated_pass = 0
+        validated_fail = 0
+
+        for j in to_validate:
+            speed_mult, vol_mult = (
+                self.on_demand_validator.calculate_ondemand_reward_multipliers(
+                    job_created_at=j.job.created_at,
+                    submission_timestamp=j.submission.submitted_at,
+                    returned_count=j.job.limit or 100,
+                    requested_limit=j.job.limit,
+                )
+            )
+
+            passed = await self._validate_od_submission(
+                uid, hotkey, j.job, j.submission, j.submission.job_id
+            )
+            if passed:
+                self.scorer.apply_ondemand_reward(uid, speed_mult, vol_mult)
+                validated_pass += 1
+            else:
+                self.scorer.apply_ondemand_penalty(uid, mult_factor=1.0)
+                validated_fail += 1
+
+        # Credibility bump for non-sampled but participating submissions
+        for _ in not_sampled:
+            self.scorer.apply_ondemand_credibility_bump(uid)
+
+        bt.logging.info(
+            f"UID:{uid} - HOTKEY:{hotkey}: OD summary — "
+            f"{len(non_empty)} non-empty (validated: {validated_pass} pass, {validated_fail} fail, "
+            f"{len(not_sampled)} credibility-bumped), {len(empty)} empty penalized"
+        )
 
     async def _validate_od_submission(
-        self, uid: int, hotkey: str, job, submission, cached_result
+        self, uid: int, hotkey: str, job, submission, job_id: str
     ) -> bool:
         """Download and validate a single OD submission.
 
@@ -138,7 +228,7 @@ class MinerEvaluator:
                 if dl_resp.status_code != 200:
                     bt.logging.warning(
                         f"UID:{uid} - OD validate: download failed ({dl_resp.status_code}) "
-                        f"for job {cached_result.job_id}"
+                        f"for job {job_id}"
                     )
                     return False
 
@@ -154,13 +244,13 @@ class MinerEvaluator:
                 if data_exists:
                     bt.logging.info(
                         f"UID:{uid} - OD validate: empty submission but data exists "
-                        f"for job {cached_result.job_id}"
+                        f"for job {job_id}"
                     )
                     return False
                 else:
                     bt.logging.info(
                         f"UID:{uid} - OD validate: empty submission, data doesn't exist "
-                        f"for job {cached_result.job_id} — acceptable"
+                        f"for job {job_id} — acceptable"
                     )
                     return True
 
@@ -177,7 +267,7 @@ class MinerEvaluator:
                 ctx, schema_sample, uid
             ):
                 bt.logging.warning(
-                    f"UID:{uid} - OD validate: SCHEMA FAILED for job {cached_result.job_id} "
+                    f"UID:{uid} - OD validate: SCHEMA FAILED for job {job_id} "
                     f"(wrong XContent format)"
                 )
                 return False
@@ -187,7 +277,7 @@ class MinerEvaluator:
                 post_id = self.on_demand_validator._get_post_id(entity)
                 if not self.on_demand_validator._validate_request_fields(ctx, entity, uid):
                     bt.logging.warning(
-                        f"UID:{uid} - OD validate: JOB MATCH FAILED for job {cached_result.job_id}, "
+                        f"UID:{uid} - OD validate: JOB MATCH FAILED for job {job_id}, "
                         f"post {post_id} (wrong username/keyword/date)"
                     )
                     return False
@@ -200,20 +290,20 @@ class MinerEvaluator:
             )
             if not is_valid:
                 bt.logging.warning(
-                    f"UID:{uid} - OD validate: SCRAPER FAILED for job {cached_result.job_id}, "
+                    f"UID:{uid} - OD validate: SCRAPER FAILED for job {job_id}, "
                     f"post {post_id}"
                 )
                 return False
 
             bt.logging.info(
-                f"UID:{uid} - OD validate: PASSED job {cached_result.job_id} "
+                f"UID:{uid} - OD validate: PASSED job {job_id} "
                 f"({len(entities)} entities, schema OK, job match OK, scraper OK)"
             )
             return True
 
         except Exception as e:
             bt.logging.warning(
-                f"UID:{uid} - OD validate: error for job {cached_result.job_id}: {e}"
+                f"UID:{uid} - OD validate: error for job {job_id}: {e}"
             )
             return False
 


### PR DESCRIPTION
**Problem**

  The existing OD scoring was dropping ~95% of miner work. Validators ran a background poller hitting /on-demand/validator/jobs every 20s with limit=10, caching results in an ODJobCache. At eval time, the evaluator would drain this cache,
  randomly sample 5 jobs, re-fetch from the API (different limit=10), and only score jobs that happened to be in both result sets. Mismatches were silently dropped. Combined with all-or-nothing scoring (1 failure → penalize all pending), most
  miners got 0 rewards even when doing honest work. Only "lucky" miners — those whose random sample happened to land in the re-fetch window — got credit.

  **Solution**

  Replace the poller + cache with a direct per-miner query during eval_miner(). Each validator, when evaluating a miner, asks the API "give me this miner's recent submissions" and scores them directly. The new endpoint returns up to 500 jobs
  with fresh presigned URLs, scoped to one hotkey.

  **Key changes**

  Validator side (vali_utils/miner_evaluator.py)
  - Delete the poller loop + background thread
  - Delete ODJobCache and cache-drain logic
  - New _evaluate_od(uid, hotkey) — called from eval_miner:
    a. Query /on-demand/validator/miner-jobs for this miner's jobs since last eval
    b. Split empty (0-byte) vs non-empty submissions
    c. Penalize each empty
    d. Sample up to 3 non-empty for deep validation (download → schema → job-match → scraper), run concurrently via asyncio.gather
    e. Per-job reward/penalty based on individual result
    f. Batched credibility bump for the remainder (one lock acquisition for all ~497)
  - _validate_od_submission returns (passed, entity_count) so volume_multiplier uses actual returned count
  - Track _last_od_eval_at[hotkey] to query only new submissions each cycle; clean up on miner deregister
  - Cache API client config in __init__, add _on_demand_client() factory

  Validator config (neurons/validator.py)
  - Remove poller thread, ODJobCache construction, on_demand_thread lifecycle
  - Remove dead self.on_demand_validator field on Validator; construct it directly into the evaluator

  Shared API client (common/api_client.py)
  - New ListMinerJobsForValidationRequest / MinerJobForValidation / ListMinerJobsForValidationResponse models
  - New DataUniverseApiClient.validator_list_miner_jobs() method — signed POST to /on-demand/validator/miner-jobs
  - limit range: 1-1000, default 500 (covers p90 miners fully at 60-min eval cadence)

  Scorer (rewards/miner_scorer.py)
  - apply_ondemand_credibility_bump(uid, count=1) — batched single lock acquisition, replaces per-submission loop
  - State v9 migration: reset ondemand_boosts and ondemand_credibility (old values reflect broken lottery, not real miner behavior — S3/P2P state preserved)
  
  API endpoint -> https://data-universe-api.api.macrocosmos.ai/docs#/default/get_miner_jobs_for_validation_on_demand_validator_miner_jobs_post