### PR TITLE
fix: accept Reddit comments in on-demand metadata completeness

### DIFF
--- a/tests/integration/test_on_demand_reddit_metadata.py
+++ b/tests/integration/test_on_demand_reddit_metadata.py
@@ -1,0 +1,66 @@
+import datetime as dt
+import unittest
+
+from scraping.reddit.model import RedditContent, RedditDataType
+from vali_utils.on_demand.output_models import validate_metadata_completeness
+
+
+def _build_reddit_entity(data_type, upvote_ratio=None, num_comments=None):
+    """Build a real Reddit DataEntity for the given data_type.
+
+    The submission-only fields (upvote_ratio, num_comments) default to None to
+    mirror how comments are produced by the scrapers.
+    """
+    content = RedditContent(
+        id="t1_abc123",
+        url="https://www.reddit.com/r/test/comments/abc/def/ghi/",
+        username="alice",
+        communityName="r/test",
+        body="hello world",
+        createdAt=dt.datetime(2026, 6, 20, 12, 0, 0, tzinfo=dt.timezone.utc),
+        dataType=data_type,
+        is_nsfw=False,
+        score=5,
+        upvote_ratio=upvote_ratio,
+        num_comments=num_comments,
+    )
+    return RedditContent.to_data_entity(content)
+
+
+class TestRedditMetadataCompleteness(unittest.TestCase):
+    """Regression tests for Reddit on-demand metadata completeness.
+
+    upvote_ratio and num_comments are submission-only fields and are None by
+    design for comments, so they must not be required for comments.
+    """
+
+    def test_comment_with_none_submission_fields_passes(self):
+        """A comment with None upvote_ratio/num_comments must pass validation."""
+        entity = _build_reddit_entity(RedditDataType.COMMENT)
+        is_valid, missing_fields = validate_metadata_completeness(entity)
+        self.assertTrue(
+            is_valid,
+            f"Comment should pass metadata completeness, missing: {missing_fields}",
+        )
+        self.assertEqual(missing_fields, [])
+
+    def test_post_with_none_submission_fields_still_fails(self):
+        """A post missing upvote_ratio/num_comments must still fail (fix is scoped)."""
+        entity = _build_reddit_entity(RedditDataType.POST)
+        is_valid, missing_fields = validate_metadata_completeness(entity)
+        self.assertFalse(is_valid)
+        self.assertIn("upvote_ratio", missing_fields)
+        self.assertIn("num_comments", missing_fields)
+
+    def test_post_with_submission_fields_passes(self):
+        """A complete post must still pass validation."""
+        entity = _build_reddit_entity(
+            RedditDataType.POST, upvote_ratio=0.95, num_comments=12
+        )
+        is_valid, missing_fields = validate_metadata_completeness(entity)
+        self.assertTrue(is_valid, f"Post should pass, missing: {missing_fields}")
+        self.assertEqual(missing_fields, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vali_utils/on_demand/output_models.py
+++ b/vali_utils/on_demand/output_models.py
@@ -313,12 +313,12 @@ def _validate_reddit_metadata_completeness(
 ) -> tuple[bool, List[str]]:
     """Validate Reddit content metadata completeness using RedditOrganicOutput model."""
     try:
-        from scraping.reddit.model import RedditContent
+        from scraping.reddit.model import RedditContent, RedditDataType
 
         reddit_content = RedditContent.from_data_entity(data_entity)
         missing_fields = []
 
-        # All required fields
+        # Fields required for both posts and comments.
         required_fields = [
             ("id", reddit_content.id),
             ("url", reddit_content.url),
@@ -329,9 +329,16 @@ def _validate_reddit_metadata_completeness(
             ("dataType", reddit_content.data_type),
             ("is_nsfw", reddit_content.is_nsfw),
             ("score", reddit_content.score),
-            ("upvote_ratio", reddit_content.upvote_ratio),
-            ("num_comments", reddit_content.num_comments),
         ]
+
+        # upvote_ratio and num_comments are submission-only fields (see
+        # scraping/reddit/model.py); they are None by design for comments, so
+        # only require them for posts to avoid penalizing valid comments.
+        if reddit_content.data_type == RedditDataType.POST:
+            required_fields += [
+                ("upvote_ratio", reddit_content.upvote_ratio),
+                ("num_comments", reddit_content.num_comments),
+            ]
 
         # Check all required fields
         for field_name, field_value in required_fields:


### PR DESCRIPTION
## Problem

`upvote_ratio` and `num_comments` are **submission-only** Reddit fields — `scraping/reddit/model.py` declares both `Optional[...] = None` with the docstring "submissions only", so they are `None` by design for every **comment**.

But `_validate_reddit_metadata_completeness` (`vali_utils/on_demand/output_models.py`) lists both in `required_fields` unconditionally and rejects any `None`. So **every Reddit comment returned in an on-demand response fails metadata completeness** and incurs a penalty (OD boost EMA'd toward 0, `od_cred − 0.05`), even though the data is valid.

The internal contradiction that shows this is a bug, not intent: the Phase-1 request-field check (`_validate_reddit_request_fields`) accepts the comment; only the completeness gate rejects it.

### Repro (against `dev`)
```
COMMENT metadata valid? False | missing: ['upvote_ratio', 'num_comments']
POST    metadata valid? True  | missing: []
# same comment through OnDemandValidator: Phase-1 accepts, Phase-2 rejects
```

## Fix

Gate `upvote_ratio` / `num_comments` on `data_type == POST`. All other required fields (id, url, username, community, body, createdAt, dataType, is_nsfw, score) are still enforced for both posts and comments, so fabrication detection is unchanged.

## Testing

Adds `tests/integration/test_on_demand_reddit_metadata.py` (builds real entities via `RedditContent.to_data_entity()` and calls the real `validate_metadata_completeness`):
- comment with `None` submission fields → passes
- post with `None` submission fields → still fails (fix is scoped)
- complete post → passes

`pytest tests/integration/test_on_demand_reddit_metadata.py` → **3 passed**. Verified against `dev` @ `88c43ec7`.
