### PR TITLE
fix(s3-utils): preserve None for user_verified to honor OPTIONAL_FIELDS skip

### DIFF
--- a/vali_utils/s3_utils.py
+++ b/vali_utils/s3_utils.py
@@ -1376,7 +1376,7 @@ class DuckDBSampledValidator:
                 media=media_value,
                 user_id=str(row.get('user_id', '')),
                 user_display_name=str(row.get('user_display_name', '')) if pd.notna(row.get('user_display_name', None)) else None,
-                user_verified=bool(row.get('user_verified', False)),
+                user_verified=bool(row.get('user_verified', False)) if pd.notna(row.get('user_verified', None)) else None,
                 tweet_id=str(row.get('tweet_id', '')),
                 is_reply=bool(row.get('is_reply', False)),
                 is_quote=bool(row.get('is_quote', False)),


### PR DESCRIPTION
Fixes asymmetric None handling for `user_verified` at `vali_utils/s3_utils.py:1379`.

## Problem

The current `_create_twitter_entity` decoder coerces `None` to `False`:

```python
user_verified=bool(row.get('user_verified', False)),
```

When a miner NULLs `user_verified` at upload (drift-defense pattern for OPTIONAL_FIELDS), `bool(None) == False`, so the validator silently treats the field as `False`. Then `scraper.validate()` compares submitted=`False` vs apidojo-fetched actual=`True` for any legacy-verified account, producing a `Field: user_verified do not match` event that counts against `scraper_success_rate`.

This breaks the OPTIONAL_FIELDS None-skip contract from `scraping/x/utils.py:212-217`:

```python
if submitted_value is None or actual_value is None:
    continue
```

## Fix

Align `user_verified` decoding with the existing `user_blue_verified` pattern at line 1394:

```python
# Before
user_verified=bool(row.get('user_verified', False)),
# After
user_verified=bool(row.get('user_verified', False)) if pd.notna(row.get('user_verified', None)) else None,
```

## Reproduction (without the fix)

```python
import pandas as pd
df = pd.DataFrame([{'user_verified': None}])
df.to_parquet('/tmp/t.parquet', index=False)
row = pd.read_parquet('/tmp/t.parquet').iloc[0]
print(bool(row.get('user_verified', False)))   # False  -- coerces None to False
val = row.get('user_verified', None)
print(bool(val) if pd.notna(val) else None)    # None   -- correctly preserves None
```

## Notes

- `is_reply` and `is_quote` (lines 1381-1382) use the same coercion pattern but are not in OPTIONAL_FIELDS and miners do not NULL them at upload, so they are intentionally left untouched for a minimal-scope PR.