### PR TITLE
fix: raise DuckDB timeouts above observed honest scan time (stop false 'corrupt pages' fails)

### DIFF
--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -132,11 +132,11 @@ class MinerEvaluator:
     # Outer backstop on the WHOLE eval_miner (async phases + the synchronous DuckDB
     # phase). asyncio.wait_for only preempts at await points, so it can NOT interrupt
     # a synchronous DuckDB scan — that is bounded by the watchdog + PER_MINER_DUCKDB
-    # _BUDGET_SECS (1200s) in s3_utils. This constant must therefore sit ABOVE the
-    # honest worst case (async ~320s: OD 60 + index 120 + bucket 140; plus DuckDB
-    # budget 1200s) so it never fires on an honest large miner — it only catches a
-    # genuinely wedged async call. Kept under the 1500s join backstop.
-    PER_MINER_EVAL_TIMEOUT_SECS = 1400
+    # _BUDGET_SECS (3600s) in s3_utils. This constant must therefore sit ABOVE the
+    # honest worst case (async ~320s: OD 60 + index 120 + bucket 140; plus the DuckDB
+    # budget 3600s) so it never fires on an honest large miner — it only catches a
+    # genuinely wedged async call. Kept under the join backstop.
+    PER_MINER_EVAL_TIMEOUT_SECS = 3900
 
     def eval_miner_sync(self, uid: int) -> None:
         """Synchronous wrapper with a wall-clock backstop for the awaitable phases."""
@@ -779,11 +779,11 @@ class MinerEvaluator:
         # bucket dendrite timeouts + the asyncio backstop in eval_miner_sync for the
         # awaitable phases; the DuckDB watchdog + per-miner budget in s3_utils for
         # the synchronous phase), so a worker can't run unbounded. The shared backstop
-        # is set ABOVE the per-miner DuckDB budget (1200s) so the join waits for an
+        # is set ABOVE the per-miner DuckDB budget (3600s) so the join waits for an
         # honest slow/large miner to finish rather than abandoning it (which would
         # re-leak); it only fires if some future blocker is left uncapped — a bounded
         # stall, never an OOM.
-        join_deadline = time.monotonic() + 1500
+        join_deadline = time.monotonic() + 4200
         for t in threads:
             t.join(timeout=max(0.0, join_deadline - time.monotonic()))
 

--- a/vali_utils/s3_utils.py
+++ b/vali_utils/s3_utils.py
@@ -191,13 +191,14 @@ class DuckDBSampledValidator:
     # cannot preempt). On timeout we raise duckdb.InterruptException — a
     # duckdb.Error subclass — so the existing handler fails the file closed and
     # update_validation_info still fires (no perpetual re-skip / free pass).
-    # Sized from live measurement: an honest large miner's full per-file URL scan
-    # is ~25s (2M-row file ~46s), and the whole per-miner DuckDB phase is ~870s
-    # over a slow link under 5x concurrency. These bound true hangs WITHOUT failing
-    # a legit large miner. (A later sampling change will cut the real phase to ~1min
-    # and let these tighten.)
-    PER_FILE_DUCKDB_TIMEOUT_SECS = 90     # max wall-clock for one file's DuckDB work
-    PER_MINER_DUCKDB_BUDGET_SECS = 1200   # total S3/DuckDB wall-clock per miner (~20 min)
+    # Sized from LIVE measurement: honest large miners (110k-file, ~36GB) take the
+    # full per-miner DuckDB phase ~1200-1280s under 5x concurrency — so a 1200s
+    # budget CLIPPED them, interrupting a legitimate scan and mis-failing them as
+    # "corrupt data pages". Raised to 3600s so an honest large miner finishes; this
+    # only fires on a genuinely stuck scan. (The real fix is sampling, which cuts the
+    # phase to ~1min; until then these must sit ABOVE the observed honest worst case.)
+    PER_FILE_DUCKDB_TIMEOUT_SECS = 180    # max wall-clock for one file's DuckDB work
+    PER_MINER_DUCKDB_BUDGET_SECS = 3600   # total S3/DuckDB wall-clock per miner (~60 min)
 
     # Scraper validation window — only files uploaded within this window are scraper-validated.
     # Older files rely on credibility from previous validation cycles.


### PR DESCRIPTION
## Problem (observed live after #861 deployed)

Every large miner's S3 validation **FAILED** — 0/8 passes in the post-deploy log. All failed at ~1000–1300s with `Corrupt data pages in N files, dup 100%, empty 100%`.

**None of these are real corruption.** They are the per-miner DuckDB budget (1200s from #861) **interrupting the scan mid-read**: the only exception types in the log are `InterruptException: Interrupted!` and the follow-on `InvalidInputException: closed pending query result` — both are what `conn.interrupt()` produces, not a decode error. The handler counts them as `page_decode_failures` → mislabels honest miners as corrupt.

Proof it's a timeout, not corruption: a **smaller** miner in the same concurrent batch completed the identical check with `dup=0.0%, decode_ratio=1.000 (16521306/16521306 rows)` — perfect, real data. The big miners have the same valid data but more rows, so their ~17-min dedup scan exceeds the 1200s budget and gets killed.

I sized the 1200s budget at the *edge* of the honest scan time (~1280s) — that was the mistake. It must sit **above** the observed worst case.

## Fix

Raise the timeouts above the live-observed honest scan time (full scan still slow; sampling is a separate follow-up):

| Constant | was | now |
|---|---|---|
| `PER_FILE_DUCKDB_TIMEOUT_SECS` | 90 | 180 |
| `PER_MINER_DUCKDB_BUDGET_SECS` | 1200 | 3600 |
| `PER_MINER_EVAL_TIMEOUT_SECS` (asyncio backstop) | 1400 | 3900 |
| join backstop | 1500 | 4200 |

Layering stays ascending: 180 < 3600 < 3900 < 4200.

**OOM stays fixed** — join-to-completion bounds concurrency regardless of these values. Per-batch wall-clock rises for the large-miner case but is bounded and stable; honest large miners now finish and validate (will show `decode_ratio≈1.0 / ✅ S3` instead of `FAILED in ~1200s`).

## Follow-up
The real cure is sampling the dedup scan (~17 min → ~1 min, cost independent of file size), which makes any budget a non-issue. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)