### PR TITLE
fix(s3-validation): don't penalize miners for validator-side scraper failures

### DIFF
--- a/tests/vali_utils/test_s3_scraper_error_infra_neutral.py
+++ b/tests/vali_utils/test_s3_scraper_error_infra_neutral.py
@@ -1,0 +1,103 @@
+"""Regression test: a validator-side scraper failure must NOT zero an honest miner.
+
+Companion to the on-demand infra-neutral fix (#844) and the S3-API one (#805/#843),
+on the S3 scraper-validation path.
+
+Before the fix, the `except` in DuckDBSampledValidator._perform_scraper_validation did
+`total_validated += len(entities)` without incrementing total_passed, so when the
+VALIDATOR's own scraper timed out / 5xx'd / rate-limited, those entities counted as
+scraper *failures*. With MIN_SCRAPER_SUCCESS=80%, a validator-side scraper outage then
+drove success_rate below the threshold -> is_valid=False -> effective_size=0, collapsing
+an honest miner's S3 score on the validator's infra failure.
+
+After the fix, an all-errored validation returns success_rate=None, which the caller
+already treats as "skip the success-rate gate and rely on prior-cycle credibility".
+
+Run: python -m pytest tests/vali_utils/test_s3_scraper_error_infra_neutral.py
+ or: python tests/vali_utils/test_s3_scraper_error_infra_neutral.py
+"""
+import asyncio
+import pandas as pd
+
+import vali_utils.s3_utils as s3m
+from vali_utils.s3_utils import DuckDBSampledValidator
+from scraping.scraper import ValidationResult
+
+
+class _FakeConn:
+    """Minimal duckdb connection stub: returns the expected reddit schema columns."""
+    def __init__(self, names):
+        self._names = names
+
+    def execute(self, _query):
+        return self
+
+    def fetchall(self):
+        return [(n,) for n in self._names]
+
+    def close(self):
+        pass
+
+
+def _make_validator(scraper_raises: bool):
+    v = object.__new__(DuckDBSampledValidator)  # bypass __init__ (no network deps)
+
+    async def _validate(entities, platform):
+        if scraper_raises:
+            raise RuntimeError("simulated validator-side scraper outage (5xx/timeout)")
+        return [ValidationResult(is_valid=True, content_size_bytes_validated=1,
+                                 reason="ok") for _ in entities]
+
+    v._validate_with_scraper = _validate
+    v._create_data_entity = lambda row, platform: object()  # non-None sentinel entity
+    return v
+
+
+def _runsync(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+async def _run(scraper_raises: bool):
+    v = _make_validator(scraper_raises)
+    cols = list(DuckDBSampledValidator.EXPECTED_COLUMNS_REDDIT)
+    # Make one reddit entity flow through the file loop without touching the network:
+    s3m.duckdb.connect = lambda *a, **k: _FakeConn(cols)
+    s3m.read_random_row_group = lambda *a, **k: pd.DataFrame([{c: "x" for c in cols}])
+    sampled_files = [{'key': 'data/hotkey=HK/job_id=J1/f.parquet', 'size': 20000}]
+    presigned = {'data/hotkey=HK/job_id=J1/f.parquet': 'http://fake/f.parquet'}
+    expected_jobs = {'J1': {'params': {'platform': 'reddit'}}}
+    return await v._perform_scraper_validation('HK', sampled_files, expected_jobs,
+                                               presigned, num_entities=2)
+
+
+def test_scraper_error_yields_none_success_rate():
+    """Validator-side scraper outage -> success_rate None (gate skipped), not 0 (fail)."""
+    result = _runsync(_run(scraper_raises=True))
+    assert result['success_rate'] is None, (
+        f"expected None on validator-side scraper error, got {result['success_rate']}")
+
+
+def test_scraper_ok_yields_pass_rate():
+    """Healthy scraper -> a real numeric success_rate (regression guard)."""
+    result = _runsync(_run(scraper_raises=False))
+    assert result['success_rate'] == 100.0, (
+        f"expected 100.0 on all-valid, got {result['success_rate']}")
+
+
+if __name__ == "__main__":
+    ok = True
+    for name, fn in [("scraper-error->None", test_scraper_error_yields_none_success_rate),
+                     ("scraper-ok->100.0", test_scraper_ok_yields_pass_rate)]:
+        try:
+            fn()
+            print(f"PASS | {name}")
+        except AssertionError as e:
+            ok = False
+            print(f"FAIL | {name}: {e}")
+    import sys
+    print(f"\nRESULT: {'ALL PASS' if ok else 'FAILED'}")
+    sys.exit(0 if ok else 1)

--- a/vali_utils/s3_utils.py
+++ b/vali_utils/s3_utils.py
@@ -1399,6 +1399,7 @@ class DuckDBSampledValidator:
                 entities_by_platform[platform] = []
             entities_by_platform[platform].append((entity, job_id))
 
+        scraper_errored = False
         for platform, entities_with_jobs in entities_by_platform.items():
             entities = [e[0] for e in entities_with_jobs]
             job_ids = [e[1] for e in entities_with_jobs]
@@ -1413,14 +1414,28 @@ class DuckDBSampledValidator:
                     else:
                         sample_results.append(f"❌ {platform} ({job_id[:16]}): {result.reason}")
             except Exception as e:
-                total_validated += len(entities)
-                sample_results.append(f"❌ {platform}: Scraper error - {e}")
+                # A validator-side scraper failure (timeout / 5xx / rate-limit / network)
+                # is NOT a miner data failure. Counting these entities as validated would
+                # drive success_rate below MIN_SCRAPER_SUCCESS during an outage in the
+                # VALIDATOR's own scraper, zeroing an honest miner's effective_size. Skip
+                # them instead — same infra-neutral handling as the on-demand path (#844).
+                scraper_errored = True
+                sample_results.append(f"⚠️ {platform}: Scraper error (validator-side, not counted) - {e}")
 
-        success_rate = (total_passed / total_validated * 100) if total_validated > 0 else 0
+        if total_validated > 0:
+            success_rate = total_passed / total_validated * 100
+        elif scraper_errored:
+            # Every scraper call errored: return None so the caller skips the success-rate
+            # gate and relies on prior-cycle credibility, rather than treating the
+            # validator's infra failure as a 0% miner score. (Caller already handles None.)
+            success_rate = None
+        else:
+            success_rate = 0
 
         # Log detailed results for miners to debug
+        success_rate_display = success_rate if success_rate is not None else -1.0
         bt.logging.success(
-            f"{miner_hotkey}: S3 scraper validation finished: {total_passed}/{total_validated} passed ({success_rate:.1f}%)"
+            f"{miner_hotkey}: S3 scraper validation finished: {total_passed}/{total_validated} passed ({success_rate_display:.1f}%)"
         )
         bt.logging.info(
             f"{miner_hotkey}: S3 scraper validation details: {sample_results}"


### PR DESCRIPTION
In `DuckDBSampledValidator._perform_scraper_validation`, a failure in the **validator's own** scraper is currently counted as a miner data failure:

```python
except Exception as e:
    total_validated += len(entities)          # counted, but never total_passed
    sample_results.append(f"❌ {platform}: Scraper error - {e}")
```

When the validator-side scraper times out / 5xx's / rate-limits, those entities count as scraper-validation failures. With `MIN_SCRAPER_SUCCESS = 80.0`, an outage in the validator's scraper drives `success_rate` below the threshold → `is_valid = False` → `effective_size = 0`, collapsing an **honest** miner's S3 score because of the validator's infrastructure, not the data.

This is the same pattern already fixed for the on-demand path in #844 and for the S3 listing API in #805 — this PR extends it to the S3 scraper-validation path.

**Change:** an errored scraper batch is no longer counted toward `total_validated`. If every batch errored, `success_rate` returns `None` — which the caller already handles (it skips the `MIN_SCRAPER_SUCCESS` gate and relies on prior-cycle credibility, exactly like the existing "no recent files" path). A genuine miner data failure still fails normally; only validator-side scraper exceptions are treated as "couldn't validate" rather than "miner failed".

**Test:** `tests/vali_utils/test_s3_scraper_error_infra_neutral.py` — two cases:
- validator-side scraper raises → `success_rate is None` (gate skipped), not `0` (fail)
- healthy scraper → real numeric `success_rate` (regression guard)

No behavior change for honest data on a healthy validator; this only removes a credibility-decay vector triggered by the validator's own transient scraper failures.
