### PR TITLE
feat(od): coverage measurement + abstention penalty + OD score reset

### DIFF
--- a/common/api_client.py
+++ b/common/api_client.py
@@ -210,6 +210,28 @@ class ListMinerJobsForValidationResponse(BaseModel):
     jobs: List[MinerJobForValidation]
 
 
+class OnDemandJobsStatsRequest(BaseModel):
+    """Request for per-platform job counts within an expiry window."""
+    expired_since: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc) - timedelta(hours=2)
+    )
+    expired_until: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+    min_submitters: int = Field(default=5, ge=1, le=100)
+
+
+class PlatformJobStats(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    total_jobs: int = 0
+    doable_jobs: int = 0
+
+
+class OnDemandJobsStatsResponse(BaseModel):
+    platforms: Dict[str, PlatformJobStats]
+
+
 def _sha256_hex(data: bytes) -> str:
     return sha256(data).hexdigest()
 
@@ -462,6 +484,19 @@ class DataUniverseApiClient:
         )
         _raise_for_status(resp)
         return ListMinerJobsForValidationResponse.model_validate_json(resp.text)
+
+    async def validator_get_jobs_stats(
+        self, req: OnDemandJobsStatsRequest
+    ) -> OnDemandJobsStatsResponse:
+        """Per-platform job totals for a window — OD coverage denominators."""
+        if not self._signer:
+            raise RuntimeError("validator_keypair was not provided.")
+
+        resp = await self._post_signed_json(
+            "/on-demand/validator/jobs/stats", self._signer, req.model_dump_json()
+        )
+        _raise_for_status(resp)
+        return OnDemandJobsStatsResponse.model_validate_json(resp.text)
 
     async def validator_list_and_download_submission_json(
         self,

--- a/rewards/miner_scorer.py
+++ b/rewards/miner_scorer.py
@@ -33,7 +33,7 @@ class MinerScorer:
     # v15: Reset S3 — latest-file-per-job validation + whole-job-snapshot miner uploads.
     #      Old effective_size/credibility was computed across all historical chunks; new
     #      model counts only the latest snapshot per job, so prior scores are not comparable.
-    STATE_VERSION = 15
+    STATE_VERSION = 16
 
     # Start new miner's at a credibility of 0.
     STARTING_CREDIBILITY = 0
@@ -148,6 +148,15 @@ class MinerScorer:
                 self.s3_boosts.zero_()
                 self.s3_credibility.fill_(MinerScorer.STARTING_S3_CREDIBILITY)
                 self.effective_sizes.zero_()
+
+            if saved_version < 16:
+                bt.logging.warning(
+                    f"State migration v{saved_version} -> v16: "
+                    f"OnDemand boost/credibility reset (coverage-based OD scoring "
+                    f"rollout — boosts rebuild from the next OD evals)"
+                )
+                self.ondemand_boosts.zero_()
+                self.ondemand_credibility.fill_(MinerScorer.STARTING_ONDEMAND_CREDIBILITY)
 
     def get_scores(self) -> torch.Tensor:
         """Returns the raw scores of all miners."""

--- a/scripts/test_od_jobs_stats.py
+++ b/scripts/test_od_jobs_stats.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Standalone smoke test for the OD jobs-stats endpoint (data-universe-api PR #103).
+
+Signs requests with a real validator hotkey and:
+  1. calls POST /on-demand/validator/jobs/stats for the trailing window,
+  2. fetches the metagraph, picks the top-N miners by incentive (plus any
+     --miner hotkeys), and prints their full per-platform OD stats:
+     coverage vs doable jobs, empty submissions, submitted bytes.
+
+Usage (from repo root):
+  python scripts/test_od_jobs_stats.py --wallet-name <name> --wallet-hotkey <hotkey>
+  python scripts/test_od_jobs_stats.py --wallet-name <name> --wallet-hotkey <hotkey> \
+      --top 5 --skip-uid 162 --miner 5Dvenu...
+"""
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+def signed_post(client, signer, url: str, payload: dict):
+    body = json.dumps(payload).encode()
+    headers = {"Content-Type": "application/json", **signer.headers(body)}
+    return client.post(url, content=body, headers=headers)
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--wallet-name", required=True)
+    p.add_argument("--wallet-hotkey", required=True)
+    p.add_argument("--url", default="https://data-universe-api.api.macrocosmos.ai")
+    p.add_argument("--hours", type=float, default=3.0, help="trailing window size")
+    p.add_argument("--min-submitters", type=int, default=5)
+    p.add_argument("--top", type=int, default=5,
+                   help="check the top-N miners by incentive (0 to disable)")
+    p.add_argument("--skip-uid", type=int, action="append", default=[],
+                   help="UID to exclude from the top-N pick (repeatable)")
+    p.add_argument("--miner", action="append", default=[],
+                   help="extra miner hotkey to check (repeatable)")
+    p.add_argument("--netuid", type=int, default=13)
+    p.add_argument("--network", default="finney")
+    args = p.parse_args()
+
+    # Import after argparse — bittensor intercepts -h/--help at import time.
+    import httpx
+    import bittensor as bt
+    from common.api_client import TaoSigner
+
+    wallet = bt.wallet(name=args.wallet_name, hotkey=args.wallet_hotkey)
+    signer = TaoSigner(keypair=wallet.hotkey)
+    print(f"validator hotkey: {wallet.hotkey.ss58_address}")
+
+    # Build the miner list: top-N by incentive from the metagraph + manual ones.
+    miners = []  # (label, hotkey)
+    if args.top > 0:
+        print(f"fetching metagraph (netuid={args.netuid}, {args.network})...")
+        mg = bt.metagraph(netuid=args.netuid, network=args.network, lite=True)
+        order = sorted(range(len(mg.hotkeys)), key=lambda u: -float(mg.I[u]))
+        picked = 0
+        for uid in order:
+            if uid in args.skip_uid:
+                continue
+            miners.append((f"uid={uid} inc={float(mg.I[uid]):.5f}", mg.hotkeys[uid]))
+            picked += 1
+            if picked >= args.top:
+                break
+    miners.extend((f"manual", hk) for hk in args.miner)
+
+    n_calls = 1 + len(miners)
+    if n_calls > 12:
+        print(f"warning: {n_calls} calls exceeds the 12/min validator rate limit")
+
+    now = datetime.now(timezone.utc)
+    window = {
+        "expired_since": (now - timedelta(hours=args.hours)).isoformat(),
+        "expired_until": now.isoformat(),
+    }
+
+    with httpx.Client(timeout=60) as client:
+        # 1. jobs stats (coverage denominators)
+        r = signed_post(
+            client, signer, f"{args.url}/on-demand/validator/jobs/stats",
+            {**window, "min_submitters": args.min_submitters},
+        )
+        print(f"\n[stats] HTTP {r.status_code}  (window: last {args.hours:g}h)")
+        if r.status_code != 200:
+            print(r.text[:500])
+            sys.exit(1)
+        stats = r.json()["platforms"]
+        for platform, s in sorted(stats.items()):
+            print(f"  {platform:8s} total={s['total_jobs']:<5d} "
+                  f"doable(>={args.min_submitters} miners)={s['doable_jobs']}")
+
+        # 2. full per-miner stats over the same window
+        for label, hotkey in miners:
+            r = signed_post(
+                client, signer, f"{args.url}/on-demand/validator/miner-jobs",
+                {**window, "miner_hotkey": hotkey, "limit": 1000},
+            )
+            print(f"\n[miner] {hotkey}  ({label})  HTTP {r.status_code}")
+            if r.status_code != 200:
+                print(f"  {r.text[:300]}")
+                continue
+            jobs = r.json()["jobs"]
+
+            per = {}  # platform -> dict
+            for j in jobs:
+                platform = j["job"]["job"]["platform"]
+                d = per.setdefault(
+                    platform, {"jobs": 0, "empty": 0, "bytes": 0}
+                )
+                d["jobs"] += 1
+                size = j["submission"].get("s3_content_length") or 0
+                d["bytes"] += size
+                if size == 0:
+                    d["empty"] += 1
+
+            for platform, s in sorted(stats.items()):
+                d = per.get(platform, {"jobs": 0, "empty": 0, "bytes": 0})
+                doable = s["doable_jobs"]
+                cov = f"{min(1.0, d['jobs'] / doable):6.1%}" if doable else "   n/a"
+                print(f"  {platform:8s} submitted={d['jobs']:<4d} doable={doable:<4d} "
+                      f"coverage={cov}  empty={d['empty']:<3d} bytes={d['bytes']:,}")
+            if len(jobs) == 1000:
+                print("  (warning: hit limit=1000, counts may be truncated)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/rewards/test_miner_scorer_state.py
+++ b/tests/rewards/test_miner_scorer_state.py
@@ -1,0 +1,65 @@
+"""Tests for MinerScorer state save/load migrations."""
+
+import os
+import tempfile
+import unittest
+
+import torch
+
+from rewards.data_value_calculator import DataValueCalculator
+from rewards.miner_scorer import MinerScorer
+
+
+class TestStateMigrationV16(unittest.TestCase):
+    """v16 resets OnDemand boost/credibility only; everything else survives."""
+
+    def _roundtrip(self, mutate_saved_version=None):
+        n = 8
+        scorer = MinerScorer(n, DataValueCalculator())
+        scorer.scores = torch.rand(n)
+        scorer.miner_credibility = torch.rand(n, 1)
+        scorer.s3_boosts = torch.rand(n)
+        scorer.s3_credibility = torch.rand(n, 1)
+        scorer.ondemand_boosts = torch.rand(n) * 100
+        scorer.ondemand_credibility = torch.rand(n, 1)
+
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "scorer.pickle")
+            scorer.save_state(path)
+            if mutate_saved_version is not None:
+                state = torch.load(path, weights_only=True)
+                state["state_version"] = mutate_saved_version
+                torch.save(state, path)
+
+            loaded = MinerScorer(n, DataValueCalculator())
+            loaded.load_state(path)
+            return scorer, loaded
+
+    def test_old_state_resets_od_only(self):
+        saved, loaded = self._roundtrip(mutate_saved_version=15)
+
+        # OD reset
+        self.assertTrue(torch.all(loaded.ondemand_boosts == 0))
+        self.assertTrue(
+            torch.all(
+                loaded.ondemand_credibility
+                == MinerScorer.STARTING_ONDEMAND_CREDIBILITY
+            )
+        )
+        # everything else preserved
+        self.assertTrue(torch.equal(loaded.scores, saved.scores))
+        self.assertTrue(torch.equal(loaded.miner_credibility, saved.miner_credibility))
+        self.assertTrue(torch.equal(loaded.s3_boosts, saved.s3_boosts))
+        self.assertTrue(torch.equal(loaded.s3_credibility, saved.s3_credibility))
+
+    def test_current_state_untouched(self):
+        saved, loaded = self._roundtrip()
+
+        self.assertTrue(torch.equal(loaded.ondemand_boosts, saved.ondemand_boosts))
+        self.assertTrue(
+            torch.equal(loaded.ondemand_credibility, saved.ondemand_credibility)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/vali_utils/test_od_coverage_shadow.py
+++ b/tests/vali_utils/test_od_coverage_shadow.py
@@ -1,0 +1,172 @@
+"""Tests for the OD coverage shadow measurement (log-only, no scoring impact).
+
+Covers:
+- _log_od_coverage_shadow: per-platform numerators, thin-window skip, clamping
+- _get_od_jobs_stats: caching across calls, failure tolerance
+- _evaluate_od: reward path still restricted to the since-last-eval window
+"""
+
+import asyncio
+import datetime as dt
+import json
+import threading
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from common.api_client import (
+    MinerJobForValidation,
+    OnDemandJob,
+    OnDemandJobSubmission,
+    OnDemandJobsStatsResponse,
+    PlatformJobStats,
+)
+from vali_utils.miner_evaluator import MinerEvaluator
+
+
+def _stub_evaluator():
+    """MinerEvaluator instance without running __init__ (heavy deps)."""
+    ev = MinerEvaluator.__new__(MinerEvaluator)
+    ev._od_stats_cache = None
+    ev._od_stats_lock = threading.Lock()
+    ev._last_od_eval_at = {}
+    ev.on_demand_validator = MagicMock()
+    return ev
+
+
+def _job(platform: str, expire_at: dt.datetime, content_length: int = 100) -> MinerJobForValidation:
+    payload = {"platform": platform, "keywords": ["k"]}
+    return MinerJobForValidation(
+        job=OnDemandJob(id="j", expire_at=expire_at, job=payload),
+        submission=OnDemandJobSubmission(job_id="j", s3_content_length=content_length),
+    )
+
+
+def _stats(reddit=(90, 85), x=(60, 4)) -> OnDemandJobsStatsResponse:
+    return OnDemandJobsStatsResponse(
+        platforms={
+            "reddit": PlatformJobStats(total_jobs=reddit[0], doable_jobs=reddit[1]),
+            "x": PlatformJobStats(total_jobs=x[0], doable_jobs=x[1]),
+        }
+    )
+
+
+class TestLogCoverageShadow(unittest.TestCase):
+    def setUp(self):
+        self.ev = _stub_evaluator()
+        self.now = dt.datetime.now(dt.timezone.utc)
+        self.since = self.now - dt.timedelta(hours=3)
+
+    def _capture_event(self, jobs, stats):
+        with patch("vali_utils.miner_evaluator.bt.logging.info") as mock_log:
+            self.ev._log_od_coverage_shadow(1, "hk", jobs, stats, self.since)
+            if not mock_log.call_args_list:
+                return None
+            return json.loads(mock_log.call_args_list[-1].args[0])
+
+    def test_counts_per_platform_within_window(self):
+        in_window = self.now - dt.timedelta(hours=1)
+        out_of_window = self.now - dt.timedelta(hours=5)
+        jobs = [
+            _job("reddit", in_window, content_length=9_000),
+            _job("reddit", in_window, content_length=11_000),
+            _job("reddit", out_of_window, content_length=999_999),  # excluded
+            _job("x", in_window, content_length=500),
+        ]
+        event = self._capture_event(jobs, _stats(reddit=(90, 85), x=(60, 40)))
+        self.assertEqual(event["reddit"]["submitted"], 2)
+        self.assertEqual(event["x"]["submitted"], 1)
+        self.assertAlmostEqual(event["reddit"]["coverage"], 2 / 85, places=4)
+        self.assertAlmostEqual(event["x"]["coverage"], 1 / 40, places=4)
+        self.assertEqual(event["reddit"]["bytes"], 20_000)
+        self.assertEqual(event["reddit"]["avg_bytes"], 10_000)
+        self.assertEqual(event["x"]["bytes"], 500)
+
+    def test_thin_platform_reports_null_coverage(self):
+        """Below OD_COVERAGE_MIN_PLATFORM_JOBS doable jobs -> coverage is None."""
+        jobs = [_job("x", self.now - dt.timedelta(hours=1))]
+        event = self._capture_event(jobs, _stats(x=(60, 4)))
+        self.assertIsNone(event["x"]["coverage"])
+        self.assertEqual(event["x"]["submitted"], 1)  # still reported raw
+
+    def test_coverage_clamped_to_one(self):
+        """Submitting to more jobs than doable (non-doable jobs) clamps at 1.0."""
+        in_window = self.now - dt.timedelta(hours=1)
+        jobs = [_job("reddit", in_window) for _ in range(50)]
+        event = self._capture_event(jobs, _stats(reddit=(45, 40)))
+        self.assertEqual(event["reddit"]["coverage"], 1.0)
+
+    def test_no_stats_logs_nothing(self):
+        event = self._capture_event([_job("reddit", self.now)], None)
+        self.assertIsNone(event)
+
+
+class TestStatsCache(unittest.TestCase):
+    def setUp(self):
+        self.ev = _stub_evaluator()
+
+    def test_second_call_uses_cache(self):
+        client = MagicMock()
+        client.validator_get_jobs_stats = AsyncMock(return_value=_stats())
+
+        first = asyncio.run(self.ev._get_od_jobs_stats(client))
+        second = asyncio.run(self.ev._get_od_jobs_stats(client))
+
+        self.assertIs(first, second)
+        client.validator_get_jobs_stats.assert_awaited_once()
+
+    def test_fetch_failure_returns_none_and_does_not_cache(self):
+        client = MagicMock()
+        client.validator_get_jobs_stats = AsyncMock(side_effect=RuntimeError("boom"))
+
+        self.assertIsNone(asyncio.run(self.ev._get_od_jobs_stats(client)))
+        self.assertIsNone(self.ev._od_stats_cache)
+
+        # A later successful fetch works.
+        client.validator_get_jobs_stats = AsyncMock(return_value=_stats())
+        self.assertIsNotNone(asyncio.run(self.ev._get_od_jobs_stats(client)))
+
+
+class TestEvaluateOdRewardWindow(unittest.TestCase):
+    def test_reward_path_only_sees_since_last_eval_jobs(self):
+        """Coverage fetch widens the window; rewards must not resample old jobs."""
+        ev = _stub_evaluator()
+        ev.scorer = MagicMock()
+
+        now = dt.datetime.now(dt.timezone.utc)
+        last_eval = now - dt.timedelta(minutes=30)
+        ev._last_od_eval_at = {"hk": last_eval}
+
+        new_job = _job("reddit", now - dt.timedelta(minutes=10))
+        old_job = _job("reddit", now - dt.timedelta(hours=2))  # in 3h coverage window only
+
+        resp = MagicMock()
+        resp.jobs = [new_job, old_job]
+        client = MagicMock()
+        client.validator_list_miner_jobs = AsyncMock(return_value=resp)
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+        ev._on_demand_client = MagicMock(return_value=client)
+        ev._get_od_jobs_stats = AsyncMock(return_value=_stats())
+        ev._log_od_coverage_shadow = MagicMock()
+        ev._validate_od_submission = AsyncMock(return_value=(True, 10))
+        ev.on_demand_validator.calculate_ondemand_reward_multipliers = MagicMock(
+            return_value=(1.0, 1.0)
+        )
+
+        asyncio.run(ev._evaluate_od(1, "hk"))
+
+        # The wide fetch went out, but only the new job reached rewards.
+        fetch_req = client.validator_list_miner_jobs.await_args.args[0]
+        self.assertLessEqual(
+            fetch_req.expired_since, now - dt.timedelta(hours=3) + dt.timedelta(seconds=5)
+        )
+        ev._validate_od_submission.assert_awaited_once()
+        validated_job = ev._validate_od_submission.await_args.args[2]
+        self.assertIs(validated_job, new_job.job)
+        # Coverage shadow saw BOTH jobs.
+        shadow_jobs = ev._log_od_coverage_shadow.call_args.args[2]
+        self.assertEqual(len(shadow_jobs), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -1,6 +1,7 @@
 import os
 import gc
 import copy
+import json
 import asyncio
 import random
 import traceback
@@ -46,7 +47,10 @@ import httpx
 from common.api_client import (
     DataUniverseApiClient,
     ListMinerJobsForValidationRequest,
+    MinerJobForValidation,
     OnDemandJob,
+    OnDemandJobsStatsRequest,
+    OnDemandJobsStatsResponse,
     OnDemandJobSubmission,
     OnDemandMinerUpload,
 )
@@ -107,6 +111,10 @@ class MinerEvaluator:
         # Track last OD eval time per miner to query only new jobs each cycle.
         # Not persisted — on restart defaults to a 2h lookback window.
         self._last_od_eval_at: Dict[str, dt.datetime] = {}
+        # OD jobs-stats cache: identical for every miner in a batch, so fetch
+        # rarely and share. Guarded by a lock — miner evals run in parallel.
+        self._od_stats_cache: Optional[Tuple[dt.datetime, OnDemandJobsStatsResponse]] = None
+        self._od_stats_lock = threading.Lock()
         # Cache API client construction params (derived once, reused every eval).
         self._api_base_url = self.config.s3_auth_url
         self._api_verify_ssl = "localhost" not in self._api_base_url
@@ -157,6 +165,88 @@ class MinerEvaluator:
     OD_MAX_JOBS_TO_VALIDATE = 3
     # Number of entities to schema-check per downloaded submission.
     OD_SCHEMA_SAMPLE_SIZE = 5
+    # OD coverage shadow measurement (log-only, no scoring impact yet):
+    # trailing window and the 'doable' threshold for the denominator.
+    OD_COVERAGE_WINDOW_HOURS = 3
+    OD_COVERAGE_MIN_SUBMITTERS = 5
+    # Below this many doable jobs on a platform the window is too thin to judge.
+    OD_COVERAGE_MIN_PLATFORM_JOBS = 20
+    # Stats are identical for every miner in a batch — cache and refetch rarely.
+    OD_STATS_CACHE_TTL_SECS = 600
+
+    async def _get_od_jobs_stats(
+        self, client: DataUniverseApiClient
+    ) -> Optional[OnDemandJobsStatsResponse]:
+        """Per-platform job totals for the coverage window, cached across the batch."""
+        now = dt.datetime.now(dt.timezone.utc)
+        with self._od_stats_lock:
+            if self._od_stats_cache is not None:
+                fetched_at, cached = self._od_stats_cache
+                if (now - fetched_at).total_seconds() < self.OD_STATS_CACHE_TTL_SECS:
+                    return cached
+            try:
+                resp = await client.validator_get_jobs_stats(
+                    OnDemandJobsStatsRequest(
+                        expired_since=now
+                        - dt.timedelta(hours=self.OD_COVERAGE_WINDOW_HOURS),
+                        expired_until=now,
+                        min_submitters=self.OD_COVERAGE_MIN_SUBMITTERS,
+                    )
+                )
+            except Exception as e:
+                bt.logging.warning(
+                    f"OD jobs-stats fetch failed (coverage shadow skipped): {e}"
+                )
+                return None
+            self._od_stats_cache = (now, resp)
+            return resp
+
+    def _log_od_coverage_shadow(
+        self,
+        uid: int,
+        hotkey: str,
+        all_jobs: List["MinerJobForValidation"],
+        stats: Optional[OnDemandJobsStatsResponse],
+        coverage_since: dt.datetime,
+    ) -> None:
+        """Shadow-log per-platform OD coverage. Measurement only — no score impact."""
+        if stats is None:
+            return
+        submitted: Dict[str, int] = {}
+        volume_bytes: Dict[str, int] = {}
+        for j in all_jobs:
+            exp = j.job.expire_at
+            if exp is None or exp < coverage_since:
+                continue
+            platform = j.job.job.platform
+            submitted[platform] = submitted.get(platform, 0) + 1
+            volume_bytes[platform] = volume_bytes.get(platform, 0) + (
+                j.submission.s3_content_length or 0
+            )
+
+        event = {
+            "event": "od_coverage_shadow",
+            "uid": uid,
+            "hotkey": hotkey,
+            "window_hours": self.OD_COVERAGE_WINDOW_HOURS,
+        }
+        for platform, pstats in stats.platforms.items():
+            done = submitted.get(platform, 0)
+            coverage = (
+                round(min(1.0, done / pstats.doable_jobs), 4)
+                if pstats.doable_jobs >= self.OD_COVERAGE_MIN_PLATFORM_JOBS
+                else None  # too few jobs this window to judge
+            )
+            total_bytes = volume_bytes.get(platform, 0)
+            event[platform] = {
+                "submitted": done,
+                "doable": pstats.doable_jobs,
+                "total": pstats.total_jobs,
+                "coverage": coverage,
+                "bytes": total_bytes,
+                "avg_bytes": round(total_bytes / done) if done else 0,
+            }
+        bt.logging.info(json.dumps(event))
 
     async def _evaluate_od(self, uid: int, hotkey: str) -> None:
         """Evaluate a miner's on-demand submissions by querying the API directly.
@@ -173,24 +263,36 @@ class MinerEvaluator:
         expired_since = self._last_od_eval_at.get(
             hotkey, now - dt.timedelta(hours=2)
         )
+        # Fetch wide enough to also cover the coverage window; the reward
+        # path below still only sees jobs from the since-last-eval window.
+        coverage_since = now - dt.timedelta(hours=self.OD_COVERAGE_WINDOW_HOURS)
+        fetch_since = min(expired_since, coverage_since)
 
         try:
             async with self._on_demand_client() as client:
                 resp = await client.validator_list_miner_jobs(
                     ListMinerJobsForValidationRequest(
                         miner_hotkey=hotkey,
-                        expired_since=expired_since,
+                        expired_since=fetch_since,
                         expired_until=now,
-                        limit=500,
+                        limit=1000,
                     )
                 )
+                stats = await self._get_od_jobs_stats(client)
         except Exception as e:
             bt.logging.warning(f"UID:{uid} - HOTKEY:{hotkey}: OD API fetch failed: {e}")
             return
 
         self._last_od_eval_at[hotkey] = now
 
-        jobs = resp.jobs
+        self._log_od_coverage_shadow(uid, hotkey, resp.jobs, stats, coverage_since)
+
+        # Reward path: unchanged semantics — only jobs from the since-last-eval window.
+        jobs = [
+            j
+            for j in resp.jobs
+            if j.job.expire_at is None or j.job.expire_at >= expired_since
+        ]
         if not jobs:
             return
 
@@ -226,6 +328,25 @@ class MinerEvaluator:
             )
             for j in to_validate
         ])
+
+        # Rows+bytes for the sampled jobs — calibrates the bytes-only volume
+        # signal in od_coverage_shadow (bytes/row ratio per miner/platform).
+        bt.logging.info(json.dumps({
+            "event": "od_sampled_rows",
+            "uid": uid,
+            "hotkey": hotkey,
+            "sampled": [
+                {
+                    "job_id": j.submission.job_id,
+                    "platform": j.job.job.platform,
+                    "limit": j.job.limit,
+                    "rows": count,
+                    "bytes": j.submission.s3_content_length or 0,
+                    "passed": passed,
+                }
+                for j, (passed, count) in zip(to_validate, validation_results)
+            ],
+        }))
 
         # Apply per-job rewards/penalties based on validation results
         validated_pass = 0


### PR DESCRIPTION
Two changes toward coverage-based OD scoring:

**1. Coverage shadow measurement — log-only, no scoring impact.** Each miner eval measures per-platform OD job coverage over a trailing 3h window using `/on-demand/validator/jobs/stats` (data-universe-api #103, deployed): `coverage = jobs submitted ÷ doable jobs` (doable = ≥5 distinct submitters, so niche jobs nobody could serve don't count). Emits structured `od_coverage_shadow` events (incl. byte volume per platform) and `od_sampled_rows` (exact rows for spot-checked jobs — calibrates bytes→rows). Platforms with <20 doable jobs log `coverage: null` instead of judging. Stats cached 10 min across the eval batch. The reward path is unchanged — a test asserts widened fetches never leak old jobs into rewards.

**2. OD score reset (STATE_VERSION 15→16).** Zeroes `ondemand_boosts` and resets `ondemand_credibility` to 0.5 for all miners. P2P and S3 state untouched. Expect weights to re-form over the first eval sweep after restart.

9 new tests. Pre-existing `test_od_flow.py` failures on dev are unrelated (reproduced on clean origin/dev).

Follow-up (separate PR): abstention penalty + relative OD scoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)