### PR TITLE
fix: restore 10-byte tolerance in Reddit content validation

### DIFF
--- a/scraping/reddit/utils.py
+++ b/scraping/reddit/utils.py
@@ -262,7 +262,7 @@ def validate_reddit_content(
 
         # Extra check that the content size is reasonably close to what we expect.
         # Allow a 10 byte difference to account for timestamp serialization differences.
-        byte_difference_allowed = 0
+        byte_difference_allowed = 10
 
         if (
                 entity_to_validate.content_size_bytes - actual_entity.content_size_bytes


### PR DESCRIPTION
## Problem

`scraping/reddit/utils.py` documents the content-size check as:

> Allow a 10 byte difference to account for timestamp serialization differences.

…but the value is `0`:

```python
byte_difference_allowed = 0
if (entity_to_validate.content_size_bytes - actual_entity.content_size_bytes) > byte_difference_allowed:
    return ValidationResult(is_valid=False, reason="The claimed bytes are too big compared to the actual Reddit content", ...)
```

With zero tolerance, any 1-byte difference between the claimed content size and the validator's re-fetched size fails the miner outright — the same credibility penalty as fabricated data.

## Impact

This fires on natural Reddit mutation, not dishonesty. Reproducible example (reported by DiegoTao in the SN13 Discord):

- A post's `num_comments` drops `15 -> 6` between scrape and validation (comments removed/moderated). The serialized content is 1 byte smaller, so `(claimed - actual) = 1 > 0` → `is_valid=False`.

Any honest miner holding Reddit posts whose comment count (or other numeric fields) shifts by a digit between scrape and re-fetch eats a full rejection.

## Fix

Set the tolerance to `10`, matching the value the comment already documents. It absorbs serialization/mutation noise while staying far below anything that would admit fabricated content — the check only guards against *over-claiming* size, and 10 bytes is negligible against real content sizes.

```diff
-        byte_difference_allowed = 0
+        byte_difference_allowed = 10
```

Credit: reported by **DiegoTao** in the SN13 Discord (points 2 & 3), with the reproducible example above.
