### PR TITLE
chore: enforce scraped_at as string in S3 + remove dead deadline gate

### DIFF
--- a/common/constants.py
+++ b/common/constants.py
@@ -45,6 +45,13 @@ X_ENHANCED_FORMAT_COMPATIBILITY_EXPIRATION_DATE = dt.datetime(2025, 9, 30, tzinf
 # Date after which scraped_at field is required on X and Reddit content
 SCRAPED_AT_REQUIRED_DATE = dt.datetime(2026, 3, 10, tzinfo=dt.timezone.utc)
 
+# Date after which uploaded parquet files must store scraped_at / scrapedAt
+# as a string (ISO format), not a parquet timestamp dtype. Files uploaded
+# before this date are grandfathered — miners cannot rewrite already-uploaded
+# parquet. Sampled files violating this post-deadline are dropped from
+# validation totals (size and row count).
+SCRAPED_AT_STRING_REQUIRED_DATE = dt.datetime(2026, 5, 6, tzinfo=dt.timezone.utc)
+
 EVALUATION_ON_STARTUP = 10
 
 # Emission Control / Burn Configuration

--- a/common/constants.py
+++ b/common/constants.py
@@ -42,15 +42,12 @@ REDDIT_MEDIA_REQUIRED_DATE = dt.datetime(2025, 8, 7, tzinfo=dt.timezone.utc)  # 
 # Date after which backwards compatibility for nested X content format will be removed
 X_ENHANCED_FORMAT_COMPATIBILITY_EXPIRATION_DATE = dt.datetime(2025, 9, 30, tzinfo=dt.timezone.utc) # September 30, 2025 UTC
 
-# Date after which scraped_at field is required on X and Reddit content
-SCRAPED_AT_REQUIRED_DATE = dt.datetime(2026, 3, 10, tzinfo=dt.timezone.utc)
-
 # Date after which uploaded parquet files must store scraped_at / scrapedAt
 # as a string (ISO format), not a parquet timestamp dtype. Files uploaded
 # before this date are grandfathered — miners cannot rewrite already-uploaded
 # parquet. Sampled files violating this post-deadline are dropped from
 # validation totals (size and row count).
-SCRAPED_AT_STRING_REQUIRED_DATE = dt.datetime(2026, 5, 6, tzinfo=dt.timezone.utc)
+SCRAPED_AT_STRING_REQUIRED_DATE = dt.datetime(2026, 5, 13, tzinfo=dt.timezone.utc)
 
 EVALUATION_ON_STARTUP = 10
 

--- a/scraping/reddit/utils.py
+++ b/scraping/reddit/utils.py
@@ -9,7 +9,7 @@ from scraping import utils
 from scraping.scraper import ValidationResult
 from scraping.reddit.model import RedditContent, RedditDataType
 from common.data import DataEntity, DataLabel
-from common.constants import REDDIT_MEDIA_REQUIRED_DATE, SCRAPED_AT_REQUIRED_DATE
+from common.constants import REDDIT_MEDIA_REQUIRED_DATE
 
 
 def is_valid_reddit_url(url: str) -> bool:
@@ -34,13 +34,11 @@ def validate_scraped_at(
     now = dt.datetime.now(dt.timezone.utc)
 
     if content_to_validate.scraped_at is None:
-        if now >= SCRAPED_AT_REQUIRED_DATE:
-            return ValidationResult(
-                is_valid=False,
-                reason=f"scraped_at is required after {SCRAPED_AT_REQUIRED_DATE.isoformat()}",
-                content_size_bytes_validated=entity.content_size_bytes,
-            )
-        return None
+        return ValidationResult(
+            is_valid=False,
+            reason="scraped_at is required",
+            content_size_bytes_validated=entity.content_size_bytes,
+        )
 
     # Must be obfuscated to the minute
     if content_to_validate.scraped_at.second != 0 or content_to_validate.scraped_at.microsecond != 0:

--- a/scraping/x/utils.py
+++ b/scraping/x/utils.py
@@ -6,7 +6,7 @@ import bittensor as bt
 from typing import Dict, List, Optional
 from urllib.parse import urlparse
 from common.data import DataEntity
-from common.constants import NO_TWITTER_URLS_DATE, SCRAPED_AT_REQUIRED_DATE
+from common.constants import NO_TWITTER_URLS_DATE
 from scraping import utils
 from scraping.scraper import ValidationResult
 from scraping.x.model import XContent
@@ -289,13 +289,11 @@ def validate_scraped_at(
     now = dt.datetime.now(dt.timezone.utc)
 
     if tweet_to_verify.scraped_at is None:
-        if now >= SCRAPED_AT_REQUIRED_DATE:
-            return ValidationResult(
-                is_valid=False,
-                reason=f"scraped_at is required after {SCRAPED_AT_REQUIRED_DATE.isoformat()}",
-                content_size_bytes_validated=entity.content_size_bytes,
-            )
-        return None
+        return ValidationResult(
+            is_valid=False,
+            reason="scraped_at is required",
+            content_size_bytes_validated=entity.content_size_bytes,
+        )
 
     # Must be obfuscated to the minute
     if tweet_to_verify.scraped_at.second != 0 or tweet_to_verify.scraped_at.microsecond != 0:

--- a/tests/scraping/reddit/test_utils.py
+++ b/tests/scraping/reddit/test_utils.py
@@ -256,13 +256,14 @@ class TestValidateScrapedAt(unittest.TestCase):
         self.assertFalse(result.is_valid)
         self.assertIn("future", result.reason)
 
-    def test_scraped_at_none_before_deadline(self):
-        """scraped_at=None is allowed before the deadline."""
+    def test_scraped_at_none_fails(self):
+        """scraped_at=None fails validation."""
         content, entity = self._make_content_and_entity(scraped_at=None)
         parsed = RedditContent.from_data_entity(entity)
         result = utils.validate_scraped_at(parsed, entity)
-        # Before the deadline this should return None (skip)
-        self.assertIsNone(result)
+        self.assertIsNotNone(result)
+        self.assertFalse(result.is_valid)
+        self.assertIn("required", result.reason)
 
     def test_scraped_at_equal_to_created_at(self):
         """scraped_at equal to created_at (obfuscated) is valid."""

--- a/tests/scraping/x/test_utils.py
+++ b/tests/scraping/x/test_utils.py
@@ -355,14 +355,14 @@ class TestValidateScrapedAt(unittest.TestCase):
         self.assertFalse(result.is_valid)
         self.assertIn("future", result.reason)
 
-    def test_scraped_at_none_before_deadline(self):
-        """scraped_at=None is allowed before the deadline."""
+    def test_scraped_at_none_fails(self):
+        """scraped_at=None fails validation."""
         tweet, entity = self._make_tweet_and_entity(scraped_at=None)
         parsed = XContent.from_data_entity(entity)
         result = utils.validate_scraped_at(parsed, entity)
-        # Before the deadline this should return None (skip)
-        # This test assumes we're running before 2026-03-10
-        self.assertIsNone(result)
+        self.assertIsNotNone(result)
+        self.assertFalse(result.is_valid)
+        self.assertIn("required", result.reason)
 
     def test_scraped_at_equal_to_timestamp(self):
         """scraped_at equal to timestamp (obfuscated) is valid."""

--- a/upload_utils/s3_uploader.py
+++ b/upload_utils/s3_uploader.py
@@ -23,6 +23,21 @@ from common.api_client import DataUniverseApiClient
 from common.data import DataSource
 
 
+def _to_iso_string(v):
+    """Coerce scraped_at-style values to ISO strings.
+
+    PyArrow infers parquet dtype from values: a chunk of pure ISO strings
+    becomes string, a chunk containing any datetime object becomes
+    timestamp[ns]. Forcing strings here keeps the column type stable
+    across miners and chunks.
+    """
+    if v is None:
+        return None
+    if isinstance(v, dt.datetime):
+        return v.isoformat()
+    return str(v)
+
+
 def load_dynamic_lookup() -> Dict[str, List[Dict]]:
     """Load dynamic desirability lookup from dynamic_desirability/total.json"""
     try:
@@ -438,7 +453,7 @@ class S3PartitionedUploader:
                     'score': df['decoded_content'].apply(lambda x: x.get('score')),
                     'upvote_ratio': df['decoded_content'].apply(lambda x: x.get('upvote_ratio')),
                     'num_comments': df['decoded_content'].apply(lambda x: x.get('num_comments')),
-                    'scrapedAt': df['decoded_content'].apply(lambda x: x.get('scrapedAt')),
+                    'scrapedAt': df['decoded_content'].apply(lambda x: _to_iso_string(x.get('scrapedAt'))),
                 })
             else:
                 # X/Twitter data structure (uri removed — validator uses url column)
@@ -475,7 +490,7 @@ class S3PartitionedUploader:
                     'cover_picture_url': df['decoded_content'].apply(lambda x: x.get('cover_picture_url')),
                     'user_followers_count': df['decoded_content'].apply(lambda x: x.get('user_followers_count')),
                     'user_following_count': df['decoded_content'].apply(lambda x: x.get('user_following_count')),
-                    'scraped_at': df['decoded_content'].apply(lambda x: x.get('scraped_at')),
+                    'scraped_at': df['decoded_content'].apply(lambda x: _to_iso_string(x.get('scraped_at'))),
                 })
 
             return result_df

--- a/vali_utils/s3_utils.py
+++ b/vali_utils/s3_utils.py
@@ -24,6 +24,7 @@ from scraping.provider import ScraperProvider
 from scraping.scraper import ScraperId, ValidationResult
 from scraping.x.model import XContent
 from scraping.reddit.model import RedditContent
+from common.constants import SCRAPED_AT_STRING_REQUIRED_DATE
 from common.data import DataEntity, DataSource
 from common.api_client import TaoSigner
 from vali_utils.parquet_reader import read_random_row_group
@@ -701,7 +702,7 @@ class DuckDBSampledValidator:
 
                 # --- Schema check (footer-only read) ---
                 schema_result = conn.execute(
-                    f"SELECT name FROM parquet_schema('{presigned_url}')"
+                    f"SELECT name, type FROM parquet_schema('{presigned_url}')"
                 ).fetchall()
                 excluded_names = {'schema', 'list', 'element', 'model_config'}
                 all_column_names = [row[0].lower() for row in schema_result if row[0].lower() not in excluded_names]
@@ -743,6 +744,34 @@ class DuckDBSampledValidator:
                     )
                     schema_failures += 1
                     break
+
+                # --- scraped_at dtype gate: reject post-deadline files where
+                # scraped_at/scrapedAt is a parquet timestamp instead of a string.
+                # Pre-deadline files are grandfathered (miners can't rewrite parquet).
+                now_utc = dt.datetime.now(dt.timezone.utc)
+                if now_utc >= SCRAPED_AT_STRING_REQUIRED_DATE:
+                    last_mod = file_info.get('last_modified', '')
+                    try:
+                        file_dt = pd.to_datetime(last_mod, utc=True).to_pydatetime() if last_mod else None
+                    except Exception:
+                        file_dt = None
+                    if file_dt and file_dt >= SCRAPED_AT_STRING_REQUIRED_DATE:
+                        target_col = 'scraped_at' if platform in ['x', 'twitter'] else 'scrapedat'
+                        # DuckDB parquet_schema reports physical types: BYTE_ARRAY
+                        # for strings, INT64 for parquet timestamps. Strings must
+                        # be BYTE_ARRAY — anything else (INT64, INT96, etc.) means
+                        # the value was written as a real timestamp dtype.
+                        bad_dtype = any(
+                            name.lower() == target_col and str(ptype).upper() != 'BYTE_ARRAY'
+                            for name, ptype in schema_result
+                        )
+                        if bad_dtype:
+                            bt.logging.warning(
+                                f"scraped_at must be string after "
+                                f"{SCRAPED_AT_STRING_REQUIRED_DATE.date()}: "
+                                f"{file_key} (uploaded {last_mod})"
+                            )
+                            continue
 
                 # --- Per-job dedup: read ALL urls via DuckDB (columnar read, ~500KB per file) ---
                 if job_id not in dedup_hashes_by_job:


### PR DESCRIPTION
## Summary
- Force miners to upload `scraped_at` (X) / `scrapedAt` (Reddit) as ISO strings instead of parquet timestamps, and add a validator-side dtype check during S3 sampling.
- Validator enforces from **2026-05-13 UTC** (1-week grace). Pre-deadline uploads are grandfathered — miners can't rewrite parquet already on S3.
- Clean up dead `SCRAPED_AT_REQUIRED_DATE` (2026-03-10) gate in `scraping/{reddit,x}/utils.py` — deadline passed ~2 months ago, branch was unreachable.

## Why
Miners produce mixed parquet dtypes for the same logical column:
- ~96% upload `scraped_at` as parquet `INT64` (timestamp logical type).
- ~4% upload as `BYTE_ARRAY` (ISO string).

Confirmed against 30 random miners on S3:

| Dtype | Count |
|---|---|
| `INT64` | 26 |
| `BYTE_ARRAY` | 1 |
| no column / errors | 3 |

Mixed schemas break downstream consumers that `UNION` files, force every reader to do dtype-aware coercion, and prevent locking down the parquet schema. Root cause: PyArrow infers dtype from values, and most miners pass `datetime` objects through `df.to_parquet` instead of pre-formatted strings.

## Changes

**`upload_utils/s3_uploader.py`** — new `_to_iso_string()` helper coerces `scraped_at` / `scrapedAt` to ISO strings before parquet write. Applied to both X and Reddit branches in `_create_raw_dataframe`. Effect: miners pulling this start producing `BYTE_ARRAY` columns immediately.

**`vali_utils/s3_utils.py`** — schema gate in `_sampled_duckdb_validation`:
- Extended `parquet_schema` query to include `type`.
- Dtype check fires only when **both** `now_utc >= 2026-05-13` **and** the file's `last_modified >= 2026-05-13`.
- Bad-dtype files are soft-skipped (`continue`) — the rest of the miner's data is still validated. No hard fail.
- Predicate: `ptype != 'BYTE_ARRAY'` for the target column. DuckDB's `parquet_schema()` returns physical types — `BYTE_ARRAY` for strings, `INT64` for timestamps.

**`common/constants.py`** — drop `SCRAPED_AT_REQUIRED_DATE`, add `SCRAPED_AT_STRING_REQUIRED_DATE = 2026-05-13 UTC`.

**`scraping/reddit/utils.py`, `scraping/x/utils.py`** — `validate_scraped_at` no longer gates on the past `SCRAPED_AT_REQUIRED_DATE`. Missing `scraped_at` unconditionally fails with reason `"scraped_at is required"`. Dead `return None` skip path removed.

**Tests** — `test_scraped_at_none_before_deadline` → `test_scraped_at_none_fails` in both `tests/scraping/reddit/test_utils.py` and `tests/scraping/x/test_utils.py`. 12/12 `TestValidateScrapedAt` cases pass.

## Verification
Tested against real S3 miner data (4 files across 2 miners):

| Scenario | Outcome |
|---|---|
| Pre-deadline INT64 file, validated post-deadline | Grandfathered |
| Pre-deadline BYTE_ARRAY file, validated post-deadline | Pass |
| Any file, validated today (gate dormant) | Pass |
| Simulated post-deadline INT64 upload | Soft-skipped |
| Simulated post-deadline BYTE_ARRAY upload | Pass |

Edge cases covered (local synthetic parquet):
- `string` → `BYTE_ARRAY` (pass)
- `datetime[us, UTC]` → `INT64` (rejected)
- `datetime[ns]` no tz → `INT64` (rejected)
- `decimal128` → `FIXED_LEN_BYTE_ARRAY` (rejected)

## Miner action required
Miners must pull this branch before **2026-05-13 UTC**. Files uploaded with old client after that date are excluded from `effective_size` until the dtype is corrected. Existing files on S3 are unaffected.

## Test plan
- [x] Verify `_to_iso_string` lambda runs on `decoded_content` without breaking chunk upload (locally + dev miner).
- [x] Confirm a freshly-uploaded file from this branch shows `BYTE_ARRAY` in `parquet_schema`.
- [x] Run validator against a pre-deadline INT64 miner post-deadline → no penalty.
- [x] Announce to miners ≥ 7 days before deadline.
