### PR TITLE
tune OD speed and volume reward curves

### DIFF
--- a/rewards/miner_scorer.py
+++ b/rewards/miner_scorer.py
@@ -1,3 +1,4 @@
+import json
 import threading
 from typing import List, Optional
 import torch
@@ -448,11 +449,15 @@ class MinerScorer:
             )
             new_od_cred = float(self.ondemand_credibility[uid])
 
-            bt.logging.info(
-                f"OnDemand penalty for Miner {uid}: "
-                f"OD Cred {old_od_cred:.4f} -> {new_od_cred:.4f}, "
-                f"Boost {old_boost:.0f} -> {new_boost:.0f}"
-            )
+            bt.logging.info(json.dumps({
+                "event": "od_penalty",
+                "uid": uid,
+                "mult_factor": round(mult_factor, 4),
+                "od_cred_before": round(old_od_cred, 6),
+                "od_cred_after": round(new_od_cred, 6),
+                "boost_before": round(old_boost, 2),
+                "boost_after": round(new_boost, 2),
+            }))
 
     def apply_ondemand_reward(
         self,
@@ -490,13 +495,17 @@ class MinerScorer:
             )
             new_od_cred = float(self.ondemand_credibility[uid])
 
-            bt.logging.info(
-                f"OnDemand reward for Miner {uid}: "
-                f"Speed={speed_multiplier:.3f}, Volume={volume_multiplier:.3f}, "
-                f"Raw reward={raw_reward:.0f}, "
-                f"OnDemand boost (EMA'd): {old_boost:.0f} -> {new_boost:.0f}, "
-                f"OD cred: {old_od_cred:.4f} -> {new_od_cred:.4f}"
-            )
+            bt.logging.info(json.dumps({
+                "event": "od_reward",
+                "uid": uid,
+                "speed_mult": round(speed_multiplier, 4),
+                "volume_mult": round(volume_multiplier, 4),
+                "raw_reward": round(raw_reward, 2),
+                "boost_before": round(old_boost, 2),
+                "boost_after": round(new_boost, 2),
+                "od_cred_before": round(old_od_cred, 6),
+                "od_cred_after": round(new_od_cred, 6),
+            }))
 
     def apply_ondemand_credibility_bump(self, uid: int, count: int = 1) -> None:
         """Small credibility bump for miners who submitted to OD jobs but weren't sampled.
@@ -517,10 +526,13 @@ class MinerScorer:
                 )
             new_od_cred = float(self.ondemand_credibility[uid])
 
-            bt.logging.trace(
-                f"OnDemand credibility bump (unsampled ×{count}) for Miner {uid}: "
-                f"OD cred: {old_od_cred:.4f} -> {new_od_cred:.4f}"
-            )
+            bt.logging.trace(json.dumps({
+                "event": "od_credibility_bump",
+                "uid": uid,
+                "count": count,
+                "od_cred_before": round(old_od_cred, 6),
+                "od_cred_after": round(new_od_cred, 6),
+            }))
 
     def on_miner_evaluated(
         self,

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -3,6 +3,7 @@ import gc
 import copy
 import asyncio
 import datetime
+import json
 import random
 import traceback
 import threading
@@ -167,6 +168,16 @@ class MinerEvaluator:
 
         for j in empty:
             self.scorer.apply_ondemand_penalty(uid=uid, mult_factor=1.0)
+            bt.logging.info(json.dumps({
+                "event": "od_submission",
+                "uid": uid,
+                "hotkey": hotkey,
+                "job_id": j.submission.job_id,
+                "outcome": "empty_penalized",
+                "speed_mult": 0.0,
+                "volume_mult": 0.0,
+                "entity_count": 0,
+            }))
 
         if not non_empty:
             if empty:
@@ -180,7 +191,9 @@ class MinerEvaluator:
         to_validate = random.sample(
             non_empty, min(self.OD_MAX_JOBS_TO_VALIDATE, len(non_empty))
         )
-        not_sampled_count = len(non_empty) - len(to_validate)
+        sampled_ids = {id(j) for j in to_validate}
+        not_sampled = [j for j in non_empty if id(j) not in sampled_ids]
+        not_sampled_count = len(not_sampled)
 
         # Validate sampled jobs concurrently
         validation_results: List[Tuple[bool, int]] = await asyncio.gather(*[
@@ -207,13 +220,38 @@ class MinerEvaluator:
             if passed:
                 self.scorer.apply_ondemand_reward(uid, speed_mult, vol_mult)
                 validated_pass += 1
+                outcome = "validated_pass"
             else:
                 self.scorer.apply_ondemand_penalty(uid, mult_factor=1.0)
                 validated_fail += 1
+                outcome = "validated_fail"
+
+            bt.logging.info(json.dumps({
+                "event": "od_submission",
+                "uid": uid,
+                "hotkey": hotkey,
+                "job_id": j.submission.job_id,
+                "outcome": outcome,
+                "speed_mult": round(speed_mult, 4),
+                "volume_mult": round(vol_mult, 4),
+                "entity_count": entity_count,
+                "requested_limit": j.job.limit,
+                "upload_seconds": round(
+                    (j.submission.submitted_at - j.job.created_at).total_seconds(), 3
+                ) if j.submission.submitted_at and j.job.created_at else None,
+            }))
 
         # Batch credibility bump for non-sampled but participating submissions
         if not_sampled_count > 0:
             self.scorer.apply_ondemand_credibility_bump(uid, count=not_sampled_count)
+            for j in not_sampled:
+                bt.logging.info(json.dumps({
+                    "event": "od_submission",
+                    "uid": uid,
+                    "hotkey": hotkey,
+                    "job_id": j.submission.job_id,
+                    "outcome": "not_sampled_credibility_bump",
+                }))
 
         bt.logging.info(
             f"UID:{uid} - HOTKEY:{hotkey}: OD summary — "

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -3,7 +3,6 @@ import gc
 import copy
 import asyncio
 import datetime
-import json
 import random
 import traceback
 import threading
@@ -168,16 +167,6 @@ class MinerEvaluator:
 
         for j in empty:
             self.scorer.apply_ondemand_penalty(uid=uid, mult_factor=1.0)
-            bt.logging.info(json.dumps({
-                "event": "od_submission",
-                "uid": uid,
-                "hotkey": hotkey,
-                "job_id": j.submission.job_id,
-                "outcome": "empty_penalized",
-                "speed_mult": 0.0,
-                "volume_mult": 0.0,
-                "entity_count": 0,
-            }))
 
         if not non_empty:
             if empty:
@@ -191,9 +180,7 @@ class MinerEvaluator:
         to_validate = random.sample(
             non_empty, min(self.OD_MAX_JOBS_TO_VALIDATE, len(non_empty))
         )
-        sampled_ids = {id(j) for j in to_validate}
-        not_sampled = [j for j in non_empty if id(j) not in sampled_ids]
-        not_sampled_count = len(not_sampled)
+        not_sampled_count = len(non_empty) - len(to_validate)
 
         # Validate sampled jobs concurrently
         validation_results: List[Tuple[bool, int]] = await asyncio.gather(*[
@@ -220,38 +207,13 @@ class MinerEvaluator:
             if passed:
                 self.scorer.apply_ondemand_reward(uid, speed_mult, vol_mult)
                 validated_pass += 1
-                outcome = "validated_pass"
             else:
                 self.scorer.apply_ondemand_penalty(uid, mult_factor=1.0)
                 validated_fail += 1
-                outcome = "validated_fail"
-
-            bt.logging.info(json.dumps({
-                "event": "od_submission",
-                "uid": uid,
-                "hotkey": hotkey,
-                "job_id": j.submission.job_id,
-                "outcome": outcome,
-                "speed_mult": round(speed_mult, 4),
-                "volume_mult": round(vol_mult, 4),
-                "entity_count": entity_count,
-                "requested_limit": j.job.limit,
-                "upload_seconds": round(
-                    (j.submission.submitted_at - j.job.created_at).total_seconds(), 3
-                ) if j.submission.submitted_at and j.job.created_at else None,
-            }))
 
         # Batch credibility bump for non-sampled but participating submissions
         if not_sampled_count > 0:
             self.scorer.apply_ondemand_credibility_bump(uid, count=not_sampled_count)
-            for j in not_sampled:
-                bt.logging.info(json.dumps({
-                    "event": "od_submission",
-                    "uid": uid,
-                    "hotkey": hotkey,
-                    "job_id": j.submission.job_id,
-                    "outcome": "not_sampled_credibility_bump",
-                }))
 
         bt.logging.info(
             f"UID:{uid} - HOTKEY:{hotkey}: OD summary — "

--- a/vali_utils/on_demand/on_demand_validation.py
+++ b/vali_utils/on_demand/on_demand_validation.py
@@ -21,6 +21,41 @@ from vali_utils.on_demand.output_models import validate_metadata_completeness
 from vali_utils.metrics import ORGANIC_MINER_RESULTS
 
 
+# Reward multiplier tuning constants (see docs/od_reward_formula.md)
+SPEED_HALF_LIFE_S = 45.0
+VOLUME_SHORTFALL_EXPONENT = 1.3
+VOLUME_OVER_LOG_COEF = 0.15
+VOLUME_OVER_BONUS_CAP = 0.25
+VOLUME_OPEN_REF = 1000
+VOLUME_OPEN_MAX = 1.5
+
+
+def _speed_multiplier(upload_seconds: float) -> float:
+    """Half-life decay; clamps to [0, 1]. See docs/od_reward_formula.md §3."""
+    t = max(0.0, float(upload_seconds))
+    return min(1.0, 0.5 ** (t / SPEED_HALF_LIFE_S))
+
+
+def _volume_multiplier(returned: int, limit: Optional[int]) -> float:
+    """Sub-linear below target, log-capped over target. Open mode (limit=None)
+    grades absolute volume on log scale. See docs/od_reward_formula.md §4."""
+    r = max(0, int(returned or 0))
+    if r == 0:
+        return 0.0
+
+    if limit is None or limit <= 0:
+        denom = math.log10(1 + VOLUME_OPEN_REF)
+        return min(VOLUME_OPEN_MAX, math.log10(1 + r) / denom)
+
+    L = int(limit)
+    if r <= L:
+        return (r / L) ** VOLUME_SHORTFALL_EXPONENT
+
+    extra = (r - L) / L
+    bonus = min(VOLUME_OVER_BONUS_CAP, VOLUME_OVER_LOG_COEF * math.log(1.0 + extra))
+    return 1.0 + bonus
+
+
 @dataclass
 class ValidationContext:
     """Lightweight replacement for OrganicRequest (bt.Synapse) used only for validation."""
@@ -630,30 +665,15 @@ class OnDemandValidator:
         submission_timestamp: dt.datetime,
         returned_count: int,
         requested_limit: Optional[int],
-        consensus_count: Optional[float] = None,
     ) -> Tuple[float, float]:
-        # Speed multiplier (exponential decay)
-        if submission_timestamp is None or job_created_at is None:
+        if job_created_at is None or submission_timestamp is None:
             bt.logging.warning(
-                "Missing timestamp data for reward calculation, using default speed=0.5"
+                "Missing timestamp data for reward calculation, using default (0.5, 0.0)"
             )
-            speed_multiplier = 0.5
-        else:
-            upload_time_seconds = (
-                submission_timestamp - job_created_at
-            ).total_seconds()
-            decay_rate = 0.05
-            speed_multiplier = max(0.1, math.exp(-decay_rate * upload_time_seconds))
+            return 0.5, 0.0
 
-        # Volume multiplier
-        if requested_limit is None:
-            if consensus_count and consensus_count > 0:
-                volume_multiplier = min(1.0, returned_count / consensus_count)
-            else:
-                volume_multiplier = 1.0
-        elif returned_count == 0:
-            volume_multiplier = 0.0
-        else:
-            volume_multiplier = min(1.0, returned_count / requested_limit)
-
-        return speed_multiplier, volume_multiplier
+        upload_time_seconds = (submission_timestamp - job_created_at).total_seconds()
+        return (
+            _speed_multiplier(upload_time_seconds),
+            _volume_multiplier(returned_count, requested_limit),
+        )


### PR DESCRIPTION
Replace `calculate_ondemand_reward_multipliers` with a half-life speed curve and sub-linear-then-log-bonus volume curve. Restructure the three OD scoring log lines into JSON.

Full math, derivation, invariants, and graphs: [On-Demand Reward Multipliers — Formula Specification](https://gist.github.com/Arrmlet/916f4d7f27692b2e02ed68276558ccab)

- Speed: `S(t) = min(1, 0.5^(t/45))`. Removes the `0.1` floor that flattened the back half of the expiry window.
- Volume: `(r/L)^1.3` below target, log-capped bonus up to 1.25 above. Half-fills punished, over-delivery rewarded.
- Reward range widens from ~200× to ~1700× between best and worst non-failing submission.
- Validation gate unchanged; fabricators / empty submitters still earn zero.