### PR TITLE
feat(od): abstention penalty — zero submissions on a servable platform cuts OD score

### DIFF
--- a/rewards/miner_scorer.py
+++ b/rewards/miner_scorer.py
@@ -58,6 +58,13 @@ class MinerScorer:
     # This factor scales down the raw P2P score so it stays the smallest component.
     P2P_REWARD_SCALE = 0.05
 
+    # OD abstention penalty: miners that submit to ZERO jobs on a judgeable
+    # platform (doable jobs existed, they sent nothing) get their od_component
+    # scaled by this per abstained platform. Via the S3<=2xOD and P2P<=S3+OD
+    # caps this drags the whole composite score. Recovers to 1.0 the moment
+    # they participate again.
+    OD_ABSTAIN_MULT = 0.3
+
 
     def __init__(
         self,
@@ -93,6 +100,11 @@ class MinerScorer:
             (num_neurons, 1), MinerScorer.STARTING_ONDEMAND_CREDIBILITY, dtype=torch.float32
         )
 
+        # OD abstention multiplier: 1.0 for miners that submit to jobs on every
+        # judgeable platform, OD_ABSTAIN_MULT^k for k abstained platforms.
+        # Set each eval from coverage measurement; scales od_component only.
+        self.od_coverage_mult = torch.ones(num_neurons, dtype=torch.float32)
+
         # Competition-based S3 scoring: stores effective_size for each miner
         # effective_size = total_size_bytes × coverage² (set during S3 validation)
         # S3 boost is calculated as: (my_effective_size / total_effective_size) × max_boost
@@ -115,6 +127,7 @@ class MinerScorer:
                     "scorable_bytes": self.scorable_bytes,
                     "ondemand_boosts": self.ondemand_boosts,
                     "ondemand_credibility": self.ondemand_credibility,
+                    "od_coverage_mult": self.od_coverage_mult,
                     "effective_sizes": self.effective_sizes,
                 },
                 filepath,
@@ -136,6 +149,9 @@ class MinerScorer:
             self.ondemand_credibility = state.get("ondemand_credibility", torch.full(
                 (self.scores.size(0), 1), MinerScorer.STARTING_ONDEMAND_CREDIBILITY, dtype=torch.float32
             ))
+            self.od_coverage_mult = state.get(
+                "od_coverage_mult", torch.ones(self.scores.size(0), dtype=torch.float32)
+            )
             self.effective_sizes = state.get("effective_sizes", torch.zeros(self.scores.size(0), dtype=torch.float64))
 
             # --- State migrations ---
@@ -180,7 +196,11 @@ class MinerScorer:
 
                 p2p_component = float(self.scorable_bytes[uid]) * MinerScorer.P2P_REWARD_SCALE * p2p_cred
                 s3_component = float(self.s3_boosts[uid]) * s3_cred
-                od_component = float(self.ondemand_boosts[uid]) * od_cred
+                od_component = (
+                    float(self.ondemand_boosts[uid])
+                    * od_cred
+                    * float(self.od_coverage_mult[uid])
+                )
 
                 # S3 cap (existing): S3 <= 2x OD
                 if od_component > 0:
@@ -211,7 +231,21 @@ class MinerScorer:
             self.s3_credibility[uid] = MinerScorer.STARTING_S3_CREDIBILITY
             self.ondemand_boosts[uid] = 0.0
             self.ondemand_credibility[uid] = MinerScorer.STARTING_ONDEMAND_CREDIBILITY
+            self.od_coverage_mult[uid] = 1.0
             self.effective_sizes[uid] = 0.0
+
+    def set_od_coverage_mult(self, uid: int, mult: float) -> None:
+        """Sets the OD abstention multiplier from the coverage measurement."""
+        with self.lock:
+            old = float(self.od_coverage_mult[uid])
+            self.od_coverage_mult[uid] = max(0.0, min(1.0, mult))
+            if old != float(self.od_coverage_mult[uid]):
+                bt.logging.info(json.dumps({
+                    "event": "od_coverage_mult",
+                    "uid": uid,
+                    "before": round(old, 4),
+                    "after": round(float(self.od_coverage_mult[uid]), 4),
+                }))
 
     def get_miner_credibility(self, uid: int) -> float:
         """Returns the credibility of miner 'uid'."""
@@ -275,6 +309,9 @@ class MinerScorer:
                         dtype=torch.float32,
                     ),
                 ]
+            )
+            self.od_coverage_mult = torch.cat(
+                [self.od_coverage_mult, torch.ones(to_add, dtype=torch.float32)]
             )
             self.effective_sizes = torch.cat(
                 [self.effective_sizes, torch.zeros(to_add, dtype=torch.float64)]

--- a/tests/vali_utils/test_od_coverage_shadow.py
+++ b/tests/vali_utils/test_od_coverage_shadow.py
@@ -126,6 +126,100 @@ class TestStatsCache(unittest.TestCase):
         self.assertIsNotNone(asyncio.run(self.ev._get_od_jobs_stats(client)))
 
 
+class TestAbstentionPenalty(unittest.TestCase):
+    def _run_eval(self, jobs, stats):
+        ev = _stub_evaluator()
+        ev.scorer = MagicMock()
+        resp = MagicMock()
+        resp.jobs = jobs
+        client = MagicMock()
+        client.validator_list_miner_jobs = AsyncMock(return_value=resp)
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+        ev._on_demand_client = MagicMock(return_value=client)
+        ev._get_od_jobs_stats = AsyncMock(return_value=stats)
+        ev._log_od_coverage_shadow = MagicMock()
+        ev._validate_od_submission = AsyncMock(return_value=(True, 10))
+        ev.on_demand_validator.calculate_ondemand_reward_multipliers = MagicMock(
+            return_value=(1.0, 1.0)
+        )
+        asyncio.run(ev._evaluate_od(1, "hk"))
+        return ev
+
+    def test_x_abstainer_penalized(self):
+        """Reddit-only miner gets OD_ABSTAIN_MULT when doable X jobs existed."""
+        from rewards.miner_scorer import MinerScorer
+
+        now = dt.datetime.now(dt.timezone.utc)
+        jobs = [_job("reddit", now - dt.timedelta(hours=1))]
+        ev = self._run_eval(jobs, _stats(reddit=(90, 85), x=(60, 4)))
+        ev.scorer.set_od_coverage_mult.assert_called_once_with(
+            1, MinerScorer.OD_ABSTAIN_MULT
+        )
+
+    def test_fully_absent_miner_penalized_on_both(self):
+        """Zero submissions anywhere -> penalty applied per platform, despite early return."""
+        from rewards.miner_scorer import MinerScorer
+
+        ev = self._run_eval([], _stats(reddit=(90, 85), x=(60, 4)))
+        ev.scorer.set_od_coverage_mult.assert_called_once_with(
+            1, MinerScorer.OD_ABSTAIN_MULT ** 2
+        )
+
+    def test_thin_platform_not_judged_for_abstention(self):
+        """X with fewer doable jobs than OD_ABSTAIN_MIN_PLATFORM_JOBS is skipped."""
+        now = dt.datetime.now(dt.timezone.utc)
+        jobs = [_job("reddit", now - dt.timedelta(hours=1))]
+        ev = self._run_eval(jobs, _stats(reddit=(90, 85), x=(60, 2)))
+        ev.scorer.set_od_coverage_mult.assert_called_once_with(1, 1.0)
+
+    def test_participant_restored_to_full_mult(self):
+        now = dt.datetime.now(dt.timezone.utc)
+        jobs = [
+            _job("reddit", now - dt.timedelta(hours=1)),
+            _job("x", now - dt.timedelta(hours=1)),
+        ]
+        ev = self._run_eval(jobs, _stats(reddit=(90, 85), x=(60, 4)))
+        ev.scorer.set_od_coverage_mult.assert_called_once_with(1, 1.0)
+
+
+class TestScorerCoverageMult(unittest.TestCase):
+    def test_mult_scales_od_and_drags_caps(self):
+        from rewards.data_value_calculator import DataValueCalculator
+        from rewards.miner_scorer import MinerScorer
+        import torch
+
+        scorer = MinerScorer(2, DataValueCalculator())
+        for uid in (0, 1):
+            scorer.ondemand_boosts[uid] = 100.0
+            scorer.ondemand_credibility[uid] = 1.0
+            scorer.s3_boosts[uid] = 1000.0
+            scorer.s3_credibility[uid] = 1.0
+
+        scorer.set_od_coverage_mult(1, MinerScorer.OD_ABSTAIN_MULT)
+        scores = scorer.get_scores_for_weights()
+
+        # uid0: od=100, s3 capped at 200 -> 300. uid1: od=30, s3 capped at 60 -> 90.
+        self.assertAlmostEqual(float(scores[0]), 300.0, places=2)
+        self.assertAlmostEqual(float(scores[1]), 90.0, places=2)
+
+    def test_state_roundtrip_preserves_mult(self):
+        import os
+        import tempfile
+        from rewards.data_value_calculator import DataValueCalculator
+        from rewards.miner_scorer import MinerScorer
+
+        scorer = MinerScorer(4, DataValueCalculator())
+        scorer.set_od_coverage_mult(2, 0.3)
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "scorer.pickle")
+            scorer.save_state(path)
+            loaded = MinerScorer(4, DataValueCalculator())
+            loaded.load_state(path)
+        self.assertAlmostEqual(float(loaded.od_coverage_mult[2]), 0.3, places=4)
+        self.assertAlmostEqual(float(loaded.od_coverage_mult[0]), 1.0, places=4)
+
+
 class TestEvaluateOdRewardWindow(unittest.TestCase):
     def test_reward_path_only_sees_since_last_eval_jobs(self):
         """Coverage fetch widens the window; rewards must not resample old jobs."""

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -165,12 +165,16 @@ class MinerEvaluator:
     OD_MAX_JOBS_TO_VALIDATE = 3
     # Number of entities to schema-check per downloaded submission.
     OD_SCHEMA_SAMPLE_SIZE = 5
-    # OD coverage shadow measurement (log-only, no scoring impact yet):
-    # trailing window and the 'doable' threshold for the denominator.
+    # OD coverage measurement: trailing window and the 'doable' threshold
+    # for the denominator.
     OD_COVERAGE_WINDOW_HOURS = 3
     OD_COVERAGE_MIN_SUBMITTERS = 5
-    # Below this many doable jobs on a platform the window is too thin to judge.
+    # Below this many doable jobs on a platform the window is too thin to
+    # judge a coverage RATIO (shadow logging only).
     OD_COVERAGE_MIN_PLATFORM_JOBS = 20
+    # Total ABSTENTION (zero submissions) is a much stronger signal — it is
+    # penalized once at least this many doable jobs existed on the platform.
+    OD_ABSTAIN_MIN_PLATFORM_JOBS = 3
     # Stats are identical for every miner in a batch — cache and refetch rarely.
     OD_STATS_CACHE_TTL_SECS = 600
 
@@ -286,6 +290,24 @@ class MinerEvaluator:
         self._last_od_eval_at[hotkey] = now
 
         self._log_od_coverage_shadow(uid, hotkey, resp.jobs, stats, coverage_since)
+
+        # Abstention penalty: zero submissions on a platform where doable jobs
+        # existed scales od_component down (recovers on next participation).
+        # Runs BEFORE the empty-jobs early return so fully-absent miners are hit.
+        if stats is not None:
+            submitted_platforms = {
+                j.job.job.platform
+                for j in resp.jobs
+                if j.job.expire_at is None or j.job.expire_at >= coverage_since
+            }
+            mult = 1.0
+            for platform, pstats in stats.platforms.items():
+                if (
+                    pstats.doable_jobs >= self.OD_ABSTAIN_MIN_PLATFORM_JOBS
+                    and platform not in submitted_platforms
+                ):
+                    mult *= MinerScorer.OD_ABSTAIN_MULT
+            self.scorer.set_od_coverage_mult(uid, mult)
 
         # Reward path: unchanged semantics — only jobs from the since-last-eval window.
         jobs = [


### PR DESCRIPTION
Follow-up to #872 (measurement + reset). This adds the first scoring consequence:

Miners that submit to **zero** jobs on a platform where doable jobs existed (≥3 jobs that ≥5 other miners served in the 3h window) get `od_component × OD_ABSTAIN_MULT (0.3)` per abstained platform. Via the existing S3≤2×OD and P2P≤S3+OD caps this drags the whole composite score. Recovers to 1.0 automatically on the next eval where they participate.

Total abstention is judged at a much lower job threshold (3) than the coverage ratio (20) because zero-participation is robust to measurement noise — no ratio precision required. Current ground truth: top-5 incentive miners serve ~65% of Reddit jobs and **0% of X jobs** — all five get the X penalty from their first eval.

New scorer state `od_coverage_mult` (persisted, defaults 1.0, no reset needed). 6 new tests: abstention cases incl. fully-absent miners, thin-platform guard, participation recovery, caps interaction, state roundtrip.

Fine-grained relative scoring (miners compared against each other S3-style, `work²/Σ` per platform pool) follows once shadow data calibrates it.

**Note: #872's reset only makes sense released together with this** — recommend merging both into the same release so boosts rebuild under the new rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)