### PR TITLE
chore: bump per-file size limit 512MB -> 1GB

### DIFF
--- a/vali_utils/s3_utils.py
+++ b/vali_utils/s3_utils.py
@@ -179,7 +179,7 @@ class DuckDBSampledValidator:
 
     # File size limits - prevent empty file exploit and oversized file OOM
     MIN_FILE_SIZE_BYTES = 15_000                   # 15KB - empty parquet header ≈ 8KB
-    MAX_FILE_SIZE_BYTES = 512 * 1024 * 1024        # 512MB - single file cap
+    MAX_FILE_SIZE_BYTES = 1024 * 1024 * 1024       # 1GB - single file cap
     MIN_BYTES_PER_ROW = 50                         # Legit: 80-1300 B/row. Exploits: 8-25 B/row.
 
     # Scraper validation window — only files uploaded within this window are scraper-validated.


### PR DESCRIPTION
## Summary

Raise the validator's per-file size limit from **512 MB → 1 GB**.

Whole-job snapshot uploads (commit `dfb74fa`) write one parquet file per job per cycle, capped at `max_rows = 2_000_000` by default. Production data confirms top-decile miners are already pushing close to the previous 512 MB ceiling:

- Largest files observed across top-20 miners by incentive: **497.5 MB** (one hair under the cap)
- 32 of ~50K files (0.1%) cross 400 MB
- Heavy miners self-cap right at the threshold to stay under the validator skip path

Bumping to 1 GB gives headroom for heavier jobs without dropping them from validation entirely.

## Changes

- `vali_utils/s3_utils.py:182`: `MAX_FILE_SIZE_BYTES = 512 * 1024 * 1024 → 1024 * 1024 * 1024`

One-line change. All other code paths reference `self.MAX_FILE_SIZE_BYTES`, no hardcoded 512MB literals to chase.

## Test plan

- [x] Confirmed no other 512MB literals in validator
- [x] All five `file_size > self.MAX_FILE_SIZE_BYTES` checks (lines 268, 709, 1126, 1321) pick up the new value automatically
- [x] Validator logs report the new ceiling correctly
- [ ] Smoke validation run against a known heavy miner to confirm no honest miners are now rejected at the new threshold