### PR TITLE
docs: fix editable install command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Data Universe is a data-scraping and sentiment analysis subnet that collects and
 
 3. Install dependencies:
    ```bash
-   pip install -e
+   pip install -e .
    ```
 
 4. Set up your development environment:


### PR DESCRIPTION
## Summary

- fix the editable install command in `CONTRIBUTING.md`

## Why

`pip install -e` requires a path argument. The setup step should use the current directory:

```bash
pip install -e .
```

## Test

Docs-only change. Verified with:

```bash
git diff --check
```
