### PR TITLE
fix: accept media-only tweets with empty text in S3 validation

### DIFF
--- a/tests/vali_utils/test_s3_twitter_entity_media_only.py
+++ b/tests/vali_utils/test_s3_twitter_entity_media_only.py
@@ -1,0 +1,45 @@
+"""Regression tests for media-only tweet handling in DuckDBSampledValidator.
+
+Empty tweet text is legitimate for media-only tweets, so ``_create_twitter_entity``
+must not reject such rows. Rows missing a username or URL must still be rejected
+so fabrication detection is unchanged.
+"""
+from common.data import DataEntity
+from vali_utils.s3_utils import DuckDBSampledValidator
+
+
+def _make_validator():
+    """Create a validator instance without running the network-bound __init__."""
+    return DuckDBSampledValidator.__new__(DuckDBSampledValidator)
+
+
+def test_media_only_tweet_returns_entity():
+    """A media-only tweet (empty text, username + url present) must be accepted."""
+    validator = _make_validator()
+    row = {
+        "username": "bob",
+        "text": "",
+        "url": "https://x.com/bob/status/1",
+        "tweet_id": "1",
+    }
+
+    entity = validator._create_twitter_entity(row)
+
+    assert isinstance(entity, DataEntity)
+    assert entity.uri == "https://x.com/bob/status/1"
+
+
+def test_missing_username_returns_none():
+    """A row without a username must still be rejected."""
+    validator = _make_validator()
+    row = {"username": "", "text": "hello", "url": "https://x.com/bob/status/2"}
+
+    assert validator._create_twitter_entity(row) is None
+
+
+def test_missing_url_returns_none():
+    """A row without a URL must still be rejected."""
+    validator = _make_validator()
+    row = {"username": "bob", "text": "hello", "url": ""}
+
+    assert validator._create_twitter_entity(row) is None

--- a/vali_utils/s3_utils.py
+++ b/vali_utils/s3_utils.py
@@ -1633,7 +1633,11 @@ class DuckDBSampledValidator:
             username = row.get('username', '')
             text = row.get('text', '')
             url = row.get('url', '')
-            if not all([username, text, url]):
+            # Empty text is legitimate for media-only tweets, so it must not
+            # disqualify the row. Missing username (>50% empty-username) and
+            # missing URL are still hard-failed separately, so fabrication
+            # detection is unchanged.
+            if not username or not url:
                 return None
 
             datetime_val = row.get('datetime', row.get('timestamp', ''))


### PR DESCRIPTION
## Problem

`_create_twitter_entity` (`vali_utils/s3_utils.py`) rejects any row where `username`, `text`, or `url` is falsy via `if not all([username, text, url]): return None`. Empty `text` (`""`) is legitimate for **media-only tweets** (`XContent.text` is a required `str`, so `""` is valid), so those valid rows return `None`.

The first `None` in `_perform_scraper_validation` forces `success_rate = 0.0`, which fails `MIN_SCRAPER_SUCCESS` and zeroes `effective_size` for the **whole submission** — despite the file-level `MAX_EMPTY_RATE` (10%) tolerance that already permits some empty-text rows. So the two checks encode opposite policies on the same media-only row.

### Repro (against `dev`)
```
GOOD text  -> entity is None? False
EMPTY text -> entity is None? True   (media-only tweet, valid XContent, empty text)
```

## Fix

Only reject rows missing `username` or `url`. Fabrication detection is unchanged — missing `url` and the separate `>50% empty-username` check still hard-fail; this only stops treating empty *text* as a missing entity.

## Testing

Adds `tests/vali_utils/test_s3_twitter_entity_media_only.py`:
- media-only row (username + url, empty text) → yields a `DataEntity`
- row missing username → `None` (still rejected)
- row missing url → `None` (still rejected)

`pytest tests/vali_utils/test_s3_twitter_entity_media_only.py` → **3 passed**. Verified against `dev` @ `88c43ec7`.
