### PR TITLE
fix: dedup Reddit URLs by immutable content ID

### DIFF
--- a/scraping/reddit/utils.py
+++ b/scraping/reddit/utils.py
@@ -111,7 +111,7 @@ def validate_reddit_content(
     # The URL's embedded id must match the content id (the actor echoes the
     # submitted URL, so the url check above can't catch a mismatched id).
     _url_m = re.match(
-        r"^/r/[^/]+/comments/([a-z0-9]{4,})(?:/[^/]*(?:/([a-z0-9]{4,}))?)?",
+        r"^/(?:r|user)/[^/]+/comments/([a-z0-9]{4,})(?:/[^/]*(?:/([a-z0-9]{4,}))?)?",
         urlparse(content_to_validate.url).path.lower(),
     )
     _url_post_id = _url_m.group(1) if _url_m else None

--- a/vali_utils/url_normalizer.py
+++ b/vali_utils/url_normalizer.py
@@ -36,9 +36,10 @@ def normalize_url_for_dedup(url_str: str) -> str:
 
     # --- Reddit ---
     if "reddit.com" in netloc:
-        # /r/{sub}/comments/{post_id}/{slug}/{comment_id} — key on the IDs only.
+        # /r/{sub}/comments/... and /user/{name}/comments/... (profile posts) —
+        # key on the IDs only.
         m = re.match(
-            r"^/r/[^/]+/comments/([a-z0-9]+)(?:/[^/]*(?:/([a-z0-9]+))?)?",
+            r"^/(?:r|user)/[^/]+/comments/([a-z0-9]+)(?:/[^/]*(?:/([a-z0-9]+))?)?",
             path,
         )
         if m:


### PR DESCRIPTION
Dedup keys Reddit URLs on immutable IDs only (`reddit:{post_id}[:{comment_id}]`), dropping the decorative subreddit/slug so cosmetic URL variants of the same content dedup together; adds a URL↔content-id consistency check in `validate_reddit_content`; handles both `/r/` and `/user/` permalink forms (variable-length base36 IDs); lowers `MAX_DUPLICATE_RATE` 5%→1%.