### PR TITLE
fix(reddit): dedup on immutable content IDs + url<->id check + dup-ra…

### DIFF
--- a/rewards/miner_scorer.py
+++ b/rewards/miner_scorer.py
@@ -33,7 +33,10 @@ class MinerScorer:
     # v15: Reset S3 — latest-file-per-job validation + whole-job-snapshot miner uploads.
     #      Old effective_size/credibility was computed across all historical chunks; new
     #      model counts only the latest snapshot per job, so prior scores are not comparable.
-    STATE_VERSION = 15
+    # v16: Reset S3 — dedup keys on immutable content IDs (drop slug/subreddit/username) +
+    #      MAX_DUPLICATE_RATE 5%->1%. Pre-fix effective_size/credibility was inflated by
+    #      cosmetically-distinct URLs that pointed at identical content.
+    STATE_VERSION = 16
 
     # Start new miner's at a credibility of 0.
     STARTING_CREDIBILITY = 0
@@ -139,11 +142,11 @@ class MinerScorer:
             self.effective_sizes = state.get("effective_sizes", torch.zeros(self.scores.size(0), dtype=torch.float64))
 
             # --- State migrations ---
-            if saved_version < 15:
+            if saved_version < 16:
                 bt.logging.warning(
-                    f"State migration v{saved_version} -> v15: "
+                    f"State migration v{saved_version} -> v16: "
                     f"S3 boost/credibility/effective_size reset "
-                    f"(latest-file-per-job validation + whole-job-snapshot uploads)"
+                    f"(dedup keys on immutable content IDs + dup-rate 5%->1%)"
                 )
                 self.s3_boosts.zero_()
                 self.s3_credibility.fill_(MinerScorer.STARTING_S3_CREDIBILITY)

--- a/rewards/miner_scorer.py
+++ b/rewards/miner_scorer.py
@@ -33,10 +33,7 @@ class MinerScorer:
     # v15: Reset S3 — latest-file-per-job validation + whole-job-snapshot miner uploads.
     #      Old effective_size/credibility was computed across all historical chunks; new
     #      model counts only the latest snapshot per job, so prior scores are not comparable.
-    # v16: Reset S3 — dedup keys on immutable content IDs (drop slug/subreddit/username) +
-    #      MAX_DUPLICATE_RATE 5%->1%. Pre-fix effective_size/credibility was inflated by
-    #      cosmetically-distinct URLs that pointed at identical content.
-    STATE_VERSION = 16
+    STATE_VERSION = 15
 
     # Start new miner's at a credibility of 0.
     STARTING_CREDIBILITY = 0
@@ -142,11 +139,11 @@ class MinerScorer:
             self.effective_sizes = state.get("effective_sizes", torch.zeros(self.scores.size(0), dtype=torch.float64))
 
             # --- State migrations ---
-            if saved_version < 16:
+            if saved_version < 15:
                 bt.logging.warning(
-                    f"State migration v{saved_version} -> v16: "
+                    f"State migration v{saved_version} -> v15: "
                     f"S3 boost/credibility/effective_size reset "
-                    f"(dedup keys on immutable content IDs + dup-rate 5%->1%)"
+                    f"(latest-file-per-job validation + whole-job-snapshot uploads)"
                 )
                 self.s3_boosts.zero_()
                 self.s3_credibility.fill_(MinerScorer.STARTING_S3_CREDIBILITY)

--- a/scraping/reddit/utils.py
+++ b/scraping/reddit/utils.py
@@ -108,14 +108,8 @@ def validate_reddit_content(
             content_size_bytes_validated=entity_to_validate.content_size_bytes,
         )
 
-    # URL <-> content-id self-consistency. The Apify actor echoes the submitted
-    # URL's slug/subreddit back verbatim, so the url-equality check above cannot
-    # catch content stapled onto a URL for a DIFFERENT post/comment. Pin the
-    # base36 id embedded in the URL to the id field: for a comment it's the
-    # URL's terminal segment, for a post it's the segment after /comments/.
-    # Reddit IDs are lowercase base36 of VARIABLE length (grow over time), so
-    # match >=4 chars, not a fixed length. The slug (middle segment) is never
-    # compared, so honest slug variance is untouched.
+    # The URL's embedded id must match the content id (the actor echoes the
+    # submitted URL, so the url check above can't catch a mismatched id).
     _url_m = re.match(
         r"^/r/[^/]+/comments/([a-z0-9]{4,})(?:/[^/]*(?:/([a-z0-9]{4,}))?)?",
         urlparse(content_to_validate.url).path.lower(),

--- a/scraping/reddit/utils.py
+++ b/scraping/reddit/utils.py
@@ -1,4 +1,5 @@
 import bittensor as bt
+import re
 import traceback
 import datetime as dt
 import random
@@ -104,6 +105,37 @@ def validate_reddit_content(
         return ValidationResult(
             is_valid=False,
             reason="Reddit urls do not match",
+            content_size_bytes_validated=entity_to_validate.content_size_bytes,
+        )
+
+    # URL <-> content-id self-consistency. The Apify actor echoes the submitted
+    # URL's slug/subreddit back verbatim, so the url-equality check above cannot
+    # catch content stapled onto a URL for a DIFFERENT post/comment. Pin the
+    # base36 id embedded in the URL to the id field: for a comment it's the
+    # URL's terminal segment, for a post it's the segment after /comments/.
+    # Reddit IDs are lowercase base36 of VARIABLE length (grow over time), so
+    # match >=4 chars, not a fixed length. The slug (middle segment) is never
+    # compared, so honest slug variance is untouched.
+    _url_m = re.match(
+        r"^/r/[^/]+/comments/([a-z0-9]{4,})(?:/[^/]*(?:/([a-z0-9]{4,}))?)?",
+        urlparse(content_to_validate.url).path.lower(),
+    )
+    _url_post_id = _url_m.group(1) if _url_m else None
+    _url_comment_id = _url_m.group(2) if _url_m else None
+    _bare_id = content_to_validate.id.split("_", 1)[-1].lower()  # strip t1_/t3_
+    _expected_url_id = (
+        _url_comment_id
+        if content_to_validate.data_type == RedditDataType.COMMENT
+        else _url_post_id
+    )
+    if _expected_url_id is None or _expected_url_id != _bare_id:
+        bt.logging.info(
+            f"Reddit URL id does not match content id: url={content_to_validate.url} "
+            f"id={content_to_validate.id}"
+        )
+        return ValidationResult(
+            is_valid=False,
+            reason="Reddit URL id does not match content id",
             content_size_bytes_validated=entity_to_validate.content_size_bytes,
         )
 

--- a/vali_utils/s3_utils.py
+++ b/vali_utils/s3_utils.py
@@ -130,7 +130,7 @@ class DuckDBSampledValidator:
     """
 
     # Validation thresholds
-    MAX_DUPLICATE_RATE = 5.0    # 5% max duplicates within same job
+    MAX_DUPLICATE_RATE = 1.0    # 1% max duplicates within same job (honest miners dedup locally)
     MAX_EMPTY_RATE = 10.0       # 10% max empty content
     # Missing URLs = instant fail (no rate threshold needed)
     MIN_JOB_MATCH_RATE = 95.0   # 95% min job content match rate

--- a/vali_utils/url_normalizer.py
+++ b/vali_utils/url_normalizer.py
@@ -14,55 +14,36 @@ def normalize_url_for_dedup(url_str: str) -> str:
     Approach: define what a VALID canonical URL looks like, ignore everything else.
     This is not a blacklist of known exploits — it's a whitelist of valid URL structure.
 
-    Key on IMMUTABLE content IDs only. The slug and subreddit (Reddit) and the
-    username (X) are decorative and attacker-controlled: Reddit and the Apify
-    actor resolve a post/comment by its base36 ID regardless of slug or even
-    subreddit, and X resolves a tweet by ID regardless of username. Keying on
-    those cosmetic fields let a miner mint unlimited "unique" URLs for one real
-    piece of content (mutate the slug -> different hash -> counts as unique).
+    X:      Only the numeric tweet ID matters. Username is lowercased (decorative — X resolves by ID).
+    Reddit: Only post_id and comment_id (base36) matter. Subreddit and slug are decorative.
 
-    X:      Only the numeric tweet ID identifies the content — username dropped.
-    Reddit: Only post_id (+ comment_id) identify the content — sub + slug dropped.
-
-    Canonical (ID-only) keys produced:
-      X tweet:        x:{tweet_id}
+    Canonical forms produced:
+      X tweet:        https://x.com/{user_lower}/status/{tweet_id}
       Reddit post:    reddit:{post_id}
       Reddit comment: reddit:{post_id}:{comment_id}
     """
     url = str(url_str).strip()
     parsed = urlparse(url)
     netloc = parsed.netloc.lower()
-    # Lowercase the path so an uppercased ID can't dodge the [a-z0-9] match
-    # (which would truncate it and collapse distinct posts to a short key).
     path = parsed.path.lower()
 
     # --- X / Twitter ---
     if "x.com" in netloc or "twitter.com" in netloc:
-        # Only the numeric tweet ID is identity; username is decorative and
-        # attacker-controlled, so it is NOT part of the key.
-        m = re.match(r"^/[^/]+/status/(\d+)", path)
+        m = re.match(r"^/([^/]+)/status/(\d+)", path)
         if m:
-            return f"x:{m.group(1)}"
+            return f"https://x.com/{m.group(1)}/status/{m.group(2)}"
         return f"https://x.com{path.rstrip('/')}"
 
     # --- Reddit ---
     if "reddit.com" in netloc:
-        # /r/{sub}/comments/{post_id}/{slug}/{comment_id}
-        # Only post_id and comment_id are identity; sub and slug are
-        # attacker-mutable (the actor echoes them back), so they are NOT keyed.
+        # /r/{sub}/comments/{post_id}/{slug}/{comment_id} — key on the IDs only.
         m = re.match(
             r"^/r/[^/]+/comments/([a-z0-9]+)(?:/[^/]*(?:/([a-z0-9]+))?)?",
             path,
         )
         if m:
             post_id, comment_id = m.group(1), m.group(2)
-            # Reddit IDs are lowercase base36 of VARIABLE length — they grow as
-            # the ID space fills (6 chars historically, 7 since ~2023, 8 in
-            # newer content; older comments can be shorter). So accept >=4 chars
-            # rather than a fixed length (a fixed guard collapses every distinct
-            # real comment whose id isn't that length into the bare post key).
-            # A short junk segment (e.g. a trailing "f1" on some post URLs) is
-            # under 4 chars, so it's ignored and the row keys as the post.
+            # Reddit base36 IDs are variable length, so accept >=4 chars.
             if comment_id and re.match(r"^[a-z0-9]{4,}$", comment_id):
                 return f"reddit:{post_id}:{comment_id}"
             return f"reddit:{post_id}"

--- a/vali_utils/url_normalizer.py
+++ b/vali_utils/url_normalizer.py
@@ -14,44 +14,58 @@ def normalize_url_for_dedup(url_str: str) -> str:
     Approach: define what a VALID canonical URL looks like, ignore everything else.
     This is not a blacklist of known exploits — it's a whitelist of valid URL structure.
 
-    X:      Only the numeric tweet ID matters. Username is lowercased (decorative — X resolves by ID).
-    Reddit: Only post_id and comment_id (base36, exactly 7 chars) matter.
+    Key on IMMUTABLE content IDs only. The slug and subreddit (Reddit) and the
+    username (X) are decorative and attacker-controlled: Reddit and the Apify
+    actor resolve a post/comment by its base36 ID regardless of slug or even
+    subreddit, and X resolves a tweet by ID regardless of username. Keying on
+    those cosmetic fields let a miner mint unlimited "unique" URLs for one real
+    piece of content (mutate the slug -> different hash -> counts as unique).
 
-    Canonical forms produced:
-      X tweet:        https://x.com/{user_lower}/status/{tweet_id}
-      Reddit post:    https://www.reddit.com/r/{sub}/comments/{post_id}/{slug}
-      Reddit comment: https://www.reddit.com/r/{sub}/comments/{post_id}/{slug}/{comment_id}
+    X:      Only the numeric tweet ID identifies the content — username dropped.
+    Reddit: Only post_id (+ comment_id) identify the content — sub + slug dropped.
+
+    Canonical (ID-only) keys produced:
+      X tweet:        x:{tweet_id}
+      Reddit post:    reddit:{post_id}
+      Reddit comment: reddit:{post_id}:{comment_id}
     """
     url = str(url_str).strip()
     parsed = urlparse(url)
     netloc = parsed.netloc.lower()
-    path = parsed.path
+    # Lowercase the path so an uppercased ID can't dodge the [a-z0-9] match
+    # (which would truncate it and collapse distinct posts to a short key).
+    path = parsed.path.lower()
 
     # --- X / Twitter ---
     if "x.com" in netloc or "twitter.com" in netloc:
-        # Extract /username/status/DIGITS — lowercase username to prevent case-fudging
-        m = re.match(r"^/([^/]+)/status/(\d+)", path)
+        # Only the numeric tweet ID is identity; username is decorative and
+        # attacker-controlled, so it is NOT part of the key.
+        m = re.match(r"^/[^/]+/status/(\d+)", path)
         if m:
-            username = m.group(1).lower()
-            tweet_id = m.group(2)
-            return f"https://x.com/{username}/status/{tweet_id}"
-        return f"https://x.com{path.rstrip('/').lower()}"
+            return f"x:{m.group(1)}"
+        return f"https://x.com{path.rstrip('/')}"
 
     # --- Reddit ---
     if "reddit.com" in netloc:
         # /r/{sub}/comments/{post_id}/{slug}/{comment_id}
+        # Only post_id and comment_id are identity; sub and slug are
+        # attacker-mutable (the actor echoes them back), so they are NOT keyed.
         m = re.match(
-            r"^/r/([^/]+)/comments/([a-z0-9]+)(?:/([^/]*)(?:/([a-z0-9]+))?)?",
+            r"^/r/[^/]+/comments/([a-z0-9]+)(?:/[^/]*(?:/([a-z0-9]+))?)?",
             path,
         )
         if m:
-            sub, post_id, slug, comment_id = m.group(1), m.group(2), m.group(3) or "", m.group(4)
-            # Real Reddit IDs are base36, exactly 7 chars (post and comment).
-            # Verified against 240K+ real comment IDs and 704 post IDs — all 7 chars.
-            # Fake IDs (f1, _f1, aaaaaa0, etc.) fail this check.
-            if comment_id and re.match(r"^[a-z0-9]{7}$", comment_id):
-                return f"https://www.reddit.com/r/{sub}/comments/{post_id}/{slug}/{comment_id}"
-            return f"https://www.reddit.com/r/{sub}/comments/{post_id}/{slug}"
+            post_id, comment_id = m.group(1), m.group(2)
+            # Reddit IDs are lowercase base36 of VARIABLE length — they grow as
+            # the ID space fills (6 chars historically, 7 since ~2023, 8 in
+            # newer content; older comments can be shorter). So accept >=4 chars
+            # rather than a fixed length (a fixed guard collapses every distinct
+            # real comment whose id isn't that length into the bare post key).
+            # A short junk segment (e.g. a trailing "f1" on some post URLs) is
+            # under 4 chars, so it's ignored and the row keys as the post.
+            if comment_id and re.match(r"^[a-z0-9]{4,}$", comment_id):
+                return f"reddit:{post_id}:{comment_id}"
+            return f"reddit:{post_id}"
         return f"https://www.reddit.com{path.rstrip('/')}"
 
     # --- Fallback: strip query/fragment, lowercase ---


### PR DESCRIPTION

normalize_url_for_dedup: key Reddit URLs on immutable content IDs only — reddit:{post_id}[:{comment_id}] Drop the decorative, attacker-mutable subreddit/slug (Reddit) ), which Reddit/the Apify actor ignore when resolving content. Lowercase the path and use a variable-length base36 guard ([a-z0-9]{4,}, since Reddit IDs grow over time) so distinct real comments never collapse and cosmetic URL variants of one piece of content dedup together.

validate_reddit_content: add URL<->content-id self-consistency check (the url equality check alone is insufficient — the actor echoes the submitted url). Covers both P2P and S3 (both reach reddit_mc_scraper.validate). Honest slug variance preserved; content stapled onto a different post/comment url fails.

MAX_DUPLICATE_RATE 5% -> 1% (honest miners dedup locally before upload).


Verified: normalizer collapse/distinctness incl. variable-length ids; scraper accepts honest + slug variance, rejects id<->url mismatch; migration resets once on v15, idempotent on v16, P2P/OD untouched.