### PR TITLE
fix: better data selection for S3 validation

### DIFF
--- a/rewards/miner_scorer.py
+++ b/rewards/miner_scorer.py
@@ -136,7 +136,7 @@ class MinerScorer:
             self.effective_sizes = state.get("effective_sizes", torch.zeros(self.scores.size(0), dtype=torch.float64))
 
             # --- State migrations ---
-            if saved_version < 10:
+            if saved_version < 11:
                 bt.logging.warning(
                     f"State migration v{saved_version} -> v10: "
                     f"S3 boost/credibility/effective_size reset "

--- a/rewards/miner_scorer.py
+++ b/rewards/miner_scorer.py
@@ -30,7 +30,7 @@ class MinerScorer:
     #      hex-pad, synthetic users, short status IDs, within-file dup) catches the
     #      164-hotkey sybil cluster; pre-fix effective_size/credibility is inflated by
     #      fabricated bulk uploads.
-    STATE_VERSION = 10
+    STATE_VERSION = 11
 
     # Start new miner's at a credibility of 0.
     STARTING_CREDIBILITY = 0
@@ -138,7 +138,7 @@ class MinerScorer:
             # --- State migrations ---
             if saved_version < 11:
                 bt.logging.warning(
-                    f"State migration v{saved_version} -> v10: "
+                    f"State migration v{saved_version} -> v11: "
                     f"S3 boost/credibility/effective_size reset "
                     f"(per-file fabrication detection)."
                 )

--- a/vali_utils/s3_utils.py
+++ b/vali_utils/s3_utils.py
@@ -1186,6 +1186,10 @@ class DuckDBSampledValidator:
         )
 
         for file_info in sampled_files:
+
+            if len(all_entities) >= num_entities * 2:
+                break
+
             # Skip oversized files to prevent OOM
             file_size = file_info.get('size', 0)
             if file_size > self.MAX_FILE_SIZE_BYTES:

--- a/vali_utils/s3_utils.py
+++ b/vali_utils/s3_utils.py
@@ -147,16 +147,6 @@ class DuckDBSampledValidator:
     MIN_ENGAGEMENT_RATE = 95.0  # 95% of X rows must have non-null view_count
     MIN_UNIQUE_CONTENT_RATIO = 10.0  # 10% min unique tweet_ids / total rows
 
-    # Fabrication-detection floors (data-driven from SN13 sybil cluster corpus, May 2026):
-    #   Recipe A files: text repeats verbatim across all rows (text_uniq ≈ 0.0005%)
-    #   Recipe B files: 5 usernames repeated for 400K rows  (user_uniq ≈ 0.001%)
-    # Legitimate files measured: text_uniq ≥ 86.7%, user_uniq ≥ 41.7%
-    # Margin between fab and legit is enormous; thresholds chosen well above
-    # fab maxima but well below legit minima.
-    MIN_TEXT_UNIQ_RATIO = 50.0     # <50% distinct text rows = templated fab
-    MIN_USER_UNIQ_RATIO = 30.0     # <30% distinct usernames = recycled-user fab
-    UNIQ_RATIO_ROW_FLOOR = 1000    # Don't apply to small files (natural repetition OK)
-
     # File size limits - prevent empty file exploit and oversized file OOM
     MIN_FILE_SIZE_BYTES = 15_000                   # 15KB - empty parquet header ≈ 8KB
     MAX_FILE_SIZE_BYTES = 512 * 1024 * 1024        # 512MB - single file cap
@@ -901,58 +891,6 @@ class DuckDBSampledValidator:
                             ids = rg_df['id'].dropna().astype(str)
                             total_content_id_rows += len(ids)
                             unique_content_ids.update(ids.tolist())
-
-                # --- Fabrication kill: text_uniq + user_uniq per file ---
-                # Run on full file (columnar scan, ~MB-scale). Catches the SN13
-                # sybil cluster fab recipes whose templated text or 5-user pool
-                # makes the ratios collapse to <0.001.
-                if platform in ('x', 'twitter', 'reddit'):
-                    text_col = 'text' if platform in ('x', 'twitter') else 'body'
-                    if text_col in available_columns and 'username' in available_columns:
-                        try:
-                            uniq_row = conn.execute(
-                                f"SELECT COUNT(*), COUNT(DISTINCT {text_col}), "
-                                f"COUNT(DISTINCT username) "
-                                f"FROM read_parquet('{presigned_url}')"
-                            ).fetchone()
-                            file_total, uniq_text, uniq_user = uniq_row
-                            if file_total > self.UNIQ_RATIO_ROW_FLOOR:
-                                text_uniq_pct = uniq_text / file_total * 100
-                                user_uniq_pct = uniq_user / file_total * 100
-                                if text_uniq_pct < self.MIN_TEXT_UNIQ_RATIO:
-                                    bt.logging.warning(
-                                        f"FAB: low text uniqueness in {file_key}: "
-                                        f"{uniq_text}/{file_total} = {text_uniq_pct:.2f}% "
-                                        f"(min {self.MIN_TEXT_UNIQ_RATIO}%)"
-                                    )
-                                    return {
-                                        "success": False,
-                                        "duplicate_rate_within_job": 100.0,
-                                        "empty_rate": 100.0,
-                                        "total_rows": 0,
-                                        "reason": (
-                                            f"Low text uniqueness: {text_uniq_pct:.2f}% "
-                                            f"({uniq_text}/{file_total} distinct)"
-                                        ),
-                                    }
-                                if user_uniq_pct < self.MIN_USER_UNIQ_RATIO:
-                                    bt.logging.warning(
-                                        f"FAB: low user uniqueness in {file_key}: "
-                                        f"{uniq_user}/{file_total} = {user_uniq_pct:.2f}% "
-                                        f"(min {self.MIN_USER_UNIQ_RATIO}%)"
-                                    )
-                                    return {
-                                        "success": False,
-                                        "duplicate_rate_within_job": 100.0,
-                                        "empty_rate": 100.0,
-                                        "total_rows": 0,
-                                        "reason": (
-                                            f"Low user uniqueness: {user_uniq_pct:.2f}% "
-                                            f"({uniq_user}/{file_total} distinct)"
-                                        ),
-                                    }
-                        except Exception as e:
-                            bt.logging.debug(f"fab uniq-check failed for {file_key}: {e}")
 
             except Exception as e:
                 bt.logging.debug(f"Sampled validation error for file: {e}")

--- a/vali_utils/s3_utils.py
+++ b/vali_utils/s3_utils.py
@@ -1160,13 +1160,32 @@ class DuckDBSampledValidator:
         presigned_urls: Dict[str, str],
         num_entities: int = 10
     ) -> Dict[str, Any]:
-        """Validate random entities using real scrapers."""
+        """Validate random entities using real scrapers.
+
+        Invariant: a row sampled from a parquet file must either become a
+        DataEntity and be checked by the scraper, or count as a failed
+        scraper validation. Rows must never disappear silently.
+
+        Previously, `_create_data_entity` returning None (e.g., fab files
+        with `bookmark_count = array([N, 0])` crashing Pydantic field
+        validation) silently dropped the row. Fab files contributed 0
+        entities, the bait files filled `all_entities`, and the miner
+        passed at 100% scraper success. Now the first None returns
+        immediate scraper failure → MIN_SCRAPER_SUCCESS gate kills the
+        miner. Honest miners produce scalar columns and never trip this.
+        """
         all_entities = []
 
-        for file_info in sampled_files:
-            if len(all_entities) >= num_entities * 2:
-                break
+        # BIG-first iteration: cluster's 25MB fab files inspected before 25KB
+        # bait files. Combined with the None → fail return below, this ensures
+        # fab miners fail on their first sampled fab row.
+        sampled_files = sorted(
+            sampled_files,
+            key=lambda f: f.get('size', 0),
+            reverse=True,
+        )
 
+        for file_info in sampled_files:
             # Skip oversized files to prevent OOM
             file_size = file_info.get('size', 0)
             if file_size > self.MAX_FILE_SIZE_BYTES:
@@ -1227,8 +1246,31 @@ class DuckDBSampledValidator:
 
                 for _, row in df.iterrows():
                     entity = self._create_data_entity(row, platform)
-                    if entity:
-                        all_entities.append((entity, platform, job_id))
+                    if entity is None:
+                        # The invariant: a sampled row must never disappear
+                        # silently. None means entity construction failed
+                        # (e.g., fab files with array-typed numeric columns
+                        # crash Pydantic's int() coercion, swallowed by the
+                        # bare except in _create_twitter_entity). Treat as
+                        # immediate scraper failure — honest miners produce
+                        # scalar columns and never hit this path.
+                        fname = file_key.split('/')[-1]
+                        bt.logging.warning(
+                            f"{miner_hotkey}: _create_data_entity returned None "
+                            f"for sampled {platform} row in {fname} "
+                            f"(likely malformed/fab data). Failing scraper "
+                            f"validation immediately."
+                        )
+                        return {
+                            'entities_validated': 1,
+                            'entities_passed': 0,
+                            'success_rate': 0.0,
+                            'sample_results': [
+                                f"❌ {platform} ({job_id[:16]}): "
+                                f"Failed to create DataEntity for sampled row ({fname})"
+                            ],
+                        }
+                    all_entities.append((entity, platform, job_id))
 
                 del df
             except:

--- a/vali_utils/s3_utils.py
+++ b/vali_utils/s3_utils.py
@@ -794,7 +794,7 @@ class DuckDBSampledValidator:
                     url_missing = rg_df['url'].isna() | (rg_df['url'].astype(str).str.strip() == '')
                     missing_urls = int(url_missing.sum())
                     if missing_urls > 0:
-                        bt.logging.warning(f"File has {missing_urls} rows with missing URL: {file_key}")
+                        bt.logging.warning(f"File has {missing_urls} rows with missing URL")
                         return {
                             "success": False,
                             "duplicate_rate_within_job": 100.0,
@@ -817,7 +817,7 @@ class DuckDBSampledValidator:
                         empty_user = rg_df['username'].fillna('').astype(str).str.strip() == ''
                         empty_user_pct = empty_user.sum() / len(rg_df) * 100
                         if empty_user_pct > 50:
-                            bt.logging.warning(f"Empty username: {empty_user_pct:.0f}% rows have no username: {file_key}")
+                            bt.logging.warning(f"Empty username: {empty_user_pct:.0f}% rows have no username")
                             return {
                                 "success": False,
                                 "duplicate_rate_within_job": 100.0,
@@ -1176,12 +1176,15 @@ class DuckDBSampledValidator:
         """
         all_entities = []
 
-        # BIG-first iteration: cluster's 25MB fab files inspected before 25KB
-        # bait files. Combined with the None → fail return below, this ensures
-        # fab miners fail on their first sampled fab row.
+        # Size-weighted random shuffle: bigger files are MORE LIKELY to be
+        # examined first, but not deterministically. A miner cannot position
+        # one specific bait file at the top by ordering or naming because each
+        # file's effective rank is `size * random()` — big files almost always
+        # win, but the exact ordering changes per validation cycle. Same math
+        # idea as `choose_data_entity_bucket_to_query` in P2P validation.
         sampled_files = sorted(
             sampled_files,
-            key=lambda f: f.get('size', 0),
+            key=lambda f: f.get('size', 1) * random.random(),
             reverse=True,
         )
 
@@ -1258,10 +1261,9 @@ class DuckDBSampledValidator:
                         # bare except in _create_twitter_entity). Treat as
                         # immediate scraper failure — honest miners produce
                         # scalar columns and never hit this path.
-                        fname = file_key.split('/')[-1]
                         bt.logging.warning(
                             f"{miner_hotkey}: _create_data_entity returned None "
-                            f"for sampled {platform} row in {fname} "
+                            f"for sampled {platform} row "
                             f"(likely malformed/fab data). Failing scraper "
                             f"validation immediately."
                         )
@@ -1271,7 +1273,7 @@ class DuckDBSampledValidator:
                             'success_rate': 0.0,
                             'sample_results': [
                                 f"❌ {platform} ({job_id[:16]}): "
-                                f"Failed to create DataEntity for sampled row ({fname})"
+                                f"Failed to create DataEntity for sampled row"
                             ],
                         }
                     all_entities.append((entity, platform, job_id))
@@ -1411,7 +1413,7 @@ class DuckDBSampledValidator:
                 is_reply=bool(row.get('is_reply', False)),
                 is_quote=bool(row.get('is_quote', False)),
                 conversation_id=str(row.get('conversation_id', '')),
-                in_reply_to_user_id=str(row.get('in_reply_to_user_id', '')),
+                in_reply_to_user_id=str(row.get('in_reply_to_user_id', '')) if pd.notna(row.get('in_reply_to_user_id', None)) else None,
                 language=str(row.get('language', '')) if pd.notna(row.get('language', None)) else None,
                 in_reply_to_username=str(row.get('in_reply_to_username', '')) if pd.notna(row.get('in_reply_to_username', None)) else None,
                 quoted_tweet_id=str(row.get('quoted_tweet_id', '')) if pd.notna(row.get('quoted_tweet_id', None)) else None,
@@ -1431,7 +1433,8 @@ class DuckDBSampledValidator:
                 scraped_at=pd.to_datetime(row.get('scraped_at')).to_pydatetime() if row.get('scraped_at') is not None and pd.notna(row.get('scraped_at')) else None,
             )
             return XContent.to_data_entity(x_content)
-        except Exception:
+        except Exception as e:
+            bt.logging.warning(f"_create_twitter_entity failed: {type(e).__name__}: {e}")
             return None
 
     def _create_reddit_entity(self, row) -> Optional[DataEntity]:
@@ -1493,7 +1496,8 @@ class DuckDBSampledValidator:
                 scrapedAt=pd.to_datetime(row.get('scrapedAt')).to_pydatetime() if row.get('scrapedAt') is not None and pd.notna(row.get('scrapedAt')) else None,
             )
             return RedditContent.to_data_entity(reddit_content)
-        except Exception:
+        except Exception as e:
+            bt.logging.warning(f"_create_reddit_entity failed: {type(e).__name__}: {e}")
             return None
 
     async def _validate_with_scraper(

--- a/vali_utils/s3_utils.py
+++ b/vali_utils/s3_utils.py
@@ -406,15 +406,7 @@ class DuckDBSampledValidator:
                     bt.logging.info(
                         f"{miner_hotkey}: No files available for scraper validation"
                     )
-                    scraper_result = {
-                        'entities_validated': 0,
-                        'entities_passed': 0,
-                        'success_rate': None,
-                        'sample_results': [],
-                        'files_inspected': 0,
-                        'files_failed': 0,
-                        'failed_file_ratio': 0.0,
-                    }
+                    scraper_result = {'entities_validated': 0, 'entities_passed': 0, 'success_rate': None, 'sample_results': []}
 
             # Step 7: Validation decision
             issues = []
@@ -438,18 +430,6 @@ class DuckDBSampledValidator:
                 issues.append(f"Low job match: {job_match_rate:.1f}%")
             if scraper_success_rate is not None and scraper_success_rate < self.MIN_SCRAPER_SUCCESS:
                 issues.append(f"Low scraper success: {scraper_success_rate:.1f}%")
-
-            # Per-file scraper kill: if too many sampled files fail scraper
-            # validation, the miner is uploading fab data even if aggregate
-            # success rate looks ok.
-            failed_file_ratio = scraper_result.get('failed_file_ratio', 0.0)
-            files_inspected = scraper_result.get('files_inspected', 0)
-            if files_inspected > 0 and failed_file_ratio > self.SCRAPER_MAX_FAILED_FILE_RATIO:
-                files_failed = scraper_result.get('files_failed', 0)
-                issues.append(
-                    f"Per-file scraper failure: {files_failed}/{files_inspected} files "
-                    f"({failed_file_ratio*100:.1f}%)"
-                )
 
             # Compression exploit detection — always fail
             if compression_failures > 0:
@@ -1172,18 +1152,6 @@ class DuckDBSampledValidator:
             (not has_time or time_matches)
         )
 
-    # Per-file scraper validation tuning.
-    # The fab cluster mixes ~5% real "bait" SMALL files with ~95% BIG fab files.
-    # Old behavior: collect entities from sampled_files in order until budget,
-    # then break — only 6-8 files inspected of ~50 sampled. Bait at the front of
-    # the shuffle → all entities came from real bait → cluster passed.
-    # New behavior: pre-pick N files uniformly, K entities per file, no break.
-    # Each file is judged on its own scraper results. Cluster can't hide BIG
-    # fab files behind a few real bait ones.
-    SCRAPER_ENTITIES_PER_FILE = 2          # entities pulled per scraper-sampled file
-    SCRAPER_PER_FILE_MIN_PASS = 0.50       # ≥50% of a file's entities must pass scraper
-    SCRAPER_MAX_FAILED_FILE_RATIO = 0.30   # whole miner fails if >30% of scraper-sampled files failed
-
     async def _perform_scraper_validation(
         self,
         miner_hotkey: str,
@@ -1192,43 +1160,13 @@ class DuckDBSampledValidator:
         presigned_urls: Dict[str, str],
         num_entities: int = 10
     ) -> Dict[str, Any]:
-        """Validate random entities using real scrapers, with PER-FILE accounting.
+        """Validate random entities using real scrapers."""
+        all_entities = []
 
-        Routing:
-          - Pre-pick min(len(sampled_files), num_entities // SCRAPER_ENTITIES_PER_FILE)
-            files uniformly at random from sampled_files.
-          - Read SCRAPER_ENTITIES_PER_FILE entities from each (= num_entities total).
-          - No break-mid-loop. Every chosen file gets inspected.
-          - Per-file verdict: a file passes if ≥SCRAPER_PER_FILE_MIN_PASS of its
-            entities verify. Returns failed_file_ratio so the caller can drop
-            failed files' rows or whole-miner-fail.
+        for file_info in sampled_files:
+            if len(all_entities) >= num_entities * 2:
+                break
 
-        Apify cost is bounded by num_entities (unchanged budget).
-        """
-        # Number of files to actually pull entities from.
-        # For num_entities=20, ENTITIES_PER_FILE=2 → 10 files inspected.
-        files_to_inspect = min(
-            len(sampled_files),
-            max(1, num_entities // self.SCRAPER_ENTITIES_PER_FILE),
-        )
-        if files_to_inspect == 0 or not sampled_files:
-            return {
-                'entities_validated': 0,
-                'entities_passed': 0,
-                'success_rate': 0,
-                'sample_results': [],
-                'files_inspected': 0,
-                'files_failed': 0,
-                'failed_file_ratio': 0.0,
-            }
-
-        # Uniform pre-pick — no positional bias from caller's shuffle.
-        files_pool = random.sample(sampled_files, files_to_inspect)
-
-        # entities_per_file[file_key] = list[(entity, platform, job_id)]
-        entities_per_file: Dict[str, list] = {}
-
-        for file_info in files_pool:
             # Skip oversized files to prevent OOM
             file_size = file_info.get('size', 0)
             if file_size > self.MAX_FILE_SIZE_BYTES:
@@ -1278,26 +1216,22 @@ class DuckDBSampledValidator:
                 if required - available_cols:
                     continue
 
-                # Read 1 random row group, take SCRAPER_ENTITIES_PER_FILE rows.
+                # Read 1 random row group via Range requests (~3MB vs full scan)
                 df = read_random_row_group(
                     presigned_url, file_size,
-                    columns=None, max_rows=self.SCRAPER_ENTITIES_PER_FILE,
+                    columns=None, max_rows=5
                 )
 
                 if df is None or len(df) == 0:
                     continue
 
-                file_entities = []
                 for _, row in df.iterrows():
                     entity = self._create_data_entity(row, platform)
                     if entity:
-                        file_entities.append((entity, platform, job_id))
-
-                if file_entities:
-                    entities_per_file[file_key] = file_entities
+                        all_entities.append((entity, platform, job_id))
 
                 del df
-            except Exception:
+            except:
                 continue
             finally:
                 if conn:
@@ -1306,74 +1240,43 @@ class DuckDBSampledValidator:
                     except:
                         pass
 
-        if not entities_per_file:
-            return {
-                'entities_validated': 0,
-                'entities_passed': 0,
-                'success_rate': 0,
-                'sample_results': [],
-                'files_inspected': 0,
-                'files_failed': 0,
-                'failed_file_ratio': 0.0,
-            }
+        if not all_entities:
+            return {'entities_validated': 0, 'entities_passed': 0, 'success_rate': 0, 'sample_results': []}
 
-        # Batch all entities by platform for the Apify call (cost-efficient),
-        # but track which file each result came from.
-        entity_records = []  # list of (file_key, entity, platform, job_id)
-        for file_key, file_entities in entities_per_file.items():
-            for entity, platform, job_id in file_entities:
-                entity_records.append((file_key, entity, platform, job_id))
+        entities_to_validate = random.sample(all_entities, min(num_entities, len(all_entities)))
 
-        # Group by platform for the scraper call
-        by_platform = {}
-        for fk, entity, platform, job_id in entity_records:
-            by_platform.setdefault(platform, []).append((fk, entity, job_id))
-
-        # entity_results: file_key -> list[(passed: bool, reason: str)]
-        per_file_results: Dict[str, list] = {fk: [] for fk in entities_per_file}
+        total_validated = 0
+        total_passed = 0
         sample_results = []
 
-        for platform, recs in by_platform.items():
-            entities = [r[1] for r in recs]
-            file_keys = [r[0] for r in recs]
-            job_ids = [r[2] for r in recs]
+        entities_by_platform = {}
+        for entity, platform, job_id in entities_to_validate:
+            if platform not in entities_by_platform:
+                entities_by_platform[platform] = []
+            entities_by_platform[platform].append((entity, job_id))
+
+        for platform, entities_with_jobs in entities_by_platform.items():
+            entities = [e[0] for e in entities_with_jobs]
+            job_ids = [e[1] for e in entities_with_jobs]
             try:
                 results = await self._validate_with_scraper(entities, platform)
                 for i, result in enumerate(results):
-                    fk = file_keys[i]
-                    jid = job_ids[i] if i < len(job_ids) else 'unknown'
-                    per_file_results[fk].append((result.is_valid, result.reason))
-                    mark = '✅' if result.is_valid else '❌'
-                    sample_results.append(f"{mark} {platform} ({jid[:16]}): {result.reason}")
+                    job_id = job_ids[i] if i < len(job_ids) else 'unknown'
+                    total_validated += 1
+                    if result.is_valid:
+                        total_passed += 1
+                        sample_results.append(f"✅ {platform} ({job_id[:16]}): {result.reason}")
+                    else:
+                        sample_results.append(f"❌ {platform} ({job_id[:16]}): {result.reason}")
             except Exception as e:
-                # On scraper error, mark every entity in this platform batch as failed
-                for fk in file_keys:
-                    per_file_results[fk].append((False, f"scraper error: {e}"))
+                total_validated += len(entities)
                 sample_results.append(f"❌ {platform}: Scraper error - {e}")
 
-        # Per-file verdict
-        files_inspected = len(per_file_results)
-        files_failed = 0
-        total_validated = 0
-        total_passed = 0
-        for fk, results in per_file_results.items():
-            if not results:
-                continue
-            passed = sum(1 for ok, _ in results if ok)
-            total_validated += len(results)
-            total_passed += passed
-            file_pass_rate = passed / len(results)
-            if file_pass_rate < self.SCRAPER_PER_FILE_MIN_PASS:
-                files_failed += 1
-
         success_rate = (total_passed / total_validated * 100) if total_validated > 0 else 0
-        failed_file_ratio = (files_failed / files_inspected) if files_inspected > 0 else 0.0
 
         # Log detailed results for miners to debug
         bt.logging.success(
-            f"{miner_hotkey}: S3 scraper validation finished: "
-            f"{total_passed}/{total_validated} entities passed ({success_rate:.1f}%), "
-            f"{files_failed}/{files_inspected} files failed ({failed_file_ratio*100:.1f}%)"
+            f"{miner_hotkey}: S3 scraper validation finished: {total_passed}/{total_validated} passed ({success_rate:.1f}%)"
         )
         bt.logging.info(
             f"{miner_hotkey}: S3 scraper validation details: {sample_results}"
@@ -1383,10 +1286,7 @@ class DuckDBSampledValidator:
             'entities_validated': total_validated,
             'entities_passed': total_passed,
             'success_rate': success_rate,
-            'sample_results': sample_results,
-            'files_inspected': files_inspected,
-            'files_failed': files_failed,
-            'failed_file_ratio': failed_file_ratio,
+            'sample_results': sample_results
         }
 
     def _create_data_entity(self, row, platform: str) -> Optional[DataEntity]:


### PR DESCRIPTION
## Changes

`vali_utils/s3_utils.py::_perform_scraper_validation`:
- Fail scraper validation when entity construction returns `None` (sampled rows can no longer disappear silently).
- Sort sampled files BIG-first.

`vali_utils/s3_utils.py::_create_twitter_entity`:
- `in_reply_to_user_id` is `None` for non-reply tweets (was always coerced to `str`, inflating claimed bytes and rejecting honest replies).
- Log the exception when entity construction fails, so miners can see why their rows were dropped.

`rewards/miner_scorer.py`:
- Bump `STATE_VERSION` to 11. One-shot reset of `s3_boosts`, `s3_credibility`, `effective_sizes` on first load.