### PR TITLE
fix: apply S3 boost update before the P2P bucket query (prevents frozen boost)

### DIFF
--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -430,6 +430,32 @@ class MinerEvaluator:
         if not s3_validation_info or (current_block - s3_validation_info['block']) > 600:  # ~2 hrs
             s3_validation_result = await self._perform_s3_validation(uid, hotkey, current_block)
 
+        # Apply the S3 result NOW, before the P2P bucket query. The P2P step has
+        # several early returns on a failed/invalid GetDataEntityBucket response;
+        # if the S3 update were left until after them, a miner could freeze a
+        # stale (inflated) S3 boost/credibility forever by intentionally failing
+        # the bucket query. S3 scoring must not depend on the P2P outcome.
+        if s3_validation_result:
+            if s3_validation_result.is_valid:
+                bt.logging.info(
+                    f"UID:{uid} - HOTKEY:{hotkey}: Miner {uid} passed S3 validation. "
+                    f"Validation: {s3_validation_result.validation_percentage:.1f}%, "
+                    f"Jobs: {s3_validation_result.total_active_jobs}, Files: {s3_validation_result.recent_files_count}, "
+                    f"Coverage: {s3_validation_result.job_coverage_rate:.1f}%, "
+                    f"Effective size: {s3_validation_result.effective_size_bytes/(1024*1024):.1f}MB, "
+                    f"Job match: {s3_validation_result.job_match_rate:.1f}%"
+                )
+            else:
+                bt.logging.info(
+                    f"UID:{uid} - HOTKEY:{hotkey}: Miner {uid} did not pass S3 validation. "
+                    f"Reason: {s3_validation_result.reason}"
+                )
+            self.scorer.update_s3_effective_size(
+                uid=uid,
+                effective_size=s3_validation_result.effective_size_bytes,
+                validation_passed=s3_validation_result.is_valid,
+            )
+
         # From that index, find a data entity bucket to sample and get it from the miner.
         chosen_data_entity_bucket: DataEntityBucket = (
             vali_utils.choose_data_entity_bucket_to_query(index)
@@ -552,30 +578,6 @@ class MinerEvaluator:
         gc.collect()
 
         metrics.MINER_EVALUATOR_EVAL_MINER_DURATION.labels(hotkey=self.wallet.hotkey.ss58_address, miner_hotkey=hotkey, status='ok').observe(time.perf_counter() - t_start)
-
-        if s3_validation_result:
-            # Log validation result
-            if s3_validation_result.is_valid:
-                bt.logging.info(
-                    f"UID:{uid} - HOTKEY:{hotkey}: Miner {uid} passed S3 validation. "
-                    f"Validation: {s3_validation_result.validation_percentage:.1f}%, "
-                    f"Jobs: {s3_validation_result.total_active_jobs}, Files: {s3_validation_result.recent_files_count}, "
-                    f"Coverage: {s3_validation_result.job_coverage_rate:.1f}%, "
-                    f"Effective size: {s3_validation_result.effective_size_bytes/(1024*1024):.1f}MB, "
-                    f"Job match: {s3_validation_result.job_match_rate:.1f}%"
-                )
-            else:
-                bt.logging.info(
-                    f"UID:{uid} - HOTKEY:{hotkey}: Miner {uid} did not pass S3 validation. "
-                    f"Reason: {s3_validation_result.reason}"
-                )
-
-            # Update scorer with competition-based effective_size
-            self.scorer.update_s3_effective_size(
-                uid=uid,
-                effective_size=s3_validation_result.effective_size_bytes,
-                validation_passed=s3_validation_result.is_valid,
-            )
 
     async def _perform_s3_validation(
         self, uid: int, hotkey: str, current_block: int


### PR DESCRIPTION
## Problem

S3 validation runs early in `eval_miner`, but `update_s3_effective_size` was at the very end of the method — after three early `return`s that fire on a failed/invalid `GetDataEntityBucket` (P2P) response. A miner can intentionally fail the bucket query to hit one of those returns, so the S3 update never runs. Their `s3_boost` and `s3_credibility` stay frozen at their last (inflated) values indefinitely, even though they no longer pass S3 validation — letting one miner keep the largest S3 boost while having less data than others.

## Fix

Move the S3 boost/credibility update to immediately after `_perform_s3_validation`, before the P2P bucket query. S3 scoring no longer depends on the P2P outcome, so a failed bucket query can't skip it. No behavior change on the happy path; the same single update runs with the same arguments.

No score reset in this PR — existing boosts decay naturally once evaluations apply again.

Reported by Mariss.
