### PR TITLE
feat(od): content-final timing guard + shadow upload-lag + URL-normal…

### DIFF
--- a/tests/vali_utils/test_od_content_final.py
+++ b/tests/vali_utils/test_od_content_final.py
@@ -1,0 +1,393 @@
+"""Tests for OD Phase A: content-final timing guard + shadow upload-lag +
+URL-normalizer hardening.
+
+Covers:
+- normalize_url_for_dedup: X keys on tweet ID only; crafted/encoded variants cannot mint keys
+- _od_content_final_violation: overwrite-past-expiry detection (with grace), None-safety
+- _evaluate_od: listing-level timing screen penalizes violators without sampling them
+- _validate_od_submission: fails fast on violation; ETag pins content to the listing
+- _log_od_coverage_shadow: upload_lag distribution incl. missing-metadata counter
+- od_sampled_rows carries unique_rows/lag_s; speed scored from s3_last_modified
+"""
+
+import asyncio
+import datetime as dt
+import json
+import threading
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from common.api_client import (
+    MinerJobForValidation,
+    OnDemandJob,
+    OnDemandJobsStatsResponse,
+    OnDemandJobSubmission,
+    PlatformJobStats,
+)
+from vali_utils.miner_evaluator import MinerEvaluator
+from vali_utils.url_normalizer import normalize_url_for_dedup
+
+
+def _stub_evaluator():
+    """MinerEvaluator instance without running __init__ (heavy deps)."""
+    ev = MinerEvaluator.__new__(MinerEvaluator)
+    ev._od_stats_cache = None
+    ev._od_stats_lock = threading.Lock()
+    ev._last_od_eval_at = {}
+    ev.on_demand_validator = MagicMock()
+    return ev
+
+
+def _job(
+    platform: str,
+    expire_at: dt.datetime,
+    content_length: int = 100,
+    submitted_at: dt.datetime = None,
+    s3_last_modified: dt.datetime = None,
+    s3_etag: str = None,
+) -> MinerJobForValidation:
+    payload = {"platform": platform, "keywords": ["k"]}
+    return MinerJobForValidation(
+        job=OnDemandJob(id="j", expire_at=expire_at, job=payload),
+        submission=OnDemandJobSubmission(
+            job_id="j",
+            s3_content_length=content_length,
+            submitted_at=submitted_at,
+            s3_last_modified=s3_last_modified,
+            s3_etag=s3_etag,
+            s3_presigned_url="https://example.com/presigned",
+        ),
+    )
+
+
+def _stats(reddit=(90, 85), x=(60, 40)) -> OnDemandJobsStatsResponse:
+    return OnDemandJobsStatsResponse(
+        platforms={
+            "reddit": PlatformJobStats(total_jobs=reddit[0], doable_jobs=reddit[1]),
+            "x": PlatformJobStats(total_jobs=x[0], doable_jobs=x[1]),
+        }
+    )
+
+
+class TestUrlNormalizerX(unittest.TestCase):
+    """X must key on the tweet ID alone — no URL variant may mint a distinct key."""
+
+    def test_username_variants_collapse(self):
+        urls = [
+            "https://x.com/alice/status/123456",
+            "https://x.com/BOB/status/123456",
+            "https://twitter.com/carol/status/123456",
+            "https://mobile.twitter.com/dave/status/123456",
+        ]
+        keys = {normalize_url_for_dedup(u) for u in urls}
+        self.assertEqual(keys, {"x:123456"})
+
+    def test_userless_legacy_and_suffix_paths(self):
+        self.assertEqual(
+            normalize_url_for_dedup("https://x.com/i/web/status/123456"), "x:123456"
+        )
+        self.assertEqual(
+            normalize_url_for_dedup("https://twitter.com/statuses/123456"), "x:123456"
+        )
+        self.assertEqual(
+            normalize_url_for_dedup("https://x.com/alice/status/55/photo/2"), "x:55"
+        )
+
+    def test_tracking_params_and_fragments_ignored(self):
+        self.assertEqual(
+            normalize_url_for_dedup("https://x.com/a/status/99?utm_source=z#top"),
+            "x:99",
+        )
+
+    def test_leading_zero_ids_collapse(self):
+        self.assertEqual(
+            normalize_url_for_dedup("https://x.com/a/status/00123"),
+            normalize_url_for_dedup("https://x.com/b/status/123"),
+        )
+
+    def test_status_segment_hijack_cannot_mint_keys(self):
+        """A crafted leading /status/N/ segment must not vary the key."""
+        a = normalize_url_for_dedup("https://x.com/status/1/status/123456")
+        b = normalize_url_for_dedup("https://x.com/status/2/status/123456")
+        self.assertEqual(a, b)
+        self.assertEqual(a, "x:unparseable")
+
+    def test_percent_encoded_and_double_encoded_collapse(self):
+        single = normalize_url_for_dedup("https://x.com/alice%2Fstatus%2F123456")
+        double = normalize_url_for_dedup("https://x.com/alice%252Fstatus%252F123456")
+        self.assertEqual(single, "x:123456")
+        self.assertEqual(double, "x:123456")
+
+    def test_nfkc_fullwidth_digits_collapse(self):
+        self.assertEqual(
+            normalize_url_for_dedup("https://x.com/alice/status/１２３"),
+            "x:123",
+        )
+
+    def test_host_dot_and_port_variants_collapse(self):
+        self.assertEqual(
+            normalize_url_for_dedup("https://x.com./alice/status/55"), "x:55"
+        )
+        self.assertEqual(
+            normalize_url_for_dedup("https://x.com:443/alice/status/55"), "x:55"
+        )
+
+    def test_fallback_host_dot_port_order(self):
+        """Port must strip before the trailing dot ('host.:443' collapses too)."""
+        self.assertEqual(
+            normalize_url_for_dedup("https://example.com.:443/watch"),
+            normalize_url_for_dedup("https://example.com/watch"),
+        )
+
+    def test_non_status_x_paths_collapse_to_sentinel(self):
+        """Non-tweet x.com URLs cannot each mint their own key."""
+        keys = {
+            normalize_url_for_dedup("https://x.com/pad1"),
+            normalize_url_for_dedup("https://x.com/pad2"),
+            normalize_url_for_dedup("https://x.com/alice"),
+        }
+        self.assertEqual(keys, {"x:unparseable"})
+
+    def test_reddit_forms_unchanged(self):
+        self.assertEqual(
+            normalize_url_for_dedup(
+                "https://www.reddit.com/r/Sub/comments/abc123/some_slug/"
+            ),
+            "reddit:abc123",
+        )
+        self.assertEqual(
+            normalize_url_for_dedup(
+                "https://old.reddit.com/r/Sub/comments/abc123/slug/def456/"
+            ),
+            "reddit:abc123:def456",
+        )
+
+    def test_reddit_encoded_slug_keeps_comment_id(self):
+        """Decoded '#' in a slug must not gain structural meaning (fragment)."""
+        self.assertEqual(
+            normalize_url_for_dedup(
+                "https://www.reddit.com/r/sub/comments/abc123/a%23b/def456"
+            ),
+            "reddit:abc123:def456",
+        )
+
+
+class TestContentFinalGuard(unittest.TestCase):
+    def setUp(self):
+        self.ev = _stub_evaluator()
+        self.now = dt.datetime.now(dt.timezone.utc)
+        self.guard = MinerEvaluator.OD_CONTENT_FINAL_GUARD_SECS
+
+    def _violation(self, lm_after_expiry_s, submitted_at="default"):
+        expire_at = self.now + dt.timedelta(seconds=120)
+        sub = self.now if submitted_at == "default" else submitted_at
+        j = _job(
+            "reddit",
+            expire_at,
+            submitted_at=sub,
+            s3_last_modified=expire_at + dt.timedelta(seconds=lm_after_expiry_s),
+        )
+        return self.ev._od_content_final_violation(j.job, j.submission)
+
+    def test_write_before_expiry_ok(self):
+        self.assertIsNone(self._violation(lm_after_expiry_s=-30))
+
+    def test_write_within_grace_ok(self):
+        """Honest uploads finishing just past the deadline are spared."""
+        self.assertIsNone(self._violation(lm_after_expiry_s=self.guard - 5))
+
+    def test_write_past_expiry_grace_flagged(self):
+        v = self._violation(lm_after_expiry_s=self.guard + 60)
+        self.assertIsNotNone(v)
+        self.assertIn("expiry", v)
+
+    def test_missing_submitted_at_does_not_disable_guard(self):
+        """The expiry check needs only s3_last_modified — a missing
+        submitted_at must not fail open."""
+        v = self._violation(lm_after_expiry_s=1800, submitted_at=None)
+        self.assertIsNotNone(v)
+
+    def test_missing_head_metadata_is_not_a_violation(self):
+        j = _job("reddit", self.now, submitted_at=self.now, s3_last_modified=None)
+        self.assertIsNone(self.ev._od_content_final_violation(j.job, j.submission))
+
+    def test_naive_datetimes_handled(self):
+        naive = dt.datetime.utcnow()
+        j = _job(
+            "reddit",
+            naive + dt.timedelta(seconds=120),
+            submitted_at=naive,
+            s3_last_modified=naive + dt.timedelta(seconds=999),
+        )
+        self.assertIsNotNone(self.ev._od_content_final_violation(j.job, j.submission))
+
+
+class TestValidateSubmissionGates(unittest.TestCase):
+    def setUp(self):
+        self.now = dt.datetime.now(dt.timezone.utc)
+
+    def test_timing_violation_fails_without_download(self):
+        ev = _stub_evaluator()
+        expire = self.now - dt.timedelta(minutes=10)
+        j = _job(
+            "reddit",
+            expire,
+            submitted_at=expire - dt.timedelta(seconds=30),
+            s3_last_modified=expire + dt.timedelta(seconds=999),
+        )
+        with patch("vali_utils.miner_evaluator.httpx.AsyncClient") as mock_http:
+            result = asyncio.run(
+                ev._validate_od_submission(1, "hk", j.job, j.submission, "j")
+            )
+        self.assertEqual(result, (False, 0, 0))
+        mock_http.assert_not_called()
+
+    def test_etag_mismatch_fails(self):
+        """Content overwritten between the API listing and our GET must fail."""
+        ev = _stub_evaluator()
+        j = _job(
+            "reddit",
+            self.now + dt.timedelta(seconds=120),
+            submitted_at=self.now,
+            s3_last_modified=self.now + dt.timedelta(seconds=2),
+            s3_etag="aaa111",
+        )
+        dl_resp = MagicMock(status_code=200, headers={"etag": '"bbb222"'})
+        with patch("vali_utils.miner_evaluator.httpx.AsyncClient") as mock_http:
+            client = mock_http.return_value.__aenter__.return_value
+            client.get = AsyncMock(return_value=dl_resp)
+            result = asyncio.run(
+                ev._validate_od_submission(1, "hk", j.job, j.submission, "j")
+            )
+        self.assertEqual(result, (False, 0, 0))
+
+
+class TestListingLevelTimingScreen(unittest.TestCase):
+    def test_violating_submission_penalized_not_sampled(self):
+        ev = _stub_evaluator()
+        ev.scorer = MagicMock()
+        now = dt.datetime.now(dt.timezone.utc)
+        expire = now - dt.timedelta(minutes=30)
+        violator = _job(
+            "reddit",
+            expire,
+            submitted_at=expire - dt.timedelta(seconds=10),
+            s3_last_modified=expire + dt.timedelta(seconds=999),
+        )
+
+        resp = MagicMock()
+        resp.jobs = [violator]
+        client = MagicMock()
+        client.validator_list_miner_jobs = AsyncMock(return_value=resp)
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+        ev._on_demand_client = MagicMock(return_value=client)
+        ev._get_od_jobs_stats = AsyncMock(return_value=_stats())
+        ev._log_od_coverage_shadow = MagicMock()
+        ev._validate_od_submission = AsyncMock()
+
+        asyncio.run(ev._evaluate_od(1, "hk"))
+
+        ev.scorer.apply_ondemand_penalty.assert_called_once_with(uid=1, mult_factor=1.0)
+        ev._validate_od_submission.assert_not_awaited()
+        ev.scorer.apply_ondemand_credibility_bump.assert_not_called()
+
+
+class TestShadowUploadLag(unittest.TestCase):
+    def setUp(self):
+        self.ev = _stub_evaluator()
+        self.now = dt.datetime.now(dt.timezone.utc)
+        self.since = self.now - dt.timedelta(hours=3)
+
+    def _capture_event(self, jobs, stats):
+        with patch("vali_utils.miner_evaluator.bt.logging.info") as mock_log:
+            self.ev._log_od_coverage_shadow(1, "hk", jobs, stats, self.since)
+            if not mock_log.call_args_list:
+                return None
+            return json.loads(mock_log.call_args_list[-1].args[0])
+
+    def test_lag_distribution_reported(self):
+        in_window = self.now - dt.timedelta(hours=1)
+        jobs = [
+            _job(
+                "reddit",
+                in_window,
+                submitted_at=in_window - dt.timedelta(seconds=100),
+                s3_last_modified=in_window - dt.timedelta(seconds=98),  # lag 2s
+            ),
+            _job(
+                "reddit",
+                in_window,
+                submitted_at=in_window - dt.timedelta(seconds=100),
+                s3_last_modified=in_window + dt.timedelta(seconds=200),  # lag 300s, past expiry
+            ),
+        ]
+        event = self._capture_event(jobs, _stats())
+        lag = event["upload_lag"]
+        self.assertEqual(lag["n"], 2)
+        self.assertEqual(lag["p50"], 151.0)  # median of [2, 300]
+        self.assertEqual(lag["max"], 300.0)
+        self.assertEqual(lag["over_guard"], 1)
+        self.assertEqual(lag["over_expiry"], 1)
+        self.assertEqual(lag["missing"], 0)
+
+    def test_missing_metadata_counted(self):
+        """Non-empty submissions without HEAD metadata must be visible —
+        their growth silently degrades the content-final protection."""
+        jobs = [_job("reddit", self.now - dt.timedelta(hours=1))]
+        event = self._capture_event(jobs, _stats())
+        self.assertEqual(event["upload_lag"]["n"], 0)
+        self.assertEqual(event["upload_lag"]["missing"], 1)
+        self.assertIsNone(event["upload_lag"]["p50"])
+
+
+class TestSampledRowsAndSpeedSwap(unittest.TestCase):
+    def test_event_fields_and_content_final_speed(self):
+        ev = _stub_evaluator()
+        ev.scorer = MagicMock()
+        now = dt.datetime.now(dt.timezone.utc)
+        lm = now - dt.timedelta(minutes=5)
+        job = _job(
+            "reddit",
+            now - dt.timedelta(minutes=4),  # lm precedes expiry — no violation
+            submitted_at=lm - dt.timedelta(seconds=3),
+            s3_last_modified=lm,
+        )
+
+        resp = MagicMock()
+        resp.jobs = [job]
+        client = MagicMock()
+        client.validator_list_miner_jobs = AsyncMock(return_value=resp)
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+        ev._on_demand_client = MagicMock(return_value=client)
+        ev._get_od_jobs_stats = AsyncMock(return_value=_stats())
+        ev._log_od_coverage_shadow = MagicMock()
+        ev._validate_od_submission = AsyncMock(return_value=(True, 10, 7))
+        ev.on_demand_validator.calculate_ondemand_reward_multipliers = MagicMock(
+            return_value=(1.0, 1.0)
+        )
+
+        with patch("vali_utils.miner_evaluator.bt.logging.info") as mock_log:
+            asyncio.run(ev._evaluate_od(1, "hk"))
+
+        sampled_events = [
+            json.loads(c.args[0])
+            for c in mock_log.call_args_list
+            if c.args and isinstance(c.args[0], str) and "od_sampled_rows" in c.args[0]
+        ]
+        self.assertEqual(len(sampled_events), 1)
+        sample = sampled_events[0]["sampled"][0]
+        self.assertEqual(sample["rows"], 10)
+        self.assertEqual(sample["unique_rows"], 7)
+        self.assertAlmostEqual(sample["lag_s"], 3.0, places=1)
+
+        # Speed must be scored from the S3 write time, not the pre-upload stamp.
+        call_kwargs = (
+            ev.on_demand_validator.calculate_ondemand_reward_multipliers.call_args.kwargs
+        )
+        self.assertEqual(call_kwargs["submission_timestamp"], lm)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/vali_utils/test_od_coverage_shadow.py
+++ b/tests/vali_utils/test_od_coverage_shadow.py
@@ -139,7 +139,7 @@ class TestAbstentionPenalty(unittest.TestCase):
         ev._on_demand_client = MagicMock(return_value=client)
         ev._get_od_jobs_stats = AsyncMock(return_value=stats)
         ev._log_od_coverage_shadow = MagicMock()
-        ev._validate_od_submission = AsyncMock(return_value=(True, 10))
+        ev._validate_od_submission = AsyncMock(return_value=(True, 10, 10))
         ev.on_demand_validator.calculate_ondemand_reward_multipliers = MagicMock(
             return_value=(1.0, 1.0)
         )
@@ -242,7 +242,7 @@ class TestEvaluateOdRewardWindow(unittest.TestCase):
         ev._on_demand_client = MagicMock(return_value=client)
         ev._get_od_jobs_stats = AsyncMock(return_value=_stats())
         ev._log_od_coverage_shadow = MagicMock()
-        ev._validate_od_submission = AsyncMock(return_value=(True, 10))
+        ev._validate_od_submission = AsyncMock(return_value=(True, 10, 10))
         ev.on_demand_validator.calculate_ondemand_reward_multipliers = MagicMock(
             return_value=(1.0, 1.0)
         )

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -3,7 +3,9 @@ import gc
 import copy
 import json
 import asyncio
+import math
 import random
+import statistics
 import traceback
 import threading
 import time
@@ -56,6 +58,7 @@ from common.api_client import (
 )
 from rewards.miner_scorer import MinerScorer
 from vali_utils.on_demand.on_demand_validation import OnDemandValidator
+from vali_utils.url_normalizer import normalize_url_for_dedup
 
 
 class MinerEvaluator:
@@ -177,6 +180,12 @@ class MinerEvaluator:
     OD_ABSTAIN_MIN_PLATFORM_JOBS = 3
     # Stats are identical for every miner in a batch — cache and refetch rarely.
     OD_STATS_CACHE_TTL_SECS = 600
+    # Content-final timing: max seconds the S3 object write may trail the
+    # submit call. submitted_at is stamped BEFORE the upload and the presigned
+    # POST allows overwriting the same key afterwards, so content written long
+    # after submit (or after job expiry) is treated as an overwrite exploit.
+    # 60s is a generous first value; tighten from the shadow upload_lag data.
+    OD_CONTENT_FINAL_GUARD_SECS = 60
 
     async def _get_od_jobs_stats(
         self, client: DataUniverseApiClient
@@ -205,6 +214,51 @@ class MinerEvaluator:
             self._od_stats_cache = (now, resp)
             return resp
 
+    @staticmethod
+    def _as_utc(ts: Optional[dt.datetime]) -> Optional[dt.datetime]:
+        if ts is None:
+            return None
+        return ts if ts.tzinfo is not None else ts.replace(tzinfo=dt.timezone.utc)
+
+    @staticmethod
+    def _upload_lag_seconds(
+        submission: OnDemandJobSubmission,
+    ) -> Optional[float]:
+        """Seconds between the submit call and the S3 object write, when both known."""
+        if submission.s3_last_modified is None or submission.submitted_at is None:
+            return None
+        lm = MinerEvaluator._as_utc(submission.s3_last_modified)
+        sub = MinerEvaluator._as_utc(submission.submitted_at)
+        return (lm - sub).total_seconds()
+
+    def _od_content_final_violation(
+        self, job: OnDemandJob, submission: OnDemandJobSubmission
+    ) -> Optional[str]:
+        """Content-final timing check.
+
+        submitted_at is stamped server-side at the metadata call BEFORE the S3
+        upload, and the presigned POST stays valid for the same deterministic
+        key long after — a miner can lock a fast timestamp with junk and
+        overwrite the content later.
+
+        Enforcement is deliberately limited to writes past job expiry, with
+        the guard as grace so honest uploads finishing near the deadline are
+        spared. Within-window lag is only MEASURED (shadow upload_lag) until
+        the guard is calibrated; the speed multiplier already prices that lag
+        because it is scored from s3_last_modified. Depends only on
+        s3_last_modified so a missing submitted_at cannot disable it.
+
+        Returns a violation description, or None when timing is acceptable
+        (including when no S3 HEAD metadata is available).
+        """
+        lm = submission.s3_last_modified
+        if lm is None or job.expire_at is None:
+            return None
+        grace = dt.timedelta(seconds=self.OD_CONTENT_FINAL_GUARD_SECS)
+        if self._as_utc(lm) > self._as_utc(job.expire_at) + grace:
+            return "content written after job expiry"
+        return None
+
     def _log_od_coverage_shadow(
         self,
         uid: int,
@@ -218,6 +272,10 @@ class MinerEvaluator:
             return
         submitted: Dict[str, int] = {}
         volume_bytes: Dict[str, int] = {}
+        lags: List[float] = []
+        lag_over_guard = 0
+        lag_over_expiry = 0
+        lag_missing = 0
         for j in all_jobs:
             exp = j.job.expire_at
             if exp is None or exp < coverage_since:
@@ -227,6 +285,17 @@ class MinerEvaluator:
             volume_bytes[platform] = volume_bytes.get(platform, 0) + (
                 j.submission.s3_content_length or 0
             )
+            lag = self._upload_lag_seconds(j.submission)
+            if lag is not None:
+                lags.append(lag)
+                if lag > self.OD_CONTENT_FINAL_GUARD_SECS:
+                    lag_over_guard += 1
+                if self._as_utc(j.submission.s3_last_modified) > self._as_utc(exp):
+                    lag_over_expiry += 1
+            elif (j.submission.s3_content_length or 0) > 0:
+                # Content exists but HEAD metadata is missing — if this grows,
+                # the content-final protection is silently degraded.
+                lag_missing += 1
 
         event = {
             "event": "od_coverage_shadow",
@@ -249,6 +318,21 @@ class MinerEvaluator:
                 "coverage": coverage,
                 "bytes": total_bytes,
                 "avg_bytes": round(total_bytes / done) if done else 0,
+            }
+        # Upload-lag distribution (submit call -> S3 write) — calibrates the
+        # content-final guard before within-window lag is enforced.
+        if lags or lag_missing:
+            lags.sort()
+            n = len(lags)
+            event["upload_lag"] = {
+                "n": n,
+                "p50": round(statistics.median(lags), 2) if lags else None,
+                # nearest-rank p95
+                "p95": round(lags[max(0, math.ceil(0.95 * n) - 1)], 2) if lags else None,
+                "max": round(lags[-1], 2) if lags else None,
+                "over_guard": lag_over_guard,
+                "over_expiry": lag_over_expiry,
+                "missing": lag_missing,
             }
         bt.logging.info(json.dumps(event))
 
@@ -318,22 +402,34 @@ class MinerEvaluator:
         if not jobs:
             return
 
-        # Single-pass partition into empty vs non-empty submissions
-        empty, non_empty = [], []
+        # Single-pass partition into empty / timing-violating / clean
+        # submissions. The timing screen runs on the LISTING (timestamps only,
+        # no download) so an overwrite past expiry cannot hide in the
+        # unsampled majority and still collect credibility bumps.
+        empty, violations, non_empty = [], [], []
         for j in jobs:
-            if (j.submission.s3_content_length or 0) > 0:
-                non_empty.append(j)
-            else:
+            if (j.submission.s3_content_length or 0) <= 0:
                 empty.append(j)
+                continue
+            violation = self._od_content_final_violation(j.job, j.submission)
+            if violation:
+                violations.append((j, violation))
+            else:
+                non_empty.append(j)
 
         for j in empty:
             self.scorer.apply_ondemand_penalty(uid=uid, mult_factor=1.0)
+        for j, violation in violations:
+            bt.logging.warning(
+                f"UID:{uid} - OD: job {j.submission.job_id} TIMING FAILED ({violation})"
+            )
+            self.scorer.apply_ondemand_penalty(uid=uid, mult_factor=1.0)
 
         if not non_empty:
-            if empty:
+            if empty or violations:
                 bt.logging.info(
-                    f"UID:{uid} - HOTKEY:{hotkey}: OD — {len(empty)} empty submissions penalized, "
-                    f"0 non-empty"
+                    f"UID:{uid} - HOTKEY:{hotkey}: OD — {len(empty)} empty and "
+                    f"{len(violations)} timing-violating submissions penalized, 0 clean"
                 )
             return
 
@@ -344,7 +440,7 @@ class MinerEvaluator:
         not_sampled_count = len(non_empty) - len(to_validate)
 
         # Validate sampled jobs concurrently
-        validation_results: List[Tuple[Optional[bool], int]] = await asyncio.gather(*[
+        validation_results: List[Tuple[Optional[bool], int, int]] = await asyncio.gather(*[
             self._validate_od_submission(
                 uid, hotkey, j.job, j.submission, j.submission.job_id
             )
@@ -353,6 +449,7 @@ class MinerEvaluator:
 
         # Rows+bytes for the sampled jobs — calibrates the bytes-only volume
         # signal in od_coverage_shadow (bytes/row ratio per miner/platform).
+        # unique_rows (distinct normalized URLs) vs rows measures padding.
         bt.logging.info(json.dumps({
             "event": "od_sampled_rows",
             "uid": uid,
@@ -363,10 +460,12 @@ class MinerEvaluator:
                     "platform": j.job.job.platform,
                     "limit": j.job.limit,
                     "rows": count,
+                    "unique_rows": unique,
                     "bytes": j.submission.s3_content_length or 0,
+                    "lag_s": self._upload_lag_seconds(j.submission),
                     "passed": passed,
                 }
-                for j, (passed, count) in zip(to_validate, validation_results)
+                for j, (passed, count, unique) in zip(to_validate, validation_results)
             ],
         }))
 
@@ -375,7 +474,7 @@ class MinerEvaluator:
         validated_fail = 0
         validated_skipped = 0
 
-        for j, (passed, entity_count) in zip(to_validate, validation_results):
+        for j, (passed, entity_count, _unique_count) in zip(to_validate, validation_results):
             if passed is None:
                 # Validator-side download failure (5xx/timeout) — neither reward nor
                 # penalize; the miner is not at fault for our infrastructure. (companion to #805)
@@ -386,10 +485,17 @@ class MinerEvaluator:
                 )
                 continue
 
+            # Content-final: score speed from when the bytes landed in S3, not
+            # from the pre-upload metadata stamp (which a miner controls).
+            # Both operands go through _as_utc — a naive/aware mix raises
+            # inside the subtraction and would kill the whole eval thread.
             speed_mult, vol_mult = (
                 self.on_demand_validator.calculate_ondemand_reward_multipliers(
-                    job_created_at=j.job.created_at,
-                    submission_timestamp=j.submission.submitted_at,
+                    job_created_at=self._as_utc(j.job.created_at),
+                    submission_timestamp=(
+                        self._as_utc(j.submission.s3_last_modified)
+                        or self._as_utc(j.submission.submitted_at)
+                    ),
                     returned_count=entity_count,
                     requested_limit=j.job.limit,
                 )
@@ -409,7 +515,8 @@ class MinerEvaluator:
         bt.logging.info(
             f"UID:{uid} - HOTKEY:{hotkey}: OD summary — "
             f"{len(non_empty)} non-empty (validated: {validated_pass} pass, {validated_fail} fail, "
-            f"{not_sampled_count} credibility-bumped), {len(empty)} empty penalized"
+            f"{not_sampled_count} credibility-bumped), {len(empty)} empty penalized, "
+            f"{len(violations)} timing-violation penalized"
         )
 
     async def _validate_od_submission(
@@ -419,14 +526,25 @@ class MinerEvaluator:
         job: OnDemandJob,
         submission: OnDemandJobSubmission,
         job_id: str,
-    ) -> Tuple[Optional[bool], int]:
+    ) -> Tuple[Optional[bool], int, int]:
         """Download and validate a single OD submission.
 
-        Returns (passed, entity_count) — entity_count is the number of
-        entities the miner actually returned (used for volume_multiplier).
+        Returns (passed, entity_count, unique_count) — entity_count is the
+        number of entities the miner actually returned (used for
+        volume_multiplier); unique_count is the number of distinct normalized
+        URLs among them (shadow padding measurement).
         passed=None signals a validator-side download failure (5xx/timeout):
         the caller leaves credibility unchanged (neither reward nor penalty). (#805)
         """
+        # Content-final timing guard: junk-then-overwrite locks a fast
+        # submitted_at, but S3's LastModified betrays the real write time.
+        violation = self._od_content_final_violation(job, submission)
+        if violation:
+            bt.logging.warning(
+                f"UID:{uid} - OD validate: TIMING FAILED for job {job_id} ({violation})"
+            )
+            return False, 0, 0
+
         try:
             async with httpx.AsyncClient(timeout=30.0) as http:
                 dl_resp = await http.get(submission.s3_presigned_url, follow_redirects=True)
@@ -437,8 +555,20 @@ class MinerEvaluator:
                     )
                     if dl_resp.status_code >= 500:
                         # Validator/AWS server-side error — not the miner's fault.
-                        return None, 0
-                    return False, 0
+                        return None, 0, 0
+                    return False, 0, 0
+
+                # The listing's HEAD metadata predates this GET — an overwrite
+                # in between would serve different bytes than the timestamps
+                # the guard validated. ETag pins the content to the listing.
+                resp_etag = (dl_resp.headers.get("etag") or "").strip('"')
+                known_etag = (submission.s3_etag or "").strip('"')
+                if known_etag and resp_etag and resp_etag != known_etag:
+                    bt.logging.warning(
+                        f"UID:{uid} - OD validate: TIMING FAILED for job {job_id} "
+                        f"(content changed between listing and validation)"
+                    )
+                    return False, 0, 0
 
                 miner_upload = OnDemandMinerUpload.model_validate(dl_resp.json())
 
@@ -452,15 +582,16 @@ class MinerEvaluator:
                         f"UID:{uid} - OD validate: empty submission but data exists "
                         f"for job {job_id}"
                     )
-                    return False, 0
+                    return False, 0, 0
                 else:
                     bt.logging.info(
                         f"UID:{uid} - OD validate: empty submission, data doesn't exist "
                         f"for job {job_id} — acceptable"
                     )
-                    return True, 0
+                    return True, 0, 0
 
             entity_count = len(entities)
+            unique_count = len({normalize_url_for_dedup(e.uri) for e in entities})
 
             # Cap to job limit
             if job.limit and entity_count > job.limit:
@@ -478,7 +609,7 @@ class MinerEvaluator:
                     f"UID:{uid} - OD validate: SCHEMA FAILED for job {job_id} "
                     f"(wrong XContent format)"
                 )
-                return False, entity_count
+                return False, entity_count, unique_count
 
             # Phase 2: Job match — check request fields on a sample
             for entity in schema_sample:
@@ -488,7 +619,7 @@ class MinerEvaluator:
                         f"UID:{uid} - OD validate: JOB MATCH FAILED for job {job_id}, "
                         f"post {post_id} (wrong username/keyword/date)"
                     )
-                    return False, entity_count
+                    return False, entity_count, unique_count
 
             # Phase 3: Scraper validation on 1 entity from the schema-validated sample
             entity = random.choice(schema_sample)
@@ -501,25 +632,25 @@ class MinerEvaluator:
                     f"UID:{uid} - OD validate: SCRAPER FAILED for job {job_id}, "
                     f"post {post_id}"
                 )
-                return False, entity_count
+                return False, entity_count, unique_count
 
             bt.logging.info(
                 f"UID:{uid} - OD validate: PASSED job {job_id} "
                 f"({entity_count} entities, schema OK, job match OK, scraper OK)"
             )
-            return True, entity_count
+            return True, entity_count, unique_count
 
         except (httpx.TimeoutException, httpx.ConnectError, httpx.ReadError) as e:
             # Validator-side network failure downloading the submission — neutral, not miner's fault (#805)
             bt.logging.warning(
                 f"UID:{uid} - OD validate: network error for job {job_id}: {e}"
             )
-            return None, 0
+            return None, 0, 0
         except Exception as e:
             bt.logging.warning(
                 f"UID:{uid} - OD validate: error for job {job_id}: {e}"
             )
-            return False, 0
+            return False, 0, 0
 
     async def eval_miner(self, uid: int) -> None:
         """Evaluates a miner and updates their score.

--- a/vali_utils/url_normalizer.py
+++ b/vali_utils/url_normalizer.py
@@ -5,7 +5,27 @@ processes can import it without pulling in bittensor/pandas/the full
 s3_utils stack. s3_utils re-exports it, so existing imports keep working.
 """
 import re
-from urllib.parse import urlparse
+import unicodedata
+from urllib.parse import urlparse, unquote
+
+# Strict tweet-URL shapes: /{user}/status/{id}, /i/web/status/{id},
+# /statuses/{id}, optional /photo|video/N suffix. Anchored so a crafted
+# path like /status/1/status/{id} cannot hijack or vary the captured ID.
+_X_STATUS_RE = re.compile(
+    r"^/(?:i/web/|[^/]+/)?status(?:es)?/(\d+)(?:/(?:photo|video)/\d+)?/?$"
+)
+
+
+def _decode_path(path: str) -> str:
+    """Percent-decode a path to a fixpoint (bounded) so encoded variants of
+    the same URL cannot mint distinct dedup keys. Decoding happens AFTER
+    urlparse so a decoded '#' or '?' never gains structural meaning."""
+    for _ in range(3):
+        decoded = unquote(path)
+        if decoded == path:
+            break
+        path = decoded
+    return path
 
 
 def normalize_url_for_dedup(url_str: str) -> str:
@@ -14,25 +34,34 @@ def normalize_url_for_dedup(url_str: str) -> str:
     Approach: define what a VALID canonical URL looks like, ignore everything else.
     This is not a blacklist of known exploits — it's a whitelist of valid URL structure.
 
-    X:      Only the numeric tweet ID matters. Username is lowercased (decorative — X resolves by ID).
+    X:      Only the numeric tweet ID matters. The username segment is dropped entirely —
+            X resolves any tweet by ID alone, so username variants of the same tweet
+            must collapse to one key. Any x.com/twitter.com URL that is not a
+            well-formed tweet URL collapses to a single sentinel key: crafted
+            variants must not be able to mint distinct keys.
     Reddit: Only post_id and comment_id (base36) matter. Subreddit and slug are decorative.
 
     Canonical forms produced:
-      X tweet:        https://x.com/{user_lower}/status/{tweet_id}
+      X tweet:        x:{tweet_id}
+      X non-tweet:    x:unparseable
       Reddit post:    reddit:{post_id}
       Reddit comment: reddit:{post_id}:{comment_id}
     """
-    url = str(url_str).strip()
+    url = unicodedata.normalize("NFKC", str(url_str).strip())
     parsed = urlparse(url)
     netloc = parsed.netloc.lower()
-    path = parsed.path.lower()
+    if netloc.endswith(":443") or netloc.endswith(":80"):
+        netloc = netloc.rsplit(":", 1)[0]
+    netloc = netloc.rstrip(".")
+    path = _decode_path(parsed.path.lower())
 
     # --- X / Twitter ---
     if "x.com" in netloc or "twitter.com" in netloc:
-        m = re.match(r"^/([^/]+)/status/(\d+)", path)
+        m = _X_STATUS_RE.match(path)
         if m:
-            return f"https://x.com/{m.group(1)}/status/{m.group(2)}"
-        return f"https://x.com{path.rstrip('/')}"
+            # int() strips leading zeros so 0123 and 123 collapse.
+            return f"x:{int(m.group(1))}"
+        return "x:unparseable"
 
     # --- Reddit ---
     if "reddit.com" in netloc:


### PR DESCRIPTION
…izer hardening (Phase A)

Scoring integrity:
- Speed is now scored from s3_last_modified (when the bytes landed in S3), not the pre-upload submitted_at stamp a miner controls.
- Listing-level timing screen: content written past job expiry (+60s grace for honest late uploads) is penalized across ALL submissions, not just the 3 sampled ones, and never collects credibility bumps. The check depends only on s3_last_modified so a missing submitted_at cannot disable it.
- ETag cross-check pins the downloaded content to the listing's HEAD metadata, closing the overwrite-between-listing-and-validation race.
- Within-window upload lag is measured (shadow), not yet enforced — calibration data first, enforcement once the distribution is known.

Shadow measurement (calibrates the guard and the padding signal):
- od_coverage_shadow gains upload_lag {n, p50, p95, max, over_guard, over_expiry, missing} (statistics.median + nearest-rank p95).
- od_sampled_rows gains unique_rows (distinct normalized URLs, measures the 6x-padding) and lag_s per sampled job.

URL normalizer (also tightens S3 dedup):
- X keys on the tweet ID alone (x:{id}) — username variants, /i/web/, legacy /statuses/, photo/video suffixes, leading zeros, ports, trailing host dots, NFKC confusables, and (double-)percent-encoding all collapse to one key; crafted non-tweet x.com paths collapse to a single sentinel so padding cannot mint distinct keys.
- Percent-decoding is path-only after urlparse, so encoded '#'/'?' never gain structural meaning (reddit comment keys survive encoded slugs).