### PR TITLE
redact filenames from sampled-validation warning logs

### DIFF
--- a/vali_utils/s3_utils.py
+++ b/vali_utils/s3_utils.py
@@ -922,16 +922,16 @@ class DuckDBSampledValidator:
 
             except (duckdb.IOException, duckdb.HTTPException, duckdb.ConnectionException) as e:
                 # Transient S3/network errors — log and skip, do NOT fail the miner
-                bt.logging.warning(f"Transient S3/IO error on {file_key}: {type(e).__name__}: {e}")
+                bt.logging.warning(f"Transient S3/IO error: {type(e).__name__}: {e}")
                 continue
             except (duckdb.Error, pyarrow.lib.ArrowInvalid, pyarrow.lib.ArrowIOError) as e:
                 page_decode_failures += 1
                 bt.logging.warning(
-                    f"Page-decode failure on {file_key}: {type(e).__name__}: {e}"
+                    f"Page-decode failure: {type(e).__name__}: {e}"
                 )
                 continue
             except Exception as e:
-                bt.logging.warning(f"Sampled validation error for {file_key}: {e}")
+                bt.logging.warning(f"Sampled validation error: {e}")
                 continue
             finally:
                 if conn:


### PR DESCRIPTION
Drops file_key from three warning logs in _sampled_duckdb_validation: Transient S3/IO error, Page-decode failure, Sampled validation error. Keeps error type + message — sufficient to diagnose Snappy/UTF-8 decode failures without leaking miner file paths.