### PR TITLE
fix: stop score freeze when a miner fails the index query

### DIFF
--- a/rewards/miner_scorer.py
+++ b/rewards/miner_scorer.py
@@ -555,7 +555,11 @@ class MinerScorer:
             score = 0.0
 
             # If the miner has an index, update it's credibility based on the validation result and score the current index.
-            # Otherwise, score the miner 0 for this round, but don't touch its credibility.
+            # Otherwise, apply the failed validation to credibility and score the miner 0 for this round.
+            # Credibility must decay here: get_scores_for_weights() recomputes the P2P component
+            # from scorable_bytes * credibility, so leaving credibility untouched would let a miner
+            # freeze a stale (inflated) P2P score forever by refusing the index query.
+            # The EMA self-heals, so a transient network failure costs one decay step, not the score.
             if index:
                 # Compute the raw miner score based on the amount of data it has, scaled based on
                 # the reward distribution.
@@ -619,6 +623,8 @@ class MinerScorer:
                     f"{f', capped from {s3_uncapped:.0f}' if s3_uncapped != s3_component else ''}, "
                     f"OD={od_component:.0f} (boost={float(self.ondemand_boosts[uid]):.0f}, cred={float(self.ondemand_credibility[uid]):.4f})"
                 )
+            else:
+                self._update_credibility(uid, validation_results)
 
             self.scores[uid] = score
 

--- a/tests/vali_utils/test_index_fail_freeze.py
+++ b/tests/vali_utils/test_index_fail_freeze.py
@@ -1,0 +1,112 @@
+"""Tests for the frozen-score-on-index-fail fix.
+
+A miner that refuses/fails the GetMinerIndex query must not keep stale scores:
+- eval_miner runs S3 validation and applies its result BEFORE the index fetch,
+  so a broken index can't skip update_s3_effective_size (same exploit as #870,
+  one early-return earlier).
+- on_miner_evaluated with index=None applies the failed validation to P2P
+  credibility, so the P2P component recomputed by get_scores_for_weights decays
+  instead of staying frozen at its last (inflated) value.
+"""
+
+import asyncio
+import threading
+import types
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from rewards.data_value_calculator import DataValueCalculator
+from rewards.miner_scorer import MinerScorer
+from scraping.scraper import ValidationResult
+from vali_utils.miner_evaluator import MinerEvaluator
+
+
+def _failed_index_result() -> ValidationResult:
+    return ValidationResult(
+        is_valid=False,
+        reason="No available miner index.",
+        content_size_bytes_validated=0,
+    )
+
+
+class TestEvalMinerS3BeforeIndex(unittest.TestCase):
+    def _stub_evaluator(self):
+        ev = MinerEvaluator.__new__(MinerEvaluator)
+        ev.lock = threading.Lock()
+        ev.metagraph = MagicMock()
+        ev.metagraph.axons = [MagicMock()]
+        ev.metagraph.hotkeys = ["miner-hk"]
+        ev.metagraph.block = 1000
+        ev.wallet = MagicMock()
+        ev.wallet.hotkey.ss58_address = "vali-hk"
+        ev.scorer = MagicMock()
+        ev.s3_storage = MagicMock()
+        ev.s3_storage.get_validation_info.return_value = None  # forces S3 validation
+        ev._evaluate_od = AsyncMock()
+        ev._update_and_get_miner_index = AsyncMock(return_value=None)  # broken index
+        ev._perform_s3_validation = AsyncMock(
+            return_value=types.SimpleNamespace(
+                is_valid=False,
+                reason="stale files",
+                effective_size_bytes=123_456,
+            )
+        )
+        return ev
+
+    def test_s3_update_applied_despite_broken_index(self):
+        ev = self._stub_evaluator()
+        asyncio.run(ev.eval_miner(0))
+
+        ev._perform_s3_validation.assert_awaited_once()
+        ev.scorer.update_s3_effective_size.assert_called_once_with(
+            uid=0, effective_size=123_456, validation_passed=False
+        )
+        # The no-index path still reports the failed validation to the scorer.
+        ev.scorer.on_miner_evaluated.assert_called_once()
+        args = ev.scorer.on_miner_evaluated.call_args.args
+        self.assertIsNone(args[1])
+        self.assertFalse(args[2][0].is_valid)
+
+
+class TestScorerNoIndexCredibility(unittest.TestCase):
+    def test_no_index_eval_decays_p2p_credibility(self):
+        scorer = MinerScorer(2, DataValueCalculator())
+        scorer.miner_credibility[0] = 1.0
+
+        scorer.on_miner_evaluated(0, None, [_failed_index_result()])
+
+        expected = 1.0 - scorer.cred_alpha  # EMA toward 0
+        self.assertAlmostEqual(float(scorer.miner_credibility[0]), expected, places=4)
+        # Other miners untouched.
+        self.assertAlmostEqual(
+            float(scorer.miner_credibility[1]),
+            MinerScorer.STARTING_CREDIBILITY,
+            places=4,
+        )
+
+    def test_repeated_no_index_evals_decay_weights_score(self):
+        """The composite in get_scores_for_weights must drop, not stay frozen."""
+        scorer = MinerScorer(1, DataValueCalculator())
+        scorer.miner_credibility[0] = 1.0
+        # p2p = 1000 * 0.05 = 50, under the P2P<=S3+OD cap (100) so decay is visible
+        scorer.scorable_bytes[0] = 1_000
+        scorer.ondemand_boosts[0] = 100.0
+        scorer.ondemand_credibility[0] = 1.0  # keeps the caps from zeroing P2P
+
+        before = float(scorer.get_scores_for_weights()[0])
+        for _ in range(5):
+            scorer.on_miner_evaluated(0, None, [_failed_index_result()])
+        after = float(scorer.get_scores_for_weights()[0])
+
+        self.assertLess(after, before)
+        # P2P credibility decayed by (1-alpha)^5; OD component is untouched.
+        self.assertAlmostEqual(
+            float(scorer.miner_credibility[0]),
+            (1.0 - scorer.cred_alpha) ** 5,
+            places=4,
+        )
+        self.assertAlmostEqual(float(scorer.ondemand_boosts[0]), 100.0, places=4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -544,6 +544,39 @@ class MinerEvaluator:
         # Apply any cached OD results before the main P2P/S3 evaluation
         await self._evaluate_od(uid, hotkey)
 
+        current_block = int(self.metagraph.block)
+        s3_validation_info = self.s3_storage.get_validation_info(hotkey)
+        s3_validation_result = None
+
+        if not s3_validation_info or (current_block - s3_validation_info['block']) > 600:  # ~2 hrs
+            s3_validation_result = await self._perform_s3_validation(uid, hotkey, current_block)
+
+        # Apply the S3 result NOW, before any P2P step. Both the index fetch and
+        # the GetDataEntityBucket query have early returns a miner can trigger on
+        # purpose; if the S3 update ran after them, a miner could freeze a stale
+        # (inflated) S3 boost/credibility forever by intentionally failing P2P.
+        # S3 validation only needs the hotkey, not the index.
+        if s3_validation_result:
+            if s3_validation_result.is_valid:
+                bt.logging.info(
+                    f"UID:{uid} - HOTKEY:{hotkey}: Miner {uid} passed S3 validation. "
+                    f"Validation: {s3_validation_result.validation_percentage:.1f}%, "
+                    f"Jobs: {s3_validation_result.total_active_jobs}, Files: {s3_validation_result.recent_files_count}, "
+                    f"Coverage: {s3_validation_result.job_coverage_rate:.1f}%, "
+                    f"Effective size: {s3_validation_result.effective_size_bytes/(1024*1024):.1f}MB, "
+                    f"Job match: {s3_validation_result.job_match_rate:.1f}%"
+                )
+            else:
+                bt.logging.info(
+                    f"UID:{uid} - HOTKEY:{hotkey}: Miner {uid} did not pass S3 validation. "
+                    f"Reason: {s3_validation_result.reason}"
+                )
+            self.scorer.update_s3_effective_size(
+                uid=uid,
+                effective_size=s3_validation_result.effective_size_bytes,
+                validation_passed=s3_validation_result.is_valid,
+            )
+
         # Query the miner for the latest index.
         index = await self._update_and_get_miner_index(hotkey, uid, axon_info)
         if not index:
@@ -565,39 +598,6 @@ class MinerEvaluator:
 
             metrics.MINER_EVALUATOR_EVAL_MINER_DURATION.labels(hotkey=self.wallet.hotkey.ss58_address, miner_hotkey=hotkey, status='unavailable miner index').observe(time.perf_counter() - t_start)
             return
-
-        current_block = int(self.metagraph.block)
-        s3_validation_info = self.s3_storage.get_validation_info(hotkey)
-        s3_validation_result = None
-
-        if not s3_validation_info or (current_block - s3_validation_info['block']) > 600:  # ~2 hrs
-            s3_validation_result = await self._perform_s3_validation(uid, hotkey, current_block)
-
-        # Apply the S3 result NOW, before the P2P bucket query. The P2P step has
-        # several early returns on a failed/invalid GetDataEntityBucket response;
-        # if the S3 update were left until after them, a miner could freeze a
-        # stale (inflated) S3 boost/credibility forever by intentionally failing
-        # the bucket query. S3 scoring must not depend on the P2P outcome.
-        if s3_validation_result:
-            if s3_validation_result.is_valid:
-                bt.logging.info(
-                    f"UID:{uid} - HOTKEY:{hotkey}: Miner {uid} passed S3 validation. "
-                    f"Validation: {s3_validation_result.validation_percentage:.1f}%, "
-                    f"Jobs: {s3_validation_result.total_active_jobs}, Files: {s3_validation_result.recent_files_count}, "
-                    f"Coverage: {s3_validation_result.job_coverage_rate:.1f}%, "
-                    f"Effective size: {s3_validation_result.effective_size_bytes/(1024*1024):.1f}MB, "
-                    f"Job match: {s3_validation_result.job_match_rate:.1f}%"
-                )
-            else:
-                bt.logging.info(
-                    f"UID:{uid} - HOTKEY:{hotkey}: Miner {uid} did not pass S3 validation. "
-                    f"Reason: {s3_validation_result.reason}"
-                )
-            self.scorer.update_s3_effective_size(
-                uid=uid,
-                effective_size=s3_validation_result.effective_size_bytes,
-                validation_passed=s3_validation_result.is_valid,
-            )
 
         # From that index, find a data entity bucket to sample and get it from the miner.
         chosen_data_entity_bucket: DataEntityBucket = (


### PR DESCRIPTION
## Problem

Follow-up to #870, which moved the S3 boost update above the `GetDataEntityBucket` early returns. There is an earlier door with the same exploit: when the miner fails/refuses the **`GetMinerIndex`** query, `eval_miner` returns before S3 validation runs, so `update_s3_effective_size` never executes and `s3_boosts`/`s3_credibility` stay frozen at their last (inflated) values.

It's worse than just S3. In the scorer, the `index=None` branch discarded the failed `ValidationResult` without touching credibility ("score 0 for this round, but don't touch its credibility") — and the `self.scores[uid] = 0` it sets is dead weight, because `get_scores_for_weights()` recomputes every component from the raw tensors (`scorable_bytes`, credibilities, boosts) and never reads `self.scores`. Net effect: a miner that deliberately breaks the index query keeps its **entire composite (P2P + S3 + OD) frozen** at inflated values indefinitely, while OD (which runs before the index check) can be kept minimally alive to satisfy the S3≤2×OD cap.

## Fix

1. **`vali_utils/miner_evaluator.py`** — run S3 validation and apply its result **before** the index fetch. S3 validation only needs the hotkey, not the index, so there was no structural reason for the ordering. Same hoist as #870, one early-return earlier. No behavior change on the happy path.
2. **`rewards/miner_scorer.py`** — when `index=None`, apply the failed validation to P2P credibility via the existing EMA (`cred × 0.85` per failed eval, ≈×0.67 on the P2P component after the ^2.5 exponent). A transient network failure costs one decay step and self-heals on the next successful eval; a deliberate index-refuser decays to nothing within a few evals.

## Tests

`tests/vali_utils/test_index_fail_freeze.py` (3 new, all passing):
- S3 update is applied even when the index fetch returns None
- one no-index eval decays P2P credibility by exactly `1−α`
- repeated no-index evals visibly drop the `get_scores_for_weights` composite while OD stays untouched

Existing OD coverage/scorer-state suites (17 tests) still pass. Full `tests/rewards` + `tests/vali_utils` failures compared against a clean `origin/dev` worktree: identical — all pre-existing, none introduced here.

