### PR TITLE
fix(s3-validation): don't decay miner credibility on validator-side API failures (#805)

### DIFF
--- a/tests/vali_utils/test_s3_infra_error_805.py
+++ b/tests/vali_utils/test_s3_infra_error_805.py
@@ -1,0 +1,67 @@
+import sys, asyncio
+sys.path.insert(0, '/tmp/du-pr-805')
+import vali_utils.validator_s3_access as vsa
+from vali_utils.validator_s3_access import ValidatorS3Access, S3InfraError
+
+HK = "HK"
+
+def xml_page(keys, is_truncated, token=None):
+    contents = "".join(
+        f'<Contents><Key>data/hotkey={HK}/job_id=1/{k}.parquet</Key>'
+        f'<Size>20000</Size><LastModified>2026-01-01</LastModified></Contents>'
+        for k in keys
+    )
+    trunc = 'true' if is_truncated else 'false'
+    tok = f'<NextContinuationToken>{token}</NextContinuationToken>' if token else ''
+    return (f'<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
+            f'{contents}<IsTruncated>{trunc}</IsTruncated>{tok}</ListBucketResult>')
+
+class FakeResp:
+    def __init__(self, status, text):
+        self.status_code = status
+        self.text = text
+
+_gseq = {'seq': []}
+vsa.requests.get = lambda url, timeout=None: _gseq['seq'].pop(0)
+
+def make_obj(presign_seq):
+    o = object.__new__(ValidatorS3Access)
+    pseq = list(presign_seq)
+    async def _presign(hk, tok=None):
+        return pseq.pop(0)
+    o._request_presigned_list_url = _presign
+    return o
+
+async def run_case(name, presign_seq, get_seq, expect):
+    o = make_obj(presign_seq)
+    _gseq['seq'] = list(get_seq)
+    try:
+        files = await o.list_all_files_with_metadata(HK)
+        outcome = ('return', len(files))
+    except S3InfraError:
+        outcome = ('raise', 'S3InfraError')
+    except Exception as e:
+        outcome = ('raise', type(e).__name__)
+    ok = (outcome[0] == expect[0]) and (expect[1] is None or outcome[1] == expect[1])
+    print(f"{'PASS' if ok else 'FAIL'} | {name}: got {outcome}, expected {expect}")
+    return ok
+
+async def main():
+    oks = []
+    # A: API unreachable on page 1 (presign None) -> infra raise (NOT empty return)
+    oks.append(await run_case("A API-unreachable->raise", [None], [], ('raise','S3InfraError')))
+    # B: genuine empty listing (200, IsTruncated=false, 0 files) -> return [] (NOT raise)
+    oks.append(await run_case("B genuine-empty->return[]", ["u1"], [FakeResp(200, xml_page([], False))], ('return',0)))
+    # C: normal 2 files, complete -> return 2
+    oks.append(await run_case("C normal-2files->return2", ["u1"], [FakeResp(200, xml_page(['a','b'], False))], ('return',2)))
+    # D: partial pagination (page1 truncated=true, page2 presign fails) -> infra raise  [Gemini-caught case]
+    oks.append(await run_case("D partial-pagination->raise", ["u1", None],
+                              [FakeResp(200, xml_page(['a'], True, 'TOK'))], ('raise','S3InfraError')))
+    # E: 503 on page1 -> infra raise
+    oks.append(await run_case("E 503->raise", ["u1"], [FakeResp(503, 'err')], ('raise','S3InfraError')))
+    # F: unparseable XML on page1 -> infra raise
+    oks.append(await run_case("F bad-xml->raise", ["u1"], [FakeResp(200, 'NOT XML <')], ('raise','S3InfraError')))
+    print(f"\nRESULT: {sum(oks)}/{len(oks)} passed")
+    sys.exit(0 if all(oks) else 1)
+
+asyncio.run(main())

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -511,12 +511,20 @@ class MinerEvaluator:
                     f"Reason: {s3_validation_result.reason}"
                 )
 
-            # Update scorer with competition-based effective_size
-            self.scorer.update_s3_effective_size(
-                uid=uid,
-                effective_size=s3_validation_result.effective_size_bytes,
-                validation_passed=s3_validation_result.is_valid,
-            )
+            # Update scorer with competition-based effective_size.
+            # Skip the update entirely on a validator-side API failure (#805): a timeout/5xx
+            # in our own S3 listing/presign service must not decay the miner's credibility.
+            if s3_validation_result.infra_error:
+                bt.logging.warning(
+                    f"UID:{uid} - HOTKEY:{hotkey}: S3 validation hit a validator-side API error; "
+                    f"leaving S3 credibility unchanged ({s3_validation_result.reason})"
+                )
+            else:
+                self.scorer.update_s3_effective_size(
+                    uid=uid,
+                    effective_size=s3_validation_result.effective_size_bytes,
+                    validation_passed=s3_validation_result.is_valid,
+                )
 
     async def _perform_s3_validation(
         self, uid: int, hotkey: str, current_block: int

--- a/vali_utils/s3_utils.py
+++ b/vali_utils/s3_utils.py
@@ -27,6 +27,7 @@ from scraping.reddit.model import RedditContent
 from common.data import DataEntity, DataSource
 from common.api_client import TaoSigner
 from vali_utils.parquet_reader import read_random_row_group
+from vali_utils.validator_s3_access import S3InfraError
 from urllib.parse import urlparse
 
 
@@ -118,6 +119,10 @@ class S3ValidationResult:
     # Competition-based scoring: effective_size = total_size_bytes × coverage²
     effective_size_bytes: float = 0.0
     job_coverage_rate: float = 0.0
+
+    # True ⇒ failure was a validator-side API error (issue #805); caller must NOT
+    # update miner credibility on this result.
+    infra_error: bool = False
 
 
 # Mapping of scrapers to use based on the data source to validate
@@ -519,6 +524,12 @@ class DuckDBSampledValidator:
                 job_coverage_rate=job_coverage_rate
             )
 
+        except S3InfraError as e:
+            # Validator-side API failure (list or presign). Do NOT penalize the miner. (#805)
+            bt.logging.warning(
+                f"{miner_hotkey}: validator-side S3 API error — credibility left unchanged: {e}"
+            )
+            return self._create_failed_result(f"S3 infra error: {e}", infra_error=True)
         except Exception as e:
             bt.logging.error(f"{miner_hotkey}: DuckDB validation error: {str(e)}")
             return self._create_failed_result(f"Validation error: {str(e)}")
@@ -561,11 +572,22 @@ class DuckDBSampledValidator:
                             all_urls[key] = data['presigned_url']
                         elif isinstance(data, str):
                             all_urls[key] = data
+                elif response.status_code >= 500:
+                    # Server-side failure of the validator's presign API — infra, not the
+                    # miner's fault. Surface as S3InfraError so credibility is left unchanged (#805).
+                    raise S3InfraError(
+                        f"get-file-presigned-urls {response.status_code} (server-side)"
+                    )
                 else:
+                    # 4xx — request/data problem; treat as a genuine validation failure.
                     bt.logging.warning(
                         f"get-file-presigned-urls failed: {response.status_code}"
                     )
 
+            except S3InfraError:
+                raise  # propagate to the validate-level handler (#805)
+            except (requests.exceptions.Timeout, requests.exceptions.ConnectionError) as e:
+                raise S3InfraError(f"get-file-presigned-urls network error: {e}")
             except Exception as e:
                 bt.logging.warning(f"Presigned URL batch error: {e}")
 
@@ -1553,8 +1575,12 @@ class DuckDBSampledValidator:
         except:
             return None
 
-    def _create_failed_result(self, reason: str) -> S3ValidationResult:
-        """Create a failed validation result."""
+    def _create_failed_result(self, reason: str, infra_error: bool = False) -> S3ValidationResult:
+        """Create a failed validation result.
+
+        infra_error=True marks a validator-side API failure (issue #805) so the
+        caller leaves miner credibility unchanged instead of penalizing.
+        """
         return S3ValidationResult(
             is_valid=False,
             validation_percentage=0.0,
@@ -1576,7 +1602,8 @@ class DuckDBSampledValidator:
             sample_validation_results=[],
             sample_job_mismatches=[],
             effective_size_bytes=0.0,
-            job_coverage_rate=0.0
+            job_coverage_rate=0.0,
+            infra_error=infra_error
         )
 
     def close(self):

--- a/vali_utils/validator_s3_access.py
+++ b/vali_utils/validator_s3_access.py
@@ -9,6 +9,13 @@ import asyncio
 from common.api_client import TaoSigner
 
 
+class S3InfraError(Exception):
+    """Raised when the validator's own S3 listing/presign API is unreachable or the
+    listing did not complete. Distinct from a miner genuinely having no data — callers
+    MUST NOT decay miner credibility on this (issue #805)."""
+    pass
+
+
 class ValidatorS3Access:
     """S3 access for validators — lists miner files via presigned URLs."""
 
@@ -70,6 +77,7 @@ class ValidatorS3Access:
             continuation_token = None
             page = 1
             max_pages = 200
+            pagination_completed = False  # True only on natural end (IsTruncated=false)
 
             loop = asyncio.get_event_loop()
 
@@ -124,6 +132,7 @@ class ValidatorS3Access:
 
                 is_trunc = root.find(".//s3:IsTruncated", namespaces)
                 if is_trunc is None or str(is_trunc.text).lower() != "true":
+                    pagination_completed = True  # read every page successfully
                     break
 
                 token_elem = root.find(".//s3:NextContinuationToken", namespaces)
@@ -133,11 +142,22 @@ class ValidatorS3Access:
                 continuation_token = token_elem.text
                 page += 1
 
+            if not pagination_completed:
+                # Listing stopped early (presign/API failure, parse error, or hit
+                # max_pages while IsTruncated=true). Treat as validator-side infra,
+                # NOT as "miner has no/partial data" — see issue #805.
+                raise S3InfraError(
+                    f"S3 listing did not complete for {miner_hotkey} "
+                    f"(stopped at page {page}/{max_pages})"
+                )
+
             bt.logging.info(
                 f"S3 listing complete: {len(all_files)} files across {page} pages for {miner_hotkey}"
             )
             return all_files
 
+        except S3InfraError:
+            raise  # propagate — do not swallow into []
         except Exception as e:
             bt.logging.error(f"Exception in list_all_files_with_metadata: {str(e)}")
-            return []
+            raise S3InfraError(f"S3 listing failed for {miner_hotkey}: {e}")


### PR DESCRIPTION
Fixes #805.

When the validator's own S3 API calls (`get-miner-list`, `get-file-presigned-urls`) time out or return 5xx, the current code can't distinguish that from a miner having no/invalid data — both yield `is_valid=False` and decay `s3_credibility` via the EMA (`rewards/miner_scorer.py:308-312`). Per #805 these errors run into the hundreds/day, so honest miners silently bleed credibility and can deregister through no fault of their own.

**What this changes**
- Adds a typed `S3InfraError` (`vali_utils/validator_s3_access.py`), raised when the S3 listing/presign API is unreachable or pagination doesn't complete.
- Adds an `infra_error` flag on `S3ValidationResult`; `_create_failed_result(..., infra_error=True)` carries it.
- The evaluator skips the credibility update when `infra_error` is set, leaving the miner's credibility unchanged instead of penalizing.
- Distinguishes 5xx/timeout (validator-side → neutral) from 4xx (treated as a genuine failure, unchanged).

**Why it's safe**
- No scoring-math changes. On a genuine data verdict, behavior is identical to today.
- Ungameable: `infra_error` is set only when the validator's *own* calls to the S3 API fail (5xx/timeout). A miner cannot induce that; 4xx, genuine-empty, and parser-crash paths still penalize.
- Also fixes a partial-pagination case where an incomplete listing previously scored the miner on truncated data.

**Tests:** `tests/vali_utils/test_s3_infra_error_805.py` covers the infra-vs-genuine-empty distinction, partial pagination, 5xx, and unparseable-XML cases.
