### PR TITLE
fix the poisoned data skip via scraped at field

### DIFF
--- a/rewards/miner_scorer.py
+++ b/rewards/miner_scorer.py
@@ -30,7 +30,7 @@ class MinerScorer:
     #      hex-pad, synthetic users, short status IDs, within-file dup) catches the
     #      164-hotkey sybil cluster; pre-fix effective_size/credibility is inflated by
     #      fabricated bulk uploads.
-    STATE_VERSION = 11
+    STATE_VERSION = 12
 
     # Start new miner's at a credibility of 0.
     STARTING_CREDIBILITY = 0
@@ -136,11 +136,10 @@ class MinerScorer:
             self.effective_sizes = state.get("effective_sizes", torch.zeros(self.scores.size(0), dtype=torch.float64))
 
             # --- State migrations ---
-            if saved_version < 11:
+            if saved_version < 12:
                 bt.logging.warning(
-                    f"State migration v{saved_version} -> v11: "
-                    f"S3 boost/credibility/effective_size reset "
-                    f"(per-file fabrication detection)."
+                    f"State migration v{saved_version} -> v12: "
+                    f"S3 boost/credibility/effective_size reset."
                 )
                 self.s3_boosts.zero_()
                 self.s3_credibility.fill_(MinerScorer.STARTING_S3_CREDIBILITY)

--- a/vali_utils/s3_utils.py
+++ b/vali_utils/s3_utils.py
@@ -755,7 +755,8 @@ class DuckDBSampledValidator:
                     bt.logging.warning(
                         f"scraped_at must be string: {file_key}"
                     )
-                    continue
+                    schema_failures += 1
+                    break
 
                 # --- Per-job dedup: read ALL urls via DuckDB (columnar read, ~500KB per file) ---
                 if job_id not in dedup_hashes_by_job:

--- a/vali_utils/s3_utils.py
+++ b/vali_utils/s3_utils.py
@@ -900,9 +900,16 @@ class DuckDBSampledValidator:
         duplicate_rate = (dedup_duplicates / dedup_total * 100) if dedup_total > 0 else 0.0
         if duplicate_rate > self.MAX_DUPLICATE_RATE:
             bt.logging.warning(
-                f"Per-job dedup: {duplicate_rate:.1f}% duplicates "
+                f"Per-job dedup FAILED: {duplicate_rate:.1f}% duplicates "
                 f"({dedup_duplicates}/{dedup_total} urls across {len(dedup_hashes_by_job)} jobs)"
             )
+            return {
+                "success": False,
+                "duplicate_rate_within_job": duplicate_rate,
+                "empty_rate": 100.0,
+                "total_rows": 0,
+                "reason": f"High duplicate rate: {duplicate_rate:.1f}% (max {self.MAX_DUPLICATE_RATE}%)"
+            }
 
         # Engagement check (X only): legit scrapers always return view_count
         engagement_rate = 0.0
@@ -1479,6 +1486,21 @@ class DuckDBSampledValidator:
             else:
                 created_at = dt.datetime.now(dt.timezone.utc)
 
+            # Handle media array field (same robust handling as _create_twitter_entity)
+            raw_media = row.get('media', None)
+            if raw_media is None:
+                media_value = None
+            elif hasattr(raw_media, '__iter__') and not isinstance(raw_media, str):
+                try:
+                    media_value = list(raw_media)
+                except TypeError:
+                    media_value = None
+            else:
+                try:
+                    media_value = None if pd.isna(raw_media) else [raw_media]
+                except Exception:
+                    media_value = [raw_media]
+
             reddit_content = RedditContent(
                 id=reddit_id_str,
                 username=username_str,
@@ -1489,7 +1511,7 @@ class DuckDBSampledValidator:
                 dataType=str(row.get('dataType', 'post') or 'post'),
                 parentId=str(row.get('parentId')) if row.get('parentId') and pd.notna(row.get('parentId')) else None,
                 title=str(row.get('title', '')) if pd.notna(row.get('title')) else None,
-                media=row.get('media', None) if pd.notna(row.get('media')) else None,
+                media=media_value,
                 is_nsfw=bool(row.get('is_nsfw', False)) if pd.notna(row.get('is_nsfw')) else None,
                 score=int(row.get('score', 0)) if pd.notna(row.get('score')) else None,
                 upvote_ratio=float(row.get('upvote_ratio', 0.0)) if pd.notna(row.get('upvote_ratio')) else None,


### PR DESCRIPTION
## Changes

`vali_utils/s3_utils.py`
- Non-string `scraped_at`/`scrapedat` now fails the miner (was silently skipped, letting INT64-typed files bypass dedup/uniqueness while still counting rows).
- Per-job duplicate rate now fails validation when above `MAX_DUPLICATE_RATE` (was log-only).
- `_create_reddit_entity`: array-safe `media` handling (a list/array `media` raised `truth value of an array is ambiguous`, returned `None`, and wrongly failed honest miners at 0% scraper success).

`rewards/miner_scorer.py`
- Bump `STATE_VERSION` to 12: one-shot reset of `s3_boosts`, `s3_credibility`, `effective_sizes` (pre-fix scores are inflated by duplicate bulk uploads).