### PR TITLE
feat: route S3 validation through data-universe-api (publisher/fetcher). Get only latest file for validation

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -35,6 +35,7 @@ from dynamic_desirability.desirability_retrieval import run_retrieval_from_api
 from neurons import __spec_version__ as spec_version
 from common.api_client import DataUniverseApiClient
 from vali_utils.validator_s3_access import ValidatorS3Access
+from vali_utils.s3_validation_results_client import S3ValidationResultsClient
 from rewards.data_value_calculator import DataValueCalculator
 from rich.table import Table
 from rich.console import Console
@@ -743,8 +744,15 @@ def main():
     metagraph_syncer.start()
 
     s3_reader = ValidatorS3Access(wallet=wallet, s3_auth_url=config.s3_auth_url)
+    s3_results_client = S3ValidationResultsClient(
+        wallet=wallet, api_base_url=config.s3_auth_url
+    )
     evaluator = MinerEvaluator(
-        config=config, uid=uid, metagraph_syncer=metagraph_syncer, s3_reader=s3_reader
+        config=config,
+        uid=uid,
+        metagraph_syncer=metagraph_syncer,
+        s3_reader=s3_reader,
+        s3_results_client=s3_results_client,
     )
 
     with Validator(

--- a/rewards/miner_scorer.py
+++ b/rewards/miner_scorer.py
@@ -30,7 +30,7 @@ class MinerScorer:
     #      hex-pad, synthetic users, short status IDs, within-file dup) catches the
     #      164-hotkey sybil cluster; pre-fix effective_size/credibility is inflated by
     #      fabricated bulk uploads.
-    STATE_VERSION = 13
+    STATE_VERSION = 14
 
     # Start new miner's at a credibility of 0.
     STARTING_CREDIBILITY = 0
@@ -136,9 +136,9 @@ class MinerScorer:
             self.effective_sizes = state.get("effective_sizes", torch.zeros(self.scores.size(0), dtype=torch.float64))
 
             # --- State migrations ---
-            if saved_version < 13:
+            if saved_version < 14:
                 bt.logging.warning(
-                    f"State migration v{saved_version} -> v13: "
+                    f"State migration v{saved_version} -> v14: "
                     f"S3 boost/credibility/effective_size reset"
                 )
                 self.s3_boosts.zero_()

--- a/rewards/miner_scorer.py
+++ b/rewards/miner_scorer.py
@@ -30,7 +30,10 @@ class MinerScorer:
     #      hex-pad, synthetic users, short status IDs, within-file dup) catches the
     #      164-hotkey sybil cluster; pre-fix effective_size/credibility is inflated by
     #      fabricated bulk uploads.
-    STATE_VERSION = 14
+    # v15: Reset S3 — latest-file-per-job validation + whole-job-snapshot miner uploads.
+    #      Old effective_size/credibility was computed across all historical chunks; new
+    #      model counts only the latest snapshot per job, so prior scores are not comparable.
+    STATE_VERSION = 15
 
     # Start new miner's at a credibility of 0.
     STARTING_CREDIBILITY = 0
@@ -136,10 +139,11 @@ class MinerScorer:
             self.effective_sizes = state.get("effective_sizes", torch.zeros(self.scores.size(0), dtype=torch.float64))
 
             # --- State migrations ---
-            if saved_version < 14:
+            if saved_version < 15:
                 bt.logging.warning(
-                    f"State migration v{saved_version} -> v14: "
-                    f"S3 boost/credibility/effective_size reset"
+                    f"State migration v{saved_version} -> v15: "
+                    f"S3 boost/credibility/effective_size reset "
+                    f"(latest-file-per-job validation + whole-job-snapshot uploads)"
                 )
                 self.s3_boosts.zero_()
                 self.s3_credibility.fill_(MinerScorer.STARTING_S3_CREDIBILITY)

--- a/tests/upload_utils/test_s3_uploader_snapshot.py
+++ b/tests/upload_utils/test_s3_uploader_snapshot.py
@@ -1,0 +1,206 @@
+"""Tests for the whole-job-snapshot S3 uploader.
+
+Covers:
+- A job with rows in SQLite produces a single upload call.
+- A job with no matching rows produces zero uploads.
+- max_rows is honored: query LIMIT, no row leakage.
+- processed_state records snapshot stats per job.
+"""
+import asyncio
+import json
+import os
+import sqlite3
+import tempfile
+import datetime as dt
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from common.data import DataSource
+from upload_utils.s3_uploader import S3PartitionedUploader
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _seed_db(db_path: str, rows: list[tuple]) -> None:
+    """Create a DataEntity table and insert (uri, datetime, source, label, content) rows."""
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE DataEntity (
+            uri TEXT PRIMARY KEY,
+            datetime TEXT NOT NULL,
+            source INTEGER NOT NULL,
+            label TEXT,
+            content BLOB
+        )
+        """
+    )
+    conn.executemany(
+        "INSERT INTO DataEntity (uri, datetime, source, label, content) VALUES (?,?,?,?,?)",
+        rows,
+    )
+    conn.commit()
+    conn.close()
+
+
+def _make_uploader(db_path: str, state_path: str) -> S3PartitionedUploader:
+    """Build an uploader without touching subtensor/wallet."""
+    wallet = MagicMock()
+    wallet.hotkey.ss58_address = "5HotKey_xyz"
+
+    uploader = S3PartitionedUploader.__new__(S3PartitionedUploader)
+    uploader.db_path = db_path
+    uploader.wallet = wallet
+    uploader.subtensor = None
+    uploader.miner_hotkey = wallet.hotkey.ss58_address
+    uploader.api_base_url = "http://example.test"
+    uploader.keypair = wallet.hotkey
+    uploader.state_file = state_path
+    uploader.output_dir = tempfile.mkdtemp(prefix="snap_out_")
+    uploader.processed_state = {}
+    return uploader
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def _reddit_content(body: str) -> bytes:
+    return json.dumps({
+        "id": "abc", "username": "u", "communityName": "r/x",
+        "body": body, "title": "t", "createdAt": "2026-06-18T00:00:00Z",
+        "dataType": "comment", "parentId": None, "url": "https://reddit.com/r/x/post/1",
+        "media": None, "is_nsfw": False, "score": 1, "upvote_ratio": 1.0,
+        "num_comments": 0, "scrapedAt": "2026-06-18T00:00:00Z",
+    }).encode()
+
+
+def test_snapshot_uploads_single_file_for_job(tmp_path):
+    """A job with N matching rows produces exactly one _upload_job_snapshot call with N rows."""
+    db = str(tmp_path / "miner.db")
+    state = str(tmp_path / "state.json")
+    rows = [
+        (f"u{i}", f"2026-06-1{i}T00:00:00Z", DataSource.REDDIT.value, "r/python",
+         _reddit_content(f"body {i}"))
+        for i in range(5)
+    ]
+    _seed_db(db, rows)
+    up = _make_uploader(db, state)
+    up._upload_job_snapshot = AsyncMock(return_value=True)
+
+    job_config = {
+        "source": DataSource.REDDIT.value,
+        "type": "label",
+        "value": "r/python",
+        "max_rows": 100,
+    }
+    client = MagicMock()
+    ok = asyncio.run(up._process_job(client, "job-x", job_config))
+
+    assert ok is True
+    assert up._upload_job_snapshot.call_count == 1
+    call_df = up._upload_job_snapshot.call_args.args[1]
+    assert len(call_df) == 5
+    assert up.processed_state["job-x"]["last_snapshot_rows"] == 5
+
+
+def test_snapshot_empty_job_no_upload(tmp_path):
+    """A job with zero matching rows skips upload entirely."""
+    db = str(tmp_path / "miner.db")
+    state = str(tmp_path / "state.json")
+    _seed_db(db, [])
+    up = _make_uploader(db, state)
+    up._upload_job_snapshot = AsyncMock(return_value=True)
+
+    job_config = {
+        "source": DataSource.REDDIT.value,
+        "type": "label",
+        "value": "r/nothing",
+        "max_rows": 100,
+    }
+    client = MagicMock()
+    ok = asyncio.run(up._process_job(client, "job-empty", job_config))
+
+    assert ok is True
+    assert up._upload_job_snapshot.call_count == 0
+    assert "job-empty" not in up.processed_state
+
+
+def test_snapshot_respects_max_rows(tmp_path):
+    """Snapshot SQL LIMIT honors max_rows; only that many rows reach the uploader."""
+    db = str(tmp_path / "miner.db")
+    state = str(tmp_path / "state.json")
+    rows = [
+        (f"u{i}", f"2026-06-{i:02d}T00:00:00Z", DataSource.REDDIT.value, "r/python",
+         _reddit_content(f"body {i}"))
+        for i in range(1, 21)
+    ]
+    _seed_db(db, rows)
+    up = _make_uploader(db, state)
+    up._upload_job_snapshot = AsyncMock(return_value=True)
+
+    job_config = {
+        "source": DataSource.REDDIT.value,
+        "type": "label",
+        "value": "r/python",
+        "max_rows": 7,
+    }
+    client = MagicMock()
+    ok = asyncio.run(up._process_job(client, "job-cap", job_config))
+
+    assert ok is True
+    call_df = up._upload_job_snapshot.call_args.args[1]
+    assert len(call_df) == 7
+    assert up.processed_state["job-cap"]["last_snapshot_rows"] == 7
+
+
+def test_snapshot_uses_default_when_max_rows_missing(tmp_path, monkeypatch):
+    """If job config has no max_rows, DEFAULT_JOB_MAX_ROWS is the LIMIT."""
+    db = str(tmp_path / "miner.db")
+    state = str(tmp_path / "state.json")
+    _seed_db(db, [])
+    up = _make_uploader(db, state)
+    up._upload_job_snapshot = AsyncMock(return_value=True)
+
+    seen_limits = []
+    original = up._get_label_data
+    def spy(source, value, limit):
+        seen_limits.append(limit)
+        return original(source, value, limit)
+    up._get_label_data = spy
+
+    job_config = {
+        "source": DataSource.REDDIT.value,
+        "type": "label",
+        "value": "r/x",
+    }
+    asyncio.run(up._process_job(MagicMock(), "job-default", job_config))
+    assert seen_limits == [S3PartitionedUploader.DEFAULT_JOB_MAX_ROWS]
+
+
+def test_snapshot_propagates_upload_failure(tmp_path):
+    """If the upload call returns False, _process_job returns False and state isn't updated."""
+    db = str(tmp_path / "miner.db")
+    state = str(tmp_path / "state.json")
+    rows = [
+        ("u1", "2026-06-18T00:00:00Z", DataSource.REDDIT.value, "r/python",
+         _reddit_content("body")),
+    ]
+    _seed_db(db, rows)
+    up = _make_uploader(db, state)
+    up._upload_job_snapshot = AsyncMock(return_value=False)
+
+    job_config = {
+        "source": DataSource.REDDIT.value,
+        "type": "label",
+        "value": "r/python",
+        "max_rows": 100,
+    }
+    ok = asyncio.run(up._process_job(MagicMock(), "job-fail", job_config))
+    assert ok is False
+    assert "job-fail" not in up.processed_state

--- a/tests/vali_utils/test_s3_latest_per_job.py
+++ b/tests/vali_utils/test_s3_latest_per_job.py
@@ -1,0 +1,62 @@
+"""Unit test for the per-job latest-only filter in DuckDBSampledValidator."""
+from vali_utils.s3_utils import DuckDBSampledValidator
+
+
+def test_keep_latest_per_job_picks_newest_by_last_modified():
+    files_by_job = {
+        "job-a": [
+            {"key": "data/hotkey=H/job_id=job-a/old.parquet",
+             "size": 100, "last_modified": "2026-06-10T10:00:00.000Z"},
+            {"key": "data/hotkey=H/job_id=job-a/newer.parquet",
+             "size": 200, "last_modified": "2026-06-15T09:00:00.000Z"},
+            {"key": "data/hotkey=H/job_id=job-a/newest.parquet",
+             "size": 300, "last_modified": "2026-06-18T12:00:00.000Z"},
+        ],
+        "job-b": [
+            {"key": "data/hotkey=H/job_id=job-b/only.parquet",
+             "size": 50, "last_modified": "2026-06-01T00:00:00.000Z"},
+        ],
+    }
+
+    out, dropped = DuckDBSampledValidator._keep_latest_per_job(files_by_job)
+
+    assert dropped == 2
+    assert set(out) == {"job-a", "job-b"}
+    assert len(out["job-a"]) == 1
+    assert out["job-a"][0]["key"].endswith("newest.parquet")
+    assert out["job-a"][0]["size"] == 300
+    assert len(out["job-b"]) == 1
+    assert out["job-b"][0]["key"].endswith("only.parquet")
+
+
+def test_keep_latest_per_job_no_drops_when_single_file():
+    files_by_job = {
+        "job-a": [
+            {"key": "data/hotkey=H/job_id=job-a/f.parquet",
+             "size": 100, "last_modified": "2026-06-10T10:00:00.000Z"}
+        ],
+    }
+    out, dropped = DuckDBSampledValidator._keep_latest_per_job(files_by_job)
+    assert dropped == 0
+    assert out == files_by_job
+
+
+def test_keep_latest_per_job_empty_input():
+    out, dropped = DuckDBSampledValidator._keep_latest_per_job({})
+    assert out == {}
+    assert dropped == 0
+
+
+def test_keep_latest_per_job_handles_missing_last_modified():
+    """Files with no last_modified are treated as oldest (empty string sorts last).
+    The one with a real timestamp must win."""
+    files_by_job = {
+        "job-a": [
+            {"key": "data/hotkey=H/job_id=job-a/no-ts.parquet", "size": 100},
+            {"key": "data/hotkey=H/job_id=job-a/has-ts.parquet",
+             "size": 200, "last_modified": "2026-06-15T09:00:00.000Z"},
+        ],
+    }
+    out, dropped = DuckDBSampledValidator._keep_latest_per_job(files_by_job)
+    assert dropped == 1
+    assert out["job-a"][0]["key"].endswith("has-ts.parquet")

--- a/tests/vali_utils/test_s3_validation_results_client.py
+++ b/tests/vali_utils/test_s3_validation_results_client.py
@@ -1,0 +1,138 @@
+"""Tests for S3ValidationResultsClient against a local in-process HTTP server."""
+import asyncio
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from unittest.mock import MagicMock
+
+import pytest
+
+from vali_utils.s3_validation_results_client import (
+    MACROCOSMOS_VALIDATOR_UID,
+    S3ValidationResultsClient,
+)
+
+
+class _Handler(BaseHTTPRequestHandler):
+    received_post: dict = None
+    served_results: list = []
+
+    def log_message(self, *args, **kwargs):
+        pass
+
+    def _read_body(self):
+        n = int(self.headers.get("Content-Length", "0"))
+        return self.rfile.read(n) if n else b""
+
+    def do_POST(self):
+        if self.path == "/s3-validation/results":
+            body = self._read_body()
+            _Handler.received_post = json.loads(body.decode())
+            payload = json.dumps(
+                {"upserted": len(_Handler.received_post.get("results", []))}
+            ).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_GET(self):
+        if self.path == "/s3-validation/results":
+            payload = json.dumps(
+                {
+                    "validator_hotkey": "5VALI",
+                    "results": _Handler.served_results,
+                }
+            ).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+
+@pytest.fixture
+def server():
+    httpd = HTTPServer(("127.0.0.1", 0), _Handler)
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    yield f"http://127.0.0.1:{httpd.server_address[1]}"
+    httpd.shutdown()
+    httpd.server_close()
+    _Handler.received_post = None
+    _Handler.served_results = []
+
+
+@pytest.fixture
+def fake_wallet():
+    # Create a real Keypair via substrateinterface so TaoSigner.headers() can sign.
+    from substrateinterface.keypair import Keypair
+
+    kp = Keypair.create_from_mnemonic(Keypair.generate_mnemonic())
+    wallet = MagicMock()
+    wallet.hotkey = kp
+    return wallet
+
+
+def test_publish_sends_signed_payload(server, fake_wallet):
+    client = S3ValidationResultsClient(wallet=fake_wallet, api_base_url=server)
+    n = asyncio.run(
+        client.publish(
+            {
+                "5MINER_A": {"effective_size_bytes": 12345.0, "validation_passed": True},
+                "5MINER_B": {"effective_size_bytes": 0.0, "validation_passed": False},
+            }
+        )
+    )
+    assert n == 2
+    assert _Handler.received_post is not None
+    by_hotkey = {r["miner_hotkey"]: r["score"] for r in _Handler.received_post["results"]}
+    assert by_hotkey["5MINER_A"]["effective_size_bytes"] == 12345.0
+    assert by_hotkey["5MINER_A"]["validation_passed"] is True
+    assert by_hotkey["5MINER_B"]["validation_passed"] is False
+
+
+def test_publish_empty_short_circuits(server, fake_wallet):
+    client = S3ValidationResultsClient(wallet=fake_wallet, api_base_url=server)
+    n = asyncio.run(client.publish({}))
+    assert n == 0
+    assert _Handler.received_post is None
+
+
+def test_fetch_all_parses_response(server, fake_wallet):
+    _Handler.served_results = [
+        {
+            "miner_hotkey": "5MINER_A",
+            "validator_hotkey": "5VALI",
+            "validator_uid": MACROCOSMOS_VALIDATOR_UID,
+            "score": {"effective_size_bytes": 999.0, "validation_passed": True},
+            "updated_at": "2026-06-17T00:00:00Z",
+        },
+        {
+            "miner_hotkey": "5MINER_B",
+            "validator_hotkey": "5VALI",
+            "validator_uid": MACROCOSMOS_VALIDATOR_UID,
+            "score": {"effective_size_bytes": 0.0, "validation_passed": False},
+            "updated_at": "2026-06-17T00:00:00Z",
+        },
+    ]
+    client = S3ValidationResultsClient(wallet=fake_wallet, api_base_url=server)
+    out = asyncio.run(client.fetch_all())
+    assert set(out) == {"5MINER_A", "5MINER_B"}
+    assert out["5MINER_A"].effective_size_bytes == 999.0
+    assert out["5MINER_A"].validation_passed is True
+    assert out["5MINER_A"].validator_uid == MACROCOSMOS_VALIDATOR_UID
+    assert out["5MINER_B"].validation_passed is False
+
+
+def test_fetch_all_empty_returns_empty_dict(server, fake_wallet):
+    client = S3ValidationResultsClient(wallet=fake_wallet, api_base_url=server)
+    out = asyncio.run(client.fetch_all())
+    assert out == {}

--- a/upload_utils/s3_uploader.py
+++ b/upload_utils/s3_uploader.py
@@ -1,12 +1,12 @@
 """
-S3 Partitioned Uploader for Dynamic Desirability data using Job IDs from Gravity
-Uploads data using exact job IDs from Gravity as folder names:
-hotkey={hotkey_id}/job_id={job_id}/parquet_files
+S3 Partitioned Uploader for Dynamic Desirability data using Job IDs from Gravity.
 
-NO ENCODING - Raw data upload to S3
-Uses offset-based tracking for continuous processing of new data
+Each cycle, for every job, queries all matching rows from the miner's local
+SQLite (capped at max_rows) and uploads them as a single parquet file under
+hotkey={hotkey}/job_id={job_id}/. The validator keeps only the newest file
+per job_id, so the snapshot model matches its semantics directly.
 
-Upload flow: per-file presigned URL via POST /get-file-upload-url
+Upload flow: per-file presigned URL via POST /get-file-upload-url.
 """
 
 import os
@@ -15,7 +15,6 @@ import datetime as dt
 import pandas as pd
 import bittensor as bt
 import sqlite3
-import re
 import secrets
 from contextlib import contextmanager
 from typing import List, Dict
@@ -62,8 +61,11 @@ def load_dynamic_lookup() -> Dict[str, List[Dict]]:
 class S3PartitionedUploader:
     """
     S3 Partitioned uploader using job IDs from Gravity.
-    Handles both label matching and keyword text search.
+    Each cycle re-snapshots the whole job into a single parquet file.
     """
+
+    # Fallback row cap when a job config doesn't specify max_rows.
+    DEFAULT_JOB_MAX_ROWS = 2_000_000
 
     def __init__(
         self,
@@ -73,7 +75,6 @@ class S3PartitionedUploader:
         s3_auth_url: str,
         state_file: str,
         output_dir: str = 's3_partitioned_storage',
-        chunk_size: int = 1_000_000,
     ):
         self.db_path = db_path
         self.wallet = wallet
@@ -83,9 +84,8 @@ class S3PartitionedUploader:
         self.keypair = wallet.hotkey
         self.state_file = f"{state_file.split('.json')[0]}_s3_partitioned.json"
         self.output_dir = os.path.join(output_dir, self.miner_hotkey)
-        self.chunk_size = chunk_size
 
-        # Load processed state - tracks last processed info per job
+        # Load processed state - records last snapshot stats per job (for logging).
         self.processed_state = self._load_processed_state()
 
     @contextmanager
@@ -117,37 +117,6 @@ class S3PartitionedUploader:
                 json.dump(self.processed_state, f, indent=2)
         except Exception as e:
             bt.logging.error(f"Failed to save processed state: {e}")
-
-    def _get_last_cursor(self, job_id: str) -> dict:
-        """Get the last processed cursor for a job.
-
-        Returns dict with 'last_datetime' and 'last_uri' keys.
-        Falls back to legacy 'last_offset' by converting it on first run.
-        """
-        job_state = self.processed_state.get(job_id, {})
-        # New cursor-based state
-        if 'last_datetime' in job_state:
-            return {
-                'last_datetime': job_state['last_datetime'],
-                'last_uri': job_state.get('last_uri', ''),
-            }
-        # No state yet — start from beginning
-        return {'last_datetime': None, 'last_uri': None}
-
-    def _update_processed_state(self, job_id: str, last_datetime: str, last_uri: str, records_processed: int):
-        """Update the processed state for a job using cursor-based tracking."""
-        if job_id not in self.processed_state:
-            self.processed_state[job_id] = {}
-
-        self.processed_state[job_id].update({
-            'last_datetime': last_datetime,
-            'last_uri': last_uri,
-            'total_records_processed': self.processed_state[job_id].get('total_records_processed', 0) + records_processed,
-            'last_processed_time': dt.datetime.now().isoformat(),
-        })
-        # Clean up legacy offset key if present
-        self.processed_state[job_id].pop('last_offset', None)
-        self.processed_state[job_id].pop('processing_completed', None)
 
     def _load_dd_list(self) -> Dict[str, Dict]:
         """Load job configurations from Gravity and return by job_id"""
@@ -220,49 +189,51 @@ class S3PartitionedUploader:
             bt.logging.error(f"Failed to load jobs from Gravity: {e}")
             return {}
 
-    def _get_label_data(self, source: int, label: str, cursor: dict = None) -> pd.DataFrame:
-        """Get data matching exact label, using cursor-based pagination."""
-        if cursor is None:
-            cursor = {'last_datetime': None, 'last_uri': None}
-
-        # Normalize label for SQL query
-        normalized_label = label.lower().strip()
-
-        # Build label conditions based on source
+    @staticmethod
+    def _build_label_conditions(source: int, label: str) -> str:
+        """Source-aware SQL WHERE fragment matching ``label`` (joined by OR)."""
+        normalized = label.lower().strip()
         if source == DataSource.REDDIT.value:
-            # For Reddit: check both with and without r/ prefix
-            label_conditions = [
-                f"LOWER(label) = '{normalized_label}'",
-                f"LOWER(label) = 'r/{normalized_label.removeprefix('r/')}'",
+            parts = [
+                f"LOWER(label) = '{normalized}'",
+                f"LOWER(label) = 'r/{normalized.removeprefix('r/')}'",
             ]
         else:
-            # For X: check if label is in tweet_hashtags array (handles tweets with multiple hashtags)
-            label_without_hash = normalized_label.lstrip('#')
-            label_with_hash = f"#{label_without_hash}"
-
-            label_conditions = [
-                # Check if hashtag (with #) appears in the tweet_hashtags JSON array inside content
-                f"EXISTS (SELECT 1 FROM json_each(content, '$.tweet_hashtags') WHERE LOWER(value) = '{label_with_hash}')",
-                # Check if hashtag (without #) appears in the tweet_hashtags JSON array
-                f"EXISTS (SELECT 1 FROM json_each(content, '$.tweet_hashtags') WHERE LOWER(value) = '{label_without_hash}')",
-                # Fallback: check main label field (stores first hashtag)
-                f"LOWER(label) = '{label_with_hash}'",
-                f"LOWER(label) = '{label_without_hash}'",
+            without_hash = normalized.lstrip('#')
+            with_hash = f"#{without_hash}"
+            parts = [
+                f"EXISTS (SELECT 1 FROM json_each(content, '$.tweet_hashtags') WHERE LOWER(value) = '{with_hash}')",
+                f"EXISTS (SELECT 1 FROM json_each(content, '$.tweet_hashtags') WHERE LOWER(value) = '{without_hash}')",
+                f"LOWER(label) = '{with_hash}'",
+                f"LOWER(label) = '{without_hash}'",
             ]
+        return " OR ".join(parts)
 
-        label_condition_sql = " OR ".join(label_conditions)
+    @staticmethod
+    def _build_keyword_conditions(source: int, keyword: str) -> str:
+        """Source-aware SQL WHERE fragment matching ``keyword`` in text fields (joined by OR)."""
+        normalized = keyword.lower().strip()
+        if source == DataSource.REDDIT.value:
+            parts = [
+                f"LOWER(JSON_EXTRACT(content, '$.body')) LIKE '%{normalized}%'",
+                f"LOWER(JSON_EXTRACT(content, '$.title')) LIKE '%{normalized}%'",
+            ]
+        else:
+            parts = [f"LOWER(JSON_EXTRACT(content, '$.text')) LIKE '%{normalized}%'"]
+        return " OR ".join(parts)
 
-        # Build cursor condition
-        cursor_condition, cursor_params = self._build_cursor_condition(cursor)
+    def _get_label_data(self, source: int, label: str, limit: int) -> pd.DataFrame:
+        """Get all rows matching exact label, capped at ``limit``."""
+        label_condition_sql = self._build_label_conditions(source, label)
 
         query = f"""
             SELECT uri, datetime, label, content
             FROM DataEntity
-            WHERE source = ? AND ({label_condition_sql}){cursor_condition}
+            WHERE source = ? AND ({label_condition_sql})
             ORDER BY datetime ASC, uri ASC
             LIMIT ?
         """
-        params = [source] + cursor_params + [self.chunk_size]
+        params = [source, limit]
 
         try:
             with self.get_db_connection() as conn:
@@ -275,40 +246,18 @@ class S3PartitionedUploader:
             bt.logging.error(f"Error querying label data for {source}/{label}: {e}")
             return pd.DataFrame()
 
-    def _get_keyword_data_chunk(self, source: int, keyword: str, cursor: dict = None) -> pd.DataFrame:
-        """Get chunk of data where keyword appears in text content, using cursor-based pagination."""
-        if cursor is None:
-            cursor = {'last_datetime': None, 'last_uri': None}
-
-        # Normalize keyword
-        normalized_keyword = keyword.lower().strip()
-
-        # Build content search conditions - focus on main text fields
-        if source == DataSource.REDDIT.value:
-            # Search Reddit body field specifically
-            content_conditions = [
-                f"LOWER(JSON_EXTRACT(content, '$.body')) LIKE '%{normalized_keyword}%'",
-                f"LOWER(JSON_EXTRACT(content, '$.title')) LIKE '%{normalized_keyword}%'"
-            ]
-        else:
-            # Search X text field specifically
-            content_conditions = [
-                f"LOWER(JSON_EXTRACT(content, '$.text')) LIKE '%{normalized_keyword}%'"
-            ]
-
-        content_condition_sql = " OR ".join(content_conditions)
-
-        # Build cursor condition
-        cursor_condition, cursor_params = self._build_cursor_condition(cursor)
+    def _get_keyword_data(self, source: int, keyword: str, limit: int) -> pd.DataFrame:
+        """Get all rows where the keyword appears in text content, capped at ``limit``."""
+        content_condition_sql = self._build_keyword_conditions(source, keyword)
 
         query = f"""
             SELECT uri, datetime, label, content
             FROM DataEntity
-            WHERE source = ? AND ({content_condition_sql}){cursor_condition}
+            WHERE source = ? AND ({content_condition_sql})
             ORDER BY datetime ASC, uri ASC
             LIMIT ?
         """
-        params = [source] + cursor_params + [self.chunk_size]
+        params = [source, limit]
 
         try:
             with self.get_db_connection() as conn:
@@ -321,69 +270,21 @@ class S3PartitionedUploader:
             bt.logging.error(f"Error querying keyword data for {source}/{keyword}: {e}")
             return pd.DataFrame()
 
-    def _get_label_and_keyword_data(self, source: int, label: str, keyword: str, cursor: dict = None) -> pd.DataFrame:
-        """Get data where BOTH label matches AND keyword appears in text content (AND logic),
-        using cursor-based pagination."""
-        if cursor is None:
-            cursor = {'last_datetime': None, 'last_uri': None}
+    def _get_label_and_keyword_data(self, source: int, label: str, keyword: str, limit: int) -> pd.DataFrame:
+        """Get all rows matching BOTH the label AND the keyword, capped at ``limit``."""
+        label_condition_sql = self._build_label_conditions(source, label)
+        content_condition_sql = self._build_keyword_conditions(source, keyword)
 
-        # Normalize inputs
-        normalized_label = label.lower().strip()
-        normalized_keyword = keyword.lower().strip()
-
-        # Build label conditions based on source (same as _get_label_data)
-        if source == DataSource.REDDIT.value:
-            # For Reddit: check both with and without r/ prefix
-            label_conditions = [
-                f"LOWER(label) = '{normalized_label}'",
-                f"LOWER(label) = 'r/{normalized_label.removeprefix('r/')}'",
-            ]
-        else:
-            # For X: check if label is in tweet_hashtags array (handles tweets with multiple hashtags)
-            label_without_hash = normalized_label.lstrip('#')
-            label_with_hash = f"#{label_without_hash}"
-
-            label_conditions = [
-                # Check if hashtag (with #) appears in the tweet_hashtags JSON array inside content
-                f"EXISTS (SELECT 1 FROM json_each(content, '$.tweet_hashtags') WHERE LOWER(value) = '{label_with_hash}')",
-                # Check if hashtag (without #) appears in the tweet_hashtags JSON array
-                f"EXISTS (SELECT 1 FROM json_each(content, '$.tweet_hashtags') WHERE LOWER(value) = '{label_without_hash}')",
-                # Fallback: check main label field (stores first hashtag)
-                f"LOWER(label) = '{label_with_hash}'",
-                f"LOWER(label) = '{label_without_hash}'",
-            ]
-
-        label_condition_sql = " OR ".join(label_conditions)
-
-        # Build content search conditions based on source (same as _get_keyword_data_chunk)
-        if source == DataSource.REDDIT.value:
-            # Search Reddit body field specifically
-            content_conditions = [
-                f"LOWER(JSON_EXTRACT(content, '$.body')) LIKE '%{normalized_keyword}%'",
-                f"LOWER(JSON_EXTRACT(content, '$.title')) LIKE '%{normalized_keyword}%'"
-            ]
-        else:
-            # Search X text field specifically
-            content_conditions = [
-                f"LOWER(JSON_EXTRACT(content, '$.text')) LIKE '%{normalized_keyword}%'"
-            ]
-
-        content_condition_sql = " OR ".join(content_conditions)
-
-        # Build cursor condition
-        cursor_condition, cursor_params = self._build_cursor_condition(cursor)
-
-        # Combine with AND logic: (label conditions) AND (keyword conditions)
         query = f"""
             SELECT uri, datetime, label, content
             FROM DataEntity
             WHERE source = ?
                 AND ({label_condition_sql})
-                AND ({content_condition_sql}){cursor_condition}
+                AND ({content_condition_sql})
             ORDER BY datetime ASC, uri ASC
             LIMIT ?
         """
-        params = [source] + cursor_params + [self.chunk_size]
+        params = [source, limit]
 
         try:
             with self.get_db_connection() as conn:
@@ -395,26 +296,6 @@ class S3PartitionedUploader:
         except Exception as e:
             bt.logging.error(f"Error querying label+keyword data for {source}/{label}/{keyword}: {e}")
             return pd.DataFrame()
-
-    @staticmethod
-    def _build_cursor_condition(cursor: dict) -> tuple:
-        """Build a SQL WHERE clause fragment and params for cursor-based pagination.
-
-        Uses (datetime, uri) keyset pagination: returns rows strictly after the cursor position.
-        This is stable under data churn (inserts/deletes) unlike OFFSET.
-
-        Returns:
-            (sql_fragment, params_list) — fragment starts with ' AND' if non-empty.
-        """
-        last_dt = cursor.get('last_datetime')
-        last_uri = cursor.get('last_uri')
-        if last_dt is None:
-            return ('', [])
-        # Keyset pagination: (datetime > ?) OR (datetime = ? AND uri > ?)
-        return (
-            ' AND (datetime > ? OR (datetime = ? AND uri > ?))',
-            [last_dt, last_dt, last_uri or ''],
-        )
 
     def _create_raw_dataframe(self, df: pd.DataFrame, source: int) -> pd.DataFrame:
         """Create raw dataframe with decoded content - NO ENCODING"""
@@ -499,8 +380,8 @@ class S3PartitionedUploader:
             bt.logging.error(f"Error creating raw dataframe: {e}")
             return pd.DataFrame()
 
-    async def _upload_data_chunk(self, client: DataUniverseApiClient, df: pd.DataFrame, source: int, job_id: str) -> bool:
-        """Upload chunk via per-file presigned URL from /get-file-upload-url."""
+    async def _upload_job_snapshot(self, client: DataUniverseApiClient, df: pd.DataFrame, source: int, job_id: str) -> bool:
+        """Upload the snapshot DataFrame as one parquet file via per-file presigned URL."""
         if df.empty:
             return True
 
@@ -547,92 +428,46 @@ class S3PartitionedUploader:
             return False
 
     async def _process_job(self, client: DataUniverseApiClient, job_id: str, job_config: Dict) -> bool:
-        """Process a single job using exact job_id as folder name."""
+        """Re-snapshot a single job: query all matching rows up to max_rows and upload as one file."""
         source = job_config["source"]
         search_type = job_config["type"]
-        max_rows = job_config.get("max_rows")
+        max_rows = job_config.get("max_rows") or self.DEFAULT_JOB_MAX_ROWS
 
-        # Extract value(s) based on search type
         if search_type == "label_and_keyword":
             label = job_config["label"]
             keyword = job_config["keyword"]
             log_msg = f"label='{label}' AND keyword='{keyword}'"
-        else:
+            df = self._get_label_and_keyword_data(source, label, keyword, max_rows)
+        elif search_type == "label":
             value = job_config["value"]
-            log_msg = f"{search_type}: {value}"
+            log_msg = f"label: {value}"
+            df = self._get_label_data(source, value, max_rows)
+        elif search_type == "keyword":
+            value = job_config["value"]
+            log_msg = f"keyword: {value}"
+            df = self._get_keyword_data(source, value, max_rows)
+        else:
+            bt.logging.error(f"Unknown search type: {search_type}")
+            return False
 
-        cursor = self._get_last_cursor(job_id)
+        bt.logging.info(f"Snapshotting job {job_id} ({log_msg}), max_rows={max_rows}, rows={len(df)}")
 
-        # Check already-uploaded rows against max_rows cap
-        already_uploaded = self.processed_state.get(job_id, {}).get('total_records_processed', 0)
-        if max_rows and already_uploaded >= max_rows:
-            bt.logging.info(f"Job {job_id} already at max_rows ({already_uploaded}/{max_rows}), skipping")
+        if df.empty:
+            bt.logging.info(f"No data for job {job_id}, skipping upload")
             return True
 
-        bt.logging.info(f"Processing job {job_id} ({log_msg}), cursor: datetime={cursor.get('last_datetime')}, max_rows={max_rows}")
+        success = await self._upload_job_snapshot(client, df, source, job_id)
+        if not success:
+            bt.logging.error(f"Failed to upload snapshot for job {job_id}")
+            return False
 
-        total_processed = 0
+        self.processed_state[job_id] = {
+            'last_snapshot_rows': len(df),
+            'last_snapshot_time': dt.datetime.now().isoformat(),
+        }
+        self._save_processed_state()
 
-        while True:
-            # Get next chunk based on search type
-            if search_type == "label":
-                chunk_df = self._get_label_data(source, value, cursor)
-            elif search_type == "keyword":
-                chunk_df = self._get_keyword_data_chunk(source, value, cursor)
-            elif search_type == "label_and_keyword":
-                chunk_df = self._get_label_and_keyword_data(source, label, keyword, cursor)
-            else:
-                bt.logging.error(f"Unknown search type: {search_type}")
-                return False
-
-            if chunk_df.empty:
-                bt.logging.info(f"No new data for job {job_id}, total processed this run: {total_processed}")
-                break
-
-            # Enforce max_rows: truncate chunk if it would exceed the cap
-            if max_rows:
-                remaining = max_rows - already_uploaded - total_processed
-                if remaining <= 0:
-                    bt.logging.info(f"Job {job_id}: reached max_rows cap ({max_rows}), stopping")
-                    break
-                if len(chunk_df) > remaining:
-                    bt.logging.info(f"Job {job_id}: truncating chunk from {len(chunk_df)} to {remaining} rows (max_rows={max_rows})")
-                    chunk_df = chunk_df.iloc[:remaining]
-
-            # Upload chunk via per-file presigned URL
-            success = await self._upload_data_chunk(client, chunk_df, source, job_id)
-            if not success:
-                bt.logging.error(f"Failed to upload chunk for job {job_id}")
-                return False
-
-            total_processed += len(chunk_df)
-
-            # Advance cursor to the last row in this chunk
-            last_row = chunk_df.iloc[-1]
-            last_datetime = last_row['datetime']
-            if hasattr(last_datetime, 'isoformat'):
-                last_datetime = last_datetime.isoformat()
-            else:
-                last_datetime = str(last_datetime)
-            last_uri = str(last_row['uri'])
-            cursor = {'last_datetime': last_datetime, 'last_uri': last_uri}
-
-            # Update state after each successful chunk
-            self._update_processed_state(job_id, last_datetime, last_uri, len(chunk_df))
-            self._save_processed_state()
-
-            bt.logging.info(f"Processed {total_processed} new records for job {job_id}")
-
-            # Stop if we've hit the max_rows cap
-            if max_rows and (already_uploaded + total_processed) >= max_rows:
-                bt.logging.info(f"Job {job_id}: reached max_rows cap ({max_rows}), stopping")
-                break
-
-            # If we got less than chunk_size, we've reached the end for now
-            if len(chunk_df) < self.chunk_size:
-                break
-
-        bt.logging.info(f"Completed job {job_id}: {total_processed} records processed")
+        bt.logging.info(f"Completed job {job_id}: {len(df)} records snapshotted")
         return True
 
     async def upload_dd_data(self) -> bool:

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -36,6 +36,11 @@ from typing import Dict, List, Optional, Tuple
 from vali_utils.validator_s3_access import ValidatorS3Access
 from vali_utils.s3_utils import validate_s3_miner_data, get_s3_validation_summary, S3ValidationResult
 from vali_utils.s3_logging_utils import log_s3_validation_table
+from vali_utils.s3_validation_results_client import (
+    MACROCOSMOS_VALIDATOR_UID,
+    PublishedScore,
+    S3ValidationResultsClient,
+)
 
 import httpx
 
@@ -61,7 +66,14 @@ class MinerEvaluator:
         DataSource.REDDIT: ScraperId.REDDIT_MC,
     }
 
-    def __init__(self, config: bt.config, uid: int, metagraph_syncer: MetagraphSyncer, s3_reader: ValidatorS3Access):
+    def __init__(
+        self,
+        config: bt.config,
+        uid: int,
+        metagraph_syncer: MetagraphSyncer,
+        s3_reader: ValidatorS3Access,
+        s3_results_client: Optional[S3ValidationResultsClient] = None,
+    ):
         self.config = config
         self.uid = uid
         self.metagraph_syncer = metagraph_syncer
@@ -71,6 +83,13 @@ class MinerEvaluator:
         )
         self.vpermit_rao_limit = self.config.vpermit_rao_limit
         self.wallet = bt.wallet(config=self.config)
+
+        # API-backed S3 validation results. Used by non-macrocosmos validators
+        # to fetch what UID 89 published; UID 89 uses it to publish results.
+        self.s3_results_client = s3_results_client
+        self._published_scores_cache: Dict[str, PublishedScore] = {}
+        self._published_scores_cache_ts: float = 0.0
+        self._published_scores_cache_ttl_s: float = 300.0
 
         # Set up initial scoring weights for validation
         self.scorer = MinerScorer(self.metagraph.n, DataValueCalculator())
@@ -549,12 +568,18 @@ class MinerEvaluator:
         Returns:
             An S3ValidationResult with validation details or None if no S3 data is found.
         """
+        # Non-macrocosmos validators fetch results published by UID 89 instead of
+        # running S3 validation themselves (which they can no longer do — the API
+        # restricts the underlying S3 endpoints to UID 89).
+        if self.uid != MACROCOSMOS_VALIDATOR_UID:
+            return await self._fetch_published_s3_result(uid, hotkey, current_block)
+
         bt.logging.info(f"UID:{uid} - HOTKEY:{hotkey}: Starting comprehensive S3 validation")
 
         try:
             # Use S3 auth URL from config
             s3_auth_url = self.config.s3_auth_url
-            
+
             s3_validation_result = await validate_s3_miner_data(
                 self.wallet, s3_auth_url, hotkey,
                 config=self.config, s3_reader=self.s3_reader
@@ -606,7 +631,78 @@ class MinerEvaluator:
         if s3_validation_result:
             self.s3_storage.update_validation_info(hotkey, s3_validation_result.total_active_jobs, current_block)
 
+        # UID 89 publishes its result so other validators can fetch it.
+        if s3_validation_result and self.s3_results_client is not None:
+            try:
+                await self.s3_results_client.publish(
+                    {
+                        hotkey: {
+                            "effective_size_bytes": float(
+                                s3_validation_result.effective_size_bytes
+                            ),
+                            "validation_passed": bool(s3_validation_result.is_valid),
+                        }
+                    }
+                )
+            except Exception as e:
+                bt.logging.warning(f"{hotkey}: publish S3 validation result failed: {e}")
+
         return s3_validation_result
+
+    async def _fetch_published_s3_result(
+        self, uid: int, hotkey: str, current_block: int
+    ) -> Optional[S3ValidationResult]:
+        """Fetch the score published by UID 89 and synthesize an S3ValidationResult.
+
+        Non-macrocosmos validators call this instead of running local S3 validation.
+        Only effective_size_bytes and is_valid matter to the scorer — other fields
+        are filled with zeros.
+        """
+        if self.s3_results_client is None:
+            return None
+
+        now = time.time()
+        if (
+            not self._published_scores_cache
+            or (now - self._published_scores_cache_ts) > self._published_scores_cache_ttl_s
+        ):
+            try:
+                self._published_scores_cache = await self.s3_results_client.fetch_all()
+                self._published_scores_cache_ts = now
+            except Exception as e:
+                bt.logging.warning(f"fetch published S3 scores failed: {e}")
+                return None
+
+        published = self._published_scores_cache.get(hotkey)
+        if published is None:
+            bt.logging.debug(f"UID:{uid} - HOTKEY:{hotkey}: no published S3 score yet")
+            return None
+
+        result = S3ValidationResult(
+            is_valid=published.validation_passed,
+            validation_percentage=0.0,
+            total_active_jobs=0,
+            expected_jobs_count=0,
+            recent_jobs_analyzed=0,
+            recent_files_count=0,
+            total_size_bytes=0,
+            has_duplicates=False,
+            duplicate_percentage=0.0,
+            entities_validated=0,
+            entities_passed_scraper=0,
+            scraper_success_rate=0.0,
+            entities_checked_for_job_match=0,
+            entities_matched_job=0,
+            job_match_rate=0.0,
+            validation_issues=[],
+            reason="Result fetched from data-universe-api",
+            sample_validation_results=[],
+            sample_job_mismatches=[],
+            effective_size_bytes=published.effective_size_bytes,
+            job_coverage_rate=0.0,
+        )
+        self.s3_storage.update_validation_info(hotkey, 0, current_block)
+        return result
 
     async def run_next_eval_batch(self) -> int:
         """Asynchronously runs the next batch of miner evaluations and returns the number of seconds to wait until the next batch.

--- a/vali_utils/s3_utils.py
+++ b/vali_utils/s3_utils.py
@@ -616,13 +616,14 @@ class DuckDBSampledValidator:
 
         Returns (filtered_files_by_job, stale_files_dropped).
         """
+        def _newest_key(f):
+            return f.get('last_modified', '')
         stale_dropped = 0
         out: Dict[str, List[dict]] = {}
         for job_id, files in files_by_job.items():
             if len(files) > 1:
-                newest = max(files, key=lambda f: f.get('last_modified', ''))
+                out[job_id] = [max(files, key=_newest_key)]
                 stale_dropped += len(files) - 1
-                out[job_id] = [newest]
             else:
                 out[job_id] = files
         return out, stale_dropped

--- a/vali_utils/s3_utils.py
+++ b/vali_utils/s3_utils.py
@@ -266,6 +266,16 @@ class DuckDBSampledValidator:
                         files_by_job[job_id] = []
                     files_by_job[job_id].append(f)
 
+            # Per-job latest-only: keep only the newest upload per job_id.
+            # Miners reupload whole-job snapshots; older files in the same job_id are
+            # stale and will be reaped by the external cleanup script.
+            files_by_job, stale_files_dropped = self._keep_latest_per_job(files_by_job)
+            if stale_files_dropped > 0:
+                bt.logging.info(
+                    f"{miner_hotkey}: latest-only filter dropped {stale_files_dropped} "
+                    f"stale files across {len(files_by_job)} jobs"
+                )
+
             # Filter to active jobs only
             active_job_ids = [jid for jid in files_by_job.keys() if jid in expected_jobs]
 
@@ -390,37 +400,14 @@ class DuckDBSampledValidator:
                     sampled_files, expected_jobs, presigned_urls
                 )
 
-                # Step 6: Scraper validation — mix of recent and older files.
-                # Validating only recent files allowed miners to upload small correct
-                # files recently while bulk fabricated data (older) was never checked.
-                cutoff = dt.datetime.now(dt.timezone.utc) - dt.timedelta(hours=self.SCRAPER_MAX_AGE_HOURS)
-                recent_files = []
-                older_files = []
-                for f in sampled_files:
-                    last_mod = f.get('last_modified', '')
-                    if last_mod:
-                        try:
-                            file_dt = pd.to_datetime(last_mod, utc=True).to_pydatetime()
-                            if file_dt >= cutoff:
-                                recent_files.append(f)
-                            else:
-                                older_files.append(f)
-                        except Exception:
-                            older_files.append(f)
-                    else:
-                        older_files.append(f)
-
-                # Always include some older files in scraper validation so old data can't hide
-                scraper_files = list(recent_files)
-                if older_files:
-                    older_sample = random.sample(older_files, min(len(older_files), max(5, len(recent_files))))
-                    scraper_files.extend(older_sample)
+                # Step 6: Scraper validation — sampled_files is already latest-per-job,
+                # so no recent/older split is needed.
+                scraper_files = list(sampled_files)
                 random.shuffle(scraper_files)
 
                 if scraper_files:
                     bt.logging.info(
-                        f"{miner_hotkey}: Running scraper validation on {len(scraper_files)} files "
-                        f"({len(recent_files)} recent + {len(scraper_files) - len(recent_files)} older)..."
+                        f"{miner_hotkey}: Running scraper validation on {len(scraper_files)} files..."
                     )
                     scraper_result = await self._perform_scraper_validation(
                         miner_hotkey, scraper_files, expected_jobs, presigned_urls, num_entities=20
@@ -622,6 +609,23 @@ class DuckDBSampledValidator:
         except Exception as e:
             bt.logging.warning(f"parquet_metadata error: {e}")
             return None
+
+    @staticmethod
+    def _keep_latest_per_job(files_by_job: Dict[str, List[dict]]) -> tuple:
+        """Keep only the newest file per job_id (by last_modified desc).
+
+        Returns (filtered_files_by_job, stale_files_dropped).
+        """
+        stale_dropped = 0
+        out: Dict[str, List[dict]] = {}
+        for job_id, files in files_by_job.items():
+            if len(files) > 1:
+                newest = max(files, key=lambda f: f.get('last_modified', ''))
+                stale_dropped += len(files) - 1
+                out[job_id] = [newest]
+            else:
+                out[job_id] = files
+        return out, stale_dropped
 
     def _parse_row_count_from_filename(self, key: str) -> Optional[int]:
         """Extract row count from new filename format: data_YYYYMMDD_HHMMSS_{count}_{hex16}.parquet"""

--- a/vali_utils/s3_utils.py
+++ b/vali_utils/s3_utils.py
@@ -78,6 +78,20 @@ def normalize_url_for_dedup(url_str: str) -> str:
     return f"{parsed.scheme}://{netloc}{path.rstrip('/')}"
 
 
+def _weighted_sample_without_replacement(items, weights, k):
+    """Sample k items without replacement, probability proportional to weight.
+    Uses the exponential-rank trick: key = -log(U) / w, take k smallest keys."""
+    if k <= 0 or not items:
+        return []
+    k = min(k, len(items))
+    keys = []
+    for it, w in zip(items, weights):
+        w_eff = max(w, 1)
+        keys.append((-math.log(max(random.random(), 1e-12)) / w_eff, it))
+    keys.sort(key=lambda x: x[0])
+    return [it for _, it in keys[:k]]
+
+
 @dataclass
 class S3ValidationResult:
     """S3 validation result structure"""
@@ -318,58 +332,37 @@ class DuckDBSampledValidator:
             sample_count = max(10, int(len(active_files) * self.sample_percent / 100))
             sample_count = min(sample_count, len(active_files), 200)  # Cap at 200 files max
 
-            # Split into big (>1MB) and small files — guarantee big files are sampled
-            # since they carry the vast majority of rows/effective_size
-            big_files = [(f, j) for f, j in active_files if f.get('size', 0) > 1_000_000]
-            small_files = [(f, j) for f, j in active_files if f.get('size', 0) <= 1_000_000]
+            # Byte-weighted sampling: file selection probability proportional to its
+            # byte share of the total submitted size. Prior 50:50 big/small split let
+            # miners hide fab content behind a thin layer of real "bait" big files —
+            # uniform sampling across thousands of fab small files gave each fab file
+            # a ~0% chance of inspection. Byte-weighted weights tie validation effort
+            # to where the bytes (and the effective_size claim) actually live.
+            weights = [max(1, f.get('size', 0)) for f, _ in active_files]
+            sampled_files_with_job = _weighted_sample_without_replacement(
+                active_files, weights, sample_count
+            )
 
-            # Reserve half the sample for big files (if available)
-            big_sample_count = min(len(big_files), sample_count // 2)
-            small_sample_count = min(len(small_files), sample_count - big_sample_count)
-            # Fill remaining slots from the other pool
-            big_sample_count = min(len(big_files), sample_count - small_sample_count)
-
-            # L2: rows-weighted sampling for big files (files driving effective_size
-            # are nearly always sampled), plus force-include top-N by claimed rows.
+            # Force-include top-N by claimed rows (these drive effective_size and must
+            # always be inspected even if byte-weights would have skipped them).
             def _claimed_rows(item):
                 f, _ = item
                 r = self._parse_row_count_from_filename(f.get('key', ''))
                 return r if r and r > 0 else 1
 
-            if big_sample_count > 0:
-                weights = [_claimed_rows(item) for item in big_files]
-                seen_keys = set()
-                sampled_big = []
-                # weighted-without-replacement
-                pool = list(zip(big_files, weights))
-                while pool and len(sampled_big) < big_sample_count:
-                    items, ws = zip(*pool)
-                    pick = random.choices(items, weights=ws, k=1)[0]
-                    key = pick[0].get('key')
-                    if key in seen_keys:
-                        pool = [(it, w) for it, w in pool if it[0].get('key') != key]
-                        continue
-                    seen_keys.add(key)
-                    sampled_big.append(pick)
-                    pool = [(it, w) for it, w in pool if it[0].get('key') != key]
-            else:
-                sampled_big = []
-
-            sampled_small = random.sample(small_files, small_sample_count) if small_sample_count > 0 else []
-
-            # L2: force-include top-N by claimed rows (these drive effective_size)
             top_n = sorted(active_files, key=lambda item: -_claimed_rows(item))[:5]
-            top_n_keys = {f.get('key') for f, _ in top_n}
-            already_keys = {f.get('key') for f, _ in (sampled_big + sampled_small)}
+            already_keys = {f.get('key') for f, _ in sampled_files_with_job}
             forced = [item for item in top_n if item[0].get('key') not in already_keys]
 
-            sampled_files_with_job = sampled_big + sampled_small + forced
+            sampled_files_with_job = sampled_files_with_job + forced
             random.shuffle(sampled_files_with_job)
             sampled_files = [f for f, _ in sampled_files_with_job]
 
+            sampled_bytes = sum(f.get('size', 0) for f, _ in sampled_files_with_job)
             bt.logging.info(
                 f"{miner_hotkey}: Sampled {len(sampled_files)} files "
-                f"({len(sampled_big)} big + {len(sampled_small)} small)"
+                f"({sampled_bytes/(1024*1024):.1f}MB / {total_size_bytes/(1024*1024):.1f}MB, "
+                f"{sampled_bytes/max(total_size_bytes,1)*100:.1f}% of bytes)"
             )
 
             # Step 3: Get presigned URLs for sample
@@ -1268,17 +1261,28 @@ class DuckDBSampledValidator:
         """
         all_entities = []
 
-        # Size-weighted random shuffle: bigger files are MORE LIKELY to be
-        # examined first, but not deterministically. A miner cannot position
-        # one specific bait file at the top by ordering or naming because each
-        # file's effective rank is `size * random()` — big files almost always
-        # win, but the exact ordering changes per validation cycle. Same math
-        # idea as `choose_data_entity_bucket_to_query` in P2P validation.
-        sampled_files = sorted(
-            sampled_files,
-            key=lambda f: f.get('size', 1) * random.random(),
-            reverse=True,
+        # Byte-weighted random ordering: each file's rank is exponential(weight=size),
+        # the same trick used for file sampling. Larger files come first on average
+        # without deterministic ordering — and tiny fab files retain a real probability
+        # of being inspected, preventing bait-saturation of the entity pool.
+        file_weights = [max(f.get('size', 0), 1) for f in sampled_files]
+        ranked = _weighted_sample_without_replacement(
+            sampled_files, file_weights, len(sampled_files)
         )
+        sampled_files = ranked
+
+        # Size-proportional per-file row budget: a file holding 50% of the bytes
+        # contributes ~50% of the rows we sample. Total entity budget is
+        # `num_entities * 2` (the existing pool-size target); allocate it pro-rata.
+        sample_total_bytes = max(sum(file_weights), 1)
+        entity_budget = num_entities * 2
+        MIN_ROWS_PER_FILE = 2
+        MAX_ROWS_PER_FILE = 20
+
+        def _rows_for_file(f):
+            share = f.get('size', 0) / sample_total_bytes
+            target = int(round(share * entity_budget))
+            return max(MIN_ROWS_PER_FILE, min(MAX_ROWS_PER_FILE, target))
 
         for file_info in sampled_files:
 
@@ -1334,10 +1338,10 @@ class DuckDBSampledValidator:
                 if required - available_cols:
                     continue
 
-                # Read 1 random row group via Range requests (~3MB vs full scan)
+                # Read 1 random row group; sample size scales with file's byte share.
                 df = read_random_row_group(
                     presigned_url, file_size,
-                    columns=None, max_rows=5
+                    columns=None, max_rows=_rows_for_file(file_info)
                 )
 
                 if df is None or len(df) == 0:

--- a/vali_utils/s3_validation_results_client.py
+++ b/vali_utils/s3_validation_results_client.py
@@ -1,0 +1,124 @@
+"""Client for the data-universe-api /s3-validation/results endpoints.
+
+UID 89 publishes per-miner S3 validation scores; all other validators fetch
+those scores and apply them locally instead of running S3 validation themselves.
+"""
+import asyncio
+import json
+from dataclasses import dataclass
+from typing import Dict
+
+import bittensor as bt
+import requests
+
+from common.api_client import TaoSigner
+
+
+MACROCOSMOS_VALIDATOR_UID = 89
+
+
+@dataclass
+class PublishedScore:
+    miner_hotkey: str
+    validator_hotkey: str
+    validator_uid: int
+    effective_size_bytes: float
+    validation_passed: bool
+    raw: dict
+
+
+class S3ValidationResultsClient:
+    """HTTP client for /s3-validation/results on data-universe-api."""
+
+    def __init__(self, wallet: bt.wallet, api_base_url: str, timeout: int = 30):
+        self.api_base_url = api_base_url.rstrip("/")
+        self._signer = TaoSigner(keypair=wallet.hotkey)
+        self._timeout = timeout
+
+    async def publish(self, scores: Dict[str, Dict]) -> int:
+        """POST per-miner scores. Returns number of rows upserted.
+
+        scores: {miner_hotkey: {"effective_size_bytes": float, "validation_passed": bool, ...}}
+        """
+        if not scores:
+            return 0
+
+        payload = {
+            "results": [
+                {"miner_hotkey": hk, "score": score}
+                for hk, score in scores.items()
+            ]
+        }
+        body = json.dumps(payload).encode()
+        headers = self._signer.headers(body)
+        headers["Content-Type"] = "application/json"
+
+        loop = asyncio.get_event_loop()
+        try:
+            response = await loop.run_in_executor(
+                None,
+                lambda: requests.post(
+                    f"{self.api_base_url}/s3-validation/results",
+                    data=body,
+                    headers=headers,
+                    timeout=self._timeout,
+                ),
+            )
+        except Exception as e:
+            bt.logging.error(f"publish S3 validation results exception: {e}")
+            return 0
+
+        if response.status_code != 200:
+            bt.logging.warning(
+                f"publish S3 validation results failed: {response.status_code} {response.text[:200]}"
+            )
+            return 0
+
+        try:
+            return int(response.json().get("upserted", 0))
+        except Exception:
+            return 0
+
+    async def fetch_all(self) -> Dict[str, PublishedScore]:
+        """GET all published scores. Returns {miner_hotkey: PublishedScore}."""
+        body = b""
+        headers = self._signer.headers(body)
+
+        loop = asyncio.get_event_loop()
+        try:
+            response = await loop.run_in_executor(
+                None,
+                lambda: requests.get(
+                    f"{self.api_base_url}/s3-validation/results",
+                    headers=headers,
+                    timeout=self._timeout,
+                ),
+            )
+        except Exception as e:
+            bt.logging.error(f"fetch S3 validation results exception: {e}")
+            return {}
+
+        if response.status_code != 200:
+            bt.logging.warning(
+                f"fetch S3 validation results failed: {response.status_code} {response.text[:200]}"
+            )
+            return {}
+
+        try:
+            data = response.json()
+        except Exception as e:
+            bt.logging.error(f"fetch S3 validation results: bad JSON {e}")
+            return {}
+
+        out: Dict[str, PublishedScore] = {}
+        for entry in data.get("results", []) or []:
+            score = entry.get("score") or {}
+            out[entry["miner_hotkey"]] = PublishedScore(
+                miner_hotkey=entry["miner_hotkey"],
+                validator_hotkey=entry.get("validator_hotkey", ""),
+                validator_uid=int(entry.get("validator_uid", -1)),
+                effective_size_bytes=float(score.get("effective_size_bytes", 0.0)),
+                validation_passed=bool(score.get("validation_passed", False)),
+                raw=score,
+            )
+        return out

--- a/vali_utils/s3_validation_results_client.py
+++ b/vali_utils/s3_validation_results_client.py
@@ -24,7 +24,6 @@ class PublishedScore:
     validator_uid: int
     effective_size_bytes: float
     validation_passed: bool
-    raw: dict
 
 
 class S3ValidationResultsClient:
@@ -119,6 +118,5 @@ class S3ValidationResultsClient:
                 validator_uid=int(entry.get("validator_uid", -1)),
                 effective_size_bytes=float(score.get("effective_size_bytes", 0.0)),
                 validation_passed=bool(score.get("validation_passed", False)),
-                raw=score,
             )
         return out


### PR DESCRIPTION
## Summary

This PR rewires SN13's S3 reward path around three coordinated changes:

1. **API-routed validation.** Only UID 89 (macrocosmos) runs S3 validation locally. It publishes per-miner results to `data-universe-api`; all other validators fetch them and apply them to their local scorer. (Paired with [data-universe-api #101](https://github.com/macrocosm-os/data-universe-api/pull/101) which gates the API endpoints to UID 89.)
2. **Latest-file-per-job validation.** Within each `job_id`, only the newest file (by S3 `last_modified`) counts toward size, sampling, and scraper validation. Stale files are ignored.
3. **Whole-job-snapshot uploader.** Miners replace incremental 1M-row chunks with a single parquet per job per cycle (capped at `max_rows`). One snapshot = one validated unit.

## Why

- Validators were spending wall-clock time on stale uploads and duplicate work across the fleet. Routing through one publisher cuts S3 listing + scraper-call load by ~N-fold while keeping consensus identical.
- The bucket holds millions of files per miner. Validating "latest only" eliminates the silent listing-truncation risk and lets an external cleanup script reap the rest without touching subnet logic.
- The chunked uploader produced multiple files per job; the latest-only filter would have credited only the last chunk. The whole-job snapshot keeps the two sides aligned.

## What changes

### Validator (UID 89)
- Lists miner files → `_keep_latest_per_job` collapses to newest per `job_id` → existing DuckDB + scraper validation runs on that smaller set.
- After local validation, publishes `{effective_size_bytes, validation_passed}` per miner via `POST /s3-validation/results` (Tao-signed, server-side gated to UID 89).

### Validator (non-89)
- Skips local S3 validation entirely.
- Fetches all published scores via `GET /s3-validation/results` once per 5 min (in-memory TTL cache; one request per cycle, not per miner).
- Reconstructs an `S3ValidationResult` from the published fields and applies it via the unchanged `MinerScorer.update_s3_effective_size`.
- Returns `None` (no score update) for miners not in the published set — degrades gracefully if UID 89 is offline.

### Miner
- `upload_utils/s3_uploader.py` switches to single-shot per-job snapshots. Drops the cursor + chunked loop. Each cycle re-queries all matching rows for the job from local SQLite (capped at `max_rows`, default 2M) and uploads them as one parquet file with the existing filename format.

### Scorer
- `STATE_VERSION` 14 → 15. On load, wipes `s3_boosts`, `s3_credibility`, and `effective_sizes`. Old scores were computed under the chunked / pre-latest-only model and are not comparable to the new ones.

## Tests

- `tests/vali_utils/test_s3_latest_per_job.py` — 4 tests (multi-file pick, single-file passthrough, empty input, missing `last_modified`)
- `tests/vali_utils/test_s3_validation_results_client.py` — 4 tests (signed publish, empty short-circuit, fetch parse, empty fetch)
- `tests/upload_utils/test_s3_uploader_snapshot.py` — 5 tests (single upload, empty job, max_rows cap, default cap, failure propagation)

All 13 new tests pass. The 5 pre-existing failures in `test_od_flow.py` / `test_vali_utils.py` are present on clean `main` and unrelated.

## Rollout

| Step | What |
|---|---|
| 1 | Discord announcement: latest-file-per-job semantics + miners must upgrade to get full credit |
| 2 | Merge data-universe-api #101 (endpoints become available, UID 89 gate active) |
| 3 | Merge this PR. Validators auto-upgrade; scorer migration wipes S3 state on next load. Within one TTL window (~5 min) non-89 validators converge to UID 89's view. |
| 4 | Run external S3 cleanup script (separate tool, NOT in this PR) to reap stale files for storage savings |

## Out of scope

- The S3 file cleanup script — runs externally, not as part of the subnet.
- Server-side "latest per job" endpoint — listing pressure drops to ~1 page per miner once cleanup runs, so not needed in this iteration.

## Test plan

- [ ] Stage a non-89 validator → confirm logs show `Result fetched from data-universe-api` and `update_s3_effective_size` is called with the published values.
- [ ] Stage UID 89 → confirm `latest-only filter dropped N stale files` logs appear and `POST /s3-validation/results` returns `upserted > 0`.
- [ ] Run miner snapshot uploader against a populated SQLite → confirm exactly one file per active job appears under `data/hotkey=<HK>/job_id=<JOB>/`.
- [ ] Verify migration v14→v15 fires once on validator restart and zeros S3 state.