### PR TITLE
fix(deps): bump bittensor to 10.3.0 — fixes NetUid(u16) metagraph sync failure

### DIFF
--- a/common/api_client.py
+++ b/common/api_client.py
@@ -336,6 +336,11 @@ class DataUniverseApiClient:
         client = self._ensure_client()
         body_bytes = payload_json.encode("utf-8")
         headers = signer.headers(body=body_bytes)
+        # Send the raw signed bytes as the body but declare JSON explicitly:
+        # starlette/fastapi >= the versions bittensor 10.x pulls in no longer
+        # infer a JSON body without this header and return 422. The signature
+        # is over body_bytes only, so setting a header does not affect it.
+        headers["Content-Type"] = "application/json"
         return await client.post(path, content=body_bytes, headers=headers)
 
     async def miner_list_active_jobs(

--- a/common/api_client.py
+++ b/common/api_client.py
@@ -10,7 +10,14 @@ from typing import Any, Dict, List, Literal, Optional, Set, Union
 
 from pydantic import BaseModel, ConfigDict, Field
 from common.data import DataEntity, DataSource
-from substrateinterface.keypair import Keypair
+
+try:
+    # bittensor >= 10 ships Keypair via bittensor_wallet and no longer depends
+    # on substrate-interface (whose scalecodec conflicts with cyscale). Prefer
+    # it; fall back to the legacy package for older SDK installs.
+    from bittensor_wallet.keypair import Keypair
+except ImportError:  # pragma: no cover - legacy bittensor < 10
+    from substrateinterface.keypair import Keypair
 import httpx
 
 import bittensor as bt

--- a/common/metagraph_syncer.py
+++ b/common/metagraph_syncer.py
@@ -14,15 +14,15 @@ from common import utils
 class MetagraphSyncer:
     @dataclasses.dataclass
     class _State:
-        metagraph: Optional[bt.metagraph] = None
+        metagraph: Optional[bt.Metagraph] = None
         last_synced_time: Optional[datetime] = None
         listeners: List = field(default_factory=list)
 
-    def __init__(self, subtensor: bt.subtensor, config: Dict[int, int]):
+    def __init__(self, subtensor: bt.Subtensor, config: Dict[int, int]):
         """Constructs a new MetagraphSyncer, that periodically refreshes metagraph defined in the config.
 
         Args:
-            subtensor (bt.subtensor): The subtensor used to fetch the metagraphs.
+            subtensor (bt.Subtensor): The subtensor used to fetch the metagraphs.
             config (Dict[int, int]): A mapping of netuid to the cadence (in seconds) to sync the metagraph.
         """
         self.subtensor = subtensor
@@ -111,7 +111,7 @@ class MetagraphSyncer:
             bt.logging.info("MetagraphSyncer _run complete.")
 
     def register_listener(
-        self, listener: Callable[[bt.metagraph, int], None], netuids: List[int]
+        self, listener: Callable[[bt.Metagraph, int], None], netuids: List[int]
     ):
         """Registers a listener to be notified when a metagraph for any netuid in netuids is updated.
 
@@ -128,7 +128,7 @@ class MetagraphSyncer:
                     )
                 self.metagraph_map[netuid].listeners.append(listener)
 
-    def get_metagraph(self, netuid: int) -> bt.metagraph:
+    def get_metagraph(self, netuid: int) -> bt.Metagraph:
         """Returns the last synced version of the metagraph for netuid."""
         with self.lock:
             if netuid not in self.metagraph_map:

--- a/common/utils.py
+++ b/common/utils.py
@@ -39,7 +39,7 @@ def datetime_from_hours_since_epoch(hours: int) -> dt.datetime:
     return dt.datetime.fromtimestamp(hours * 3600, tz=dt.timezone.utc)
 
 
-def is_miner(uid: int, metagraph: bt.metagraph, vpermit_rao_limit: int) -> bool:
+def is_miner(uid: int, metagraph: bt.Metagraph, vpermit_rao_limit: int) -> bool:
     """Checks if a UID on the subnet is a miner."""
     # Assume everyone who isn't a validator is a miner.
     # This explicilty disallows validator/miner hybrids.
@@ -54,7 +54,7 @@ def is_miner(uid: int, metagraph: bt.metagraph, vpermit_rao_limit: int) -> bool:
 
 
 def is_validator(
-    uid: int, metagraph: bt.metagraph, vpermit_rao_limit: int = 10_000
+    uid: int, metagraph: bt.Metagraph, vpermit_rao_limit: int = 10_000
 ) -> bool:
     """Checks if a UID on the subnet is a validator."""
     return (
@@ -63,7 +63,7 @@ def is_validator(
 
 
 def get_validator_data(
-    metagraph: bt.metagraph, vpermit_rao_limit: int
+    metagraph: bt.Metagraph, vpermit_rao_limit: int
 ) -> Dict[str, Dict[str, Any]]:
     """Retrieve validator data (hotkey, percent stake) from metagraph. For use in Gravity."""
     total_stake = sum(
@@ -85,7 +85,7 @@ def get_validator_data(
     return validator_data
 
 
-def get_miner_uids(metagraph: bt.metagraph, vpermit_rao_limit: int) -> List[int]:
+def get_miner_uids(metagraph: bt.Metagraph, vpermit_rao_limit: int) -> List[int]:
     """Gets the uids of all miners in the metagraph."""
     return sorted(
         [
@@ -96,14 +96,14 @@ def get_miner_uids(metagraph: bt.metagraph, vpermit_rao_limit: int) -> List[int]
     )
 
 
-def get_uid(wallet: bt.wallet, metagraph: bt.metagraph) -> Optional[int]:
+def get_uid(wallet: bt.Wallet, metagraph: bt.Metagraph) -> Optional[int]:
     """Gets the uid of the wallet in the metagraph or None if not registered."""
     if wallet.hotkey.ss58_address in metagraph.hotkeys:
         return metagraph.hotkeys.index(wallet.hotkey.ss58_address)
     return None
 
 
-def assert_registered(wallet: bt.wallet, metagraph: bt.metagraph):
+def assert_registered(wallet: bt.Wallet, metagraph: bt.Metagraph):
     """Exits the process if wallet isn't registered in metagraph"""
     # --- Check for registration.
     if wallet.hotkey.ss58_address not in metagraph.hotkeys:
@@ -338,7 +338,7 @@ class LRUSet:
 
     def __contains__(self, key: str) -> bool:
         return key in self.data
-def get_subnet_owner_hotkey(subtensor: bt.subtensor, netuid: int) -> Optional[str]:
+def get_subnet_owner_hotkey(subtensor: bt.Subtensor, netuid: int) -> Optional[str]:
     """Query the subnet owner hotkey from the chain.
 
     Args:
@@ -363,8 +363,8 @@ def get_subnet_owner_hotkey(subtensor: bt.subtensor, netuid: int) -> Optional[st
 
 def apply_burn_to_weights(
     raw_weights: torch.Tensor,
-    metagraph: bt.metagraph,
-    subtensor: bt.subtensor,
+    metagraph: bt.Metagraph,
+    subtensor: bt.Subtensor,
     netuid: int,
     burn_percentage: float
 ) -> torch.Tensor:

--- a/dynamic_desirability/chain_utils.py
+++ b/dynamic_desirability/chain_utils.py
@@ -19,7 +19,7 @@ def _sync_retrieve_metadata(netuid: int, hotkey: str, network: str = "finney"):
     """Standalone function that can be pickled"""
     try:
         # Create a fresh subtensor instance for each call
-        fresh_subtensor = bt.subtensor(network=network)
+        fresh_subtensor = bt.Subtensor(network=network)
         
         metadata = bt.core.extrinsics.serving.get_metadata(
             fresh_subtensor, 
@@ -70,9 +70,9 @@ def run_in_subprocess(func: functools.partial, ttl: int = 10) -> Any:
 class ChainPreferenceStore:
     def __init__(
         self,
-        subtensor: bt.subtensor,
+        subtensor: bt.Subtensor,
         netuid: int,
-        wallet: Optional[bt.wallet] = None,
+        wallet: Optional[bt.Wallet] = None,
     ):
         self.subtensor = subtensor
         self.wallet = wallet
@@ -145,8 +145,8 @@ if __name__ == "__main__":
     add_args(parser, is_upload=False)
     args = parser.parse_args()
 
-    subtensor = bt.subtensor(network=args.network)
-    wallet = bt.wallet(name=args.wallet, hotkey=args.hotkey)
+    subtensor = bt.Subtensor(network=args.network)
+    wallet = bt.Wallet(name=args.wallet, hotkey=args.hotkey)
     
     store = ChainPreferenceStore(subtensor, args.netuid, wallet)
     

--- a/dynamic_desirability/chain_utils.py
+++ b/dynamic_desirability/chain_utils.py
@@ -20,19 +20,15 @@ def _sync_retrieve_metadata(netuid: int, hotkey: str, network: str = "finney"):
     try:
         # Create a fresh subtensor instance for each call
         fresh_subtensor = bt.Subtensor(network=network)
-        
-        metadata = bt.core.extrinsics.serving.get_metadata(
-            fresh_subtensor, 
-            netuid, 
-            hotkey
+
+        # bittensor 10.x: serving.get_metadata is gone; get_commitment takes a
+        # uid and returns the decoded commitment string directly.
+        uid = fresh_subtensor.get_uid_for_hotkey_on_subnet(
+            hotkey_ss58=hotkey, netuid=netuid
         )
-        
-        if not metadata:
+        if uid is None:
             return None
-            
-        commitment = metadata["info"]["fields"][0]
-        hex_data = commitment[list(commitment.keys())[0]][2:]
-        return bytes.fromhex(hex_data).decode()
+        return fresh_subtensor.get_commitment(netuid=netuid, uid=uid) or None
     except Exception as e:
         bt.logging.error(f"Error retrieving metadata for {hotkey}: {str(e)}")
         return None
@@ -91,14 +87,12 @@ class ChainPreferenceStore:
             raise ValueError("No data provided to store on the chain.")
 
         def sync_store():
-            return bt.core.extrinsics.serving.publish_metadata(
-                self.subtensor,
-                self.wallet,
-                self.netuid,
-                f"Raw{len(data)}",
-                data.encode(),
-                wait_for_inclusion,
-                wait_for_finalization,
+            # bittensor 10.x: serving.publish_metadata is gone; set_commitment
+            # writes a raw commitment for (wallet, netuid).
+            return self.subtensor.set_commitment(
+                wallet=self.wallet,
+                netuid=self.netuid,
+                data=data,
             )
 
         partial = functools.partial(sync_store)

--- a/dynamic_desirability/desirability_retrieval.py
+++ b/dynamic_desirability/desirability_retrieval.py
@@ -283,7 +283,7 @@ def datetime_to_timebucket(datetime_str: Optional[str]) -> Optional[int]:
         print(f"Warning: Could not parse datetime string: {datetime_str}. Error: {e}")
         return None
 
-def get_hotkey_json_submission(subtensor: bt.subtensor, netuid: int, metagraph: bt.metagraph, hotkey: str):
+def get_hotkey_json_submission(subtensor: bt.Subtensor, netuid: int, metagraph: bt.Metagraph, hotkey: str):
     """Gets the unscaled JSON submisson for a specified validator hotkey. 
        If no hotkey is specified, returns the current aggregate desirability list. """
     try:
@@ -313,8 +313,8 @@ def get_hotkey_json_submission(subtensor: bt.subtensor, netuid: int, metagraph: 
 async def run_retrieval(config) -> DataDesirabilityLookup:
     """Legacy GitHub-based retrieval. Use run_retrieval_from_api instead."""
     try:
-        my_wallet = bt.wallet(config=config)
-        subtensor = bt.subtensor(config=config)
+        my_wallet = bt.Wallet(config=config)
+        subtensor = bt.Subtensor(config=config)
         metagraph = subtensor.metagraph(netuid=config.netuid)
 
         bt.logging.info("\nGetting validator weights from the metagraph...\n")

--- a/dynamic_desirability/desirability_uploader.py
+++ b/dynamic_desirability/desirability_uploader.py
@@ -105,9 +105,9 @@ def upload_to_github(json_content: str, hotkey: str) -> str:
 
 
 async def run_uploader(args):
-    my_wallet = bt.wallet(name=args.wallet, hotkey=args.hotkey)
+    my_wallet = bt.Wallet(name=args.wallet, hotkey=args.hotkey)
     my_hotkey = my_wallet.hotkey.ss58_address
-    subtensor = bt.subtensor(network=args.network)
+    subtensor = bt.Subtensor(network=args.network)
     uid = subtensor.get_uid_for_hotkey_on_subnet(hotkey_ss58=my_hotkey, netuid=args.netuid)
 
     try:
@@ -128,8 +128,8 @@ async def run_uploader(args):
 
 
 def run_uploader_from_gravity(config, desirability_dict) -> Tuple[bool, str]:
-    wallet = bt.wallet(config=config)
-    subtensor = bt.subtensor(config=config)
+    wallet = bt.Wallet(config=config)
+    subtensor = bt.Subtensor(config=config)
     uid = subtensor.get_uid_for_hotkey_on_subnet(hotkey_ss58=wallet.hotkey.ss58_address, netuid=config.netuid)
     try:
         json_content = normalize_preferences_json(

--- a/dynamic_desirability/desirability_uploader.py
+++ b/dynamic_desirability/desirability_uploader.py
@@ -118,7 +118,7 @@ async def run_uploader(args):
 
         bt.logging.info(f"JSON content:\n{json_content}")
         github_commit = upload_to_github(json_content, my_hotkey)
-        subtensor.commit(wallet=my_wallet, netuid=args.netuid, data=github_commit)
+        subtensor.set_commitment(wallet=my_wallet, netuid=args.netuid, data=github_commit)
         result = subtensor.get_commitment(netuid=args.netuid, uid=uid)
         bt.logging.info(f"Stored {result} on chain commit hash.")
         return result
@@ -142,7 +142,7 @@ def run_uploader_from_gravity(config, desirability_dict) -> Tuple[bool, str]:
             return False, message
 
         github_commit = upload_to_github(json_content, wallet.hotkey.ss58_address)
-        subtensor.commit(wallet=wallet, netuid=config.netuid, data=github_commit)
+        subtensor.set_commitment(wallet=wallet, netuid=config.netuid, data=github_commit)
         result = subtensor.get_commitment(netuid=config.netuid, uid=uid)
         message = f"Stored {result} on chain commit hash."
         bt.logging.info(message)

--- a/neurons/config.py
+++ b/neurons/config.py
@@ -31,7 +31,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
-def check_config(config: bt.config):
+def check_config(config: bt.Config):
     r"""Checks/validates the config namespace object."""
     bt.logging.check_config(config)
 
@@ -251,10 +251,10 @@ def create_config(neuron_type: NeuronType):
     Returns the configuration for the NeuronType
     """
     parser = argparse.ArgumentParser()
-    bt.wallet.add_args(parser)
-    bt.subtensor.add_args(parser)
+    bt.Wallet.add_args(parser)
+    bt.Subtensor.add_args(parser)
     bt.logging.add_args(parser)
-    bt.axon.add_args(parser)
+    bt.Axon.add_args(parser)
     add_args(neuron_type, parser)
 
-    return bt.config(parser)
+    return bt.Config(parser)

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -81,7 +81,7 @@ class Miner:
         self.use_gravity_retrieval = self.config.gravity
 
         # The wallet holds the cryptographic key pairs for the miner.
-        self.wallet = bt.wallet(config=self.config)
+        self.wallet = bt.Wallet(config=self.config)
         bt.logging.info(f"Wallet: {self.wallet}.")
 
         if self.config.offline:
@@ -92,7 +92,7 @@ class Miner:
             self.uid = 0  # Offline mode so assume it's == 0
         else:
             # The subtensor is our connection to the Bittensor blockchain.
-            self.subtensor = bt.subtensor(config=self.config)
+            self.subtensor = bt.Subtensor(config=self.config)
             bt.logging.info(f"Subtensor: {self.subtensor}.")
 
             # The metagraph holds the state of the network, letting us know about other validators and miners.
@@ -116,7 +116,7 @@ class Miner:
             self.step = 0
 
             # The axon handles request processing, allowing validators to send this miner requests.
-            self.axon = bt.axon(wallet=self.wallet, port=self.config.axon.port)
+            self.axon = bt.Axon(wallet=self.wallet, port=self.config.axon.port)
 
             # Attach determiners which functions are called when servicing a request.
             bt.logging.info("Attaching forward function to miner axon.")
@@ -885,7 +885,7 @@ class Miner:
         )
         return priority
 
-    def get_config_for_test(self) -> bt.config:
+    def get_config_for_test(self) -> bt.Config:
         return self.config
 
     def sync(self):

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -72,7 +72,7 @@ class Validator:
         evaluator: MinerEvaluator,
         uid: int,
         config=None,
-        subtensor: bt.subtensor = None,
+        subtensor: bt.Subtensor = None,
     ):
         """
 
@@ -81,7 +81,7 @@ class Validator:
             evaluator (MinerEvaluator): The evaluator to evaluate miners.
             uid (int): The uid of the validator.
             config (_type_, optional): _description_. Defaults to None.
-            subtensor (bt.subtensor, optional): _description_. Defaults to None.
+            subtensor (bt.Subtensor, optional): _description_. Defaults to None.
         """
         self.metagraph_syncer = metagraph_syncer
         self.evaluator = evaluator
@@ -93,11 +93,11 @@ class Validator:
         bt.logging.info(self.config)
 
         # The wallet holds the cryptographic key pairs for the miner.
-        self.wallet = bt.wallet(config=self.config)
+        self.wallet = bt.Wallet(config=self.config)
         bt.logging.info(f"Wallet: {self.wallet}.")
 
         # The subtensor is our connection to the Bittensor blockchain.
-        self.subtensor = subtensor or bt.subtensor(config=self.config)
+        self.subtensor = subtensor or bt.Subtensor(config=self.config)
         bt.logging.info(f"Subtensor: {self.subtensor}.")
 
         # The metagraph holds the state of the network, letting us know about other validators and miners.
@@ -430,7 +430,7 @@ class Validator:
         """Serve axon to enable external connections."""
 
         try:
-            self.axon = bt.axon(wallet=self.wallet, config=self.config)
+            self.axon = bt.Axon(wallet=self.wallet, config=self.config)
 
             self.axon.serve(netuid=self.config.netuid, subtensor=self.subtensor).start()
             if self.config.neuron.api_on:
@@ -455,7 +455,7 @@ class Validator:
             bt.logging.error(f"Failed to setup Axon: {e}.")
             sys.exit(1)
 
-    def _on_metagraph_updated(self, metagraph: bt.metagraph, netuid: int):
+    def _on_metagraph_updated(self, metagraph: bt.Metagraph, netuid: int):
         """Processes an update to the metagraph"""
         with self.lock:
             assert netuid == self.config.netuid
@@ -735,9 +735,9 @@ def main():
 
     bt.logging(config=config, logging_dir=config.full_path)
 
-    subtensor = bt.subtensor(config=config)
+    subtensor = bt.Subtensor(config=config)
     metagraph = subtensor.metagraph(netuid=config.netuid)
-    wallet = bt.wallet(config=config)
+    wallet = bt.Wallet(config=config)
 
     # Get the wallet's UID, if registered.
     utils.assert_registered(wallet, metagraph)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 wandb==0.18.7
 apify-client==1.6.1
-asyncpraw==7.8.0
+asyncpraw>=8.0.0,<9.0.0
 bittensor==10.3.0
 jupyter==1.0.0
 numpy==2.0.1
@@ -11,7 +11,7 @@ rich==13.7.0
 torch==2.7.1
 pandas~=2.2.2
 cryptography==45.0.4
-requests==2.32.4
+requests>=2.33.0,<3.0
 huggingface-hub==0.27.1
 datasets~=2.20.0
 pyarrow==17.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 wandb==0.18.7
 apify-client==1.6.1
 asyncpraw==7.8.0
-bittensor==9.9.0
+bittensor==10.3.0
 jupyter==1.0.0
 numpy==2.0.1
 pydantic==2.10.6
@@ -25,4 +25,3 @@ duckdb==1.3.2
 langcodes==3.5.0
 prometheus-fastapi-instrumentator==7.1.0
 prometheus_client==0.22.1
-substrate-interface==1.7.11

--- a/scripts/test_od_jobs_stats.py
+++ b/scripts/test_od_jobs_stats.py
@@ -49,7 +49,7 @@ def main():
     import bittensor as bt
     from common.api_client import TaoSigner
 
-    wallet = bt.wallet(name=args.wallet_name, hotkey=args.wallet_hotkey)
+    wallet = bt.Wallet(name=args.wallet_name, hotkey=args.wallet_hotkey)
     signer = TaoSigner(keypair=wallet.hotkey)
     print(f"validator hotkey: {wallet.hotkey.ss58_address}")
 
@@ -57,7 +57,7 @@ def main():
     miners = []  # (label, hotkey)
     if args.top > 0:
         print(f"fetching metagraph (netuid={args.netuid}, {args.network})...")
-        mg = bt.metagraph(netuid=args.netuid, network=args.network, lite=True)
+        mg = bt.Metagraph(netuid=args.netuid, network=args.network, lite=True)
         order = sorted(range(len(mg.hotkeys)), key=lambda u: -float(mg.I[u]))
         picked = 0
         for uid in order:

--- a/tests/common/test_metagraph_syncer.py
+++ b/tests/common/test_metagraph_syncer.py
@@ -9,10 +9,10 @@ from common.metagraph_syncer import MetagraphSyncer
 class TestMetagraphSyncer(unittest.TestCase):
     def test_do_initial_sync(self):
         # Mock subtensor.metagraph() function
-        metagraph1 = bt.metagraph(netuid=1, sync=False)
-        metagraph2 = bt.metagraph(netuid=2, sync=False)
+        metagraph1 = bt.Metagraph(netuid=1, sync=False)
+        metagraph2 = bt.Metagraph(netuid=2, sync=False)
 
-        def get_metagraph(netuid) -> bt.metagraph:
+        def get_metagraph(netuid) -> bt.Metagraph:
             if netuid == 1:
                 return metagraph1
             elif netuid == 2:
@@ -20,7 +20,7 @@ class TestMetagraphSyncer(unittest.TestCase):
             else:
                 raise Exception("Invalid netuid")
 
-        mock_subtensor = mock.MagicMock(spec=bt.subtensor)
+        mock_subtensor = mock.MagicMock(spec=bt.Subtensor)
         metagraph_mock = mock.MagicMock(side_effect=get_metagraph)
         mock_subtensor.metagraph = metagraph_mock
 
@@ -31,17 +31,17 @@ class TestMetagraphSyncer(unittest.TestCase):
         metagraph_syncer.do_initial_sync()
 
         # Verify get_metagraph() returns the expected metagraph.
-        # We can't check object equality because of how equality is done on bt.metagraph
+        # We can't check object equality because of how equality is done on bt.Metagraph
         # so just check the netuid.
         self.assertEqual(metagraph_syncer.get_metagraph(1).netuid, metagraph1.netuid)
         self.assertEqual(metagraph_syncer.get_metagraph(2).netuid, metagraph2.netuid)
 
     def test_listener_called(self):
         # Mock subtensor.metagraph() function
-        metagraph1 = bt.metagraph(netuid=1, sync=False)
-        metagraph2 = bt.metagraph(netuid=2, sync=False)
+        metagraph1 = bt.Metagraph(netuid=1, sync=False)
+        metagraph2 = bt.Metagraph(netuid=2, sync=False)
 
-        def get_metagraph(netuid) -> bt.metagraph:
+        def get_metagraph(netuid) -> bt.Metagraph:
             if netuid == 1:
                 return metagraph1
             elif netuid == 2:
@@ -49,7 +49,7 @@ class TestMetagraphSyncer(unittest.TestCase):
             else:
                 raise Exception("Invalid netuid")
 
-        mock_subtensor = mock.MagicMock(spec=bt.subtensor)
+        mock_subtensor = mock.MagicMock(spec=bt.Subtensor)
         metagraph_mock = mock.MagicMock(side_effect=get_metagraph)
         mock_subtensor.metagraph = metagraph_mock
 

--- a/tests/integration/test_protocol.py
+++ b/tests/integration/test_protocol.py
@@ -109,7 +109,7 @@ class IntegrationTestProtocol(unittest.TestCase):
 
         self.ip = bt.utils.networking.get_external_ip()
 
-        self.wallet = bt.wallet(name="unit_test2", hotkey="unit_test2")
+        self.wallet = bt.Wallet(name="unit_test2", hotkey="unit_test2")
         self.wallet.create_if_non_existent(
             coldkey_use_password=False, hotkey_use_password=False
         )
@@ -121,7 +121,7 @@ class IntegrationTestProtocol(unittest.TestCase):
     def _test_round_trip(self, forward_fn: Callable, request: bt.Epistula) -> bt.Epistula:
         """Base test for verifying a protocol message between dendrite and axon."""
         port = 1234
-        axon = bt.axon(
+        axon = bt.Axon(
             wallet=self.wallet,
             ip="0.0.0.0",
             port=port,
@@ -132,7 +132,7 @@ class IntegrationTestProtocol(unittest.TestCase):
             axon.attach(forward_fn=forward_fn)
             axon.start()
 
-            dendrite = bt.dendrite(wallet=self.wallet)
+            dendrite = bt.Dendrite(wallet=self.wallet)
 
             response = dendrite.query(
                 axons=bt.AxonInfo(

--- a/tests/vali_utils/test_s3_validation_results_client.py
+++ b/tests/vali_utils/test_s3_validation_results_client.py
@@ -72,8 +72,11 @@ def server():
 
 @pytest.fixture
 def fake_wallet():
-    # Create a real Keypair via substrateinterface so TaoSigner.headers() can sign.
-    from substrateinterface.keypair import Keypair
+    # Create a real Keypair so TaoSigner.headers() can sign.
+    try:
+        from bittensor_wallet.keypair import Keypair
+    except ImportError:  # pragma: no cover - legacy bittensor < 10
+        from substrateinterface.keypair import Keypair
 
     kp = Keypair.create_from_mnemonic(Keypair.generate_mnemonic())
     wallet = MagicMock()

--- a/tests/vali_utils/test_validator_s3_access.py
+++ b/tests/vali_utils/test_validator_s3_access.py
@@ -24,12 +24,12 @@ def main():
     args = parser.parse_args()
 
     # Create config
-    config = bt.config()
+    config = bt.Config()
     config.netuid = args.netuid
     config.s3_auth_url = args.s3_auth_url
 
     # Create wallet and S3 access
-    wallet = bt.wallet(name=args.wallet, hotkey=args.hotkey)
+    wallet = bt.Wallet(name=args.wallet, hotkey=args.hotkey)
     s3_access = ValidatorS3Access(
         wallet=wallet,
         s3_auth_url=args.s3_auth_url

--- a/upload_utils/s3_utils.py
+++ b/upload_utils/s3_utils.py
@@ -12,8 +12,8 @@ class S3Auth:
         self.s3_auth_url = s3_auth_url
 
     def get_credentials(self,
-                        subtensor: bt.subtensor,
-                        wallet: bt.wallet) -> Optional[Dict[str, Any]]:
+                        subtensor: bt.Subtensor,
+                        wallet: bt.Wallet) -> Optional[Dict[str, Any]]:
         """Get S3 credentials using blockchain commitments and hotkey signature"""
         try:
             coldkey = wallet.get_coldkeypub().ss58_address

--- a/vali_utils/api/auth/auth.py
+++ b/vali_utils/api/auth/auth.py
@@ -21,7 +21,7 @@ api_key_header = APIKeyHeader(name=API_KEY_NAME)
 class APIKeyManager:
     API_KEYS_FILENAME = "api_keys.db"
 
-    def __init__(self, config: "bt.config" = None, db_path: str = None):
+    def __init__(self, config: "bt.Config" = None, db_path: str = None):
         self.metrics_api_key = os.getenv("METRICS_API_KEY", str(uuid4()))
 
         # Master key from environment

--- a/vali_utils/api/routes.py
+++ b/vali_utils/api/routes.py
@@ -127,7 +127,7 @@ async def query_bucket(
 
             # Query miner
             bt.logging.info(f"Querying miner {uid} for bucket {latest_bucket}")
-            async with bt.dendrite(wallet=validator.wallet) as dendrite:
+            async with bt.Dendrite(wallet=validator.wallet) as dendrite:
                 response = await dendrite.forward(
                     axons=[axon],
                     synapse=GetDataEntityBucket(

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -71,7 +71,7 @@ class MinerEvaluator:
 
     def __init__(
         self,
-        config: bt.config,
+        config: bt.Config,
         uid: int,
         metagraph_syncer: MetagraphSyncer,
         s3_reader: ValidatorS3Access,
@@ -85,7 +85,7 @@ class MinerEvaluator:
             self._on_metagraph_updated, netuids=[config.netuid]
         )
         self.vpermit_rao_limit = self.config.vpermit_rao_limit
-        self.wallet = bt.wallet(config=self.config)
+        self.wallet = bt.Wallet(config=self.config)
 
         # API-backed S3 validation results. Used by non-macrocosmos validators
         # to fetch what UID 89 published; UID 89 uses it to publish results.
@@ -608,7 +608,7 @@ class MinerEvaluator:
         )
 
         responses = None
-        async with bt.dendrite(wallet=self.wallet) as dendrite:
+        async with bt.Dendrite(wallet=self.wallet) as dendrite:
             responses = await dendrite.forward(
                 axons=[axon_info],
                 synapse=GetDataEntityBucket(
@@ -988,7 +988,7 @@ class MinerEvaluator:
 
         try:
             responses: List[GetMinerIndex] = None
-            async with bt.dendrite(wallet=self.wallet) as dendrite:
+            async with bt.Dendrite(wallet=self.wallet) as dendrite:
                 responses = await dendrite.forward(
                     axons=[miner_axon],
                     synapse=GetMinerIndex(version=constants.PROTOCOL_VERSION),
@@ -1035,7 +1035,7 @@ class MinerEvaluator:
             )
             return None
 
-    def _on_metagraph_updated(self, metagraph: bt.metagraph, netuid: int):
+    def _on_metagraph_updated(self, metagraph: bt.Metagraph, netuid: int):
         """Handles an update to a metagraph."""
         bt.logging.info(
             f"Evaluator processing an update to metagraph on subnet {netuid}."

--- a/vali_utils/s3_validation_results_client.py
+++ b/vali_utils/s3_validation_results_client.py
@@ -29,7 +29,7 @@ class PublishedScore:
 class S3ValidationResultsClient:
     """HTTP client for /s3-validation/results on data-universe-api."""
 
-    def __init__(self, wallet: bt.wallet, api_base_url: str, timeout: int = 30):
+    def __init__(self, wallet: bt.Wallet, api_base_url: str, timeout: int = 30):
         self.api_base_url = api_base_url.rstrip("/")
         self._signer = TaoSigner(keypair=wallet.hotkey)
         self._timeout = timeout

--- a/vali_utils/validator_s3_access.py
+++ b/vali_utils/validator_s3_access.py
@@ -12,7 +12,7 @@ from common.api_client import TaoSigner
 class ValidatorS3Access:
     """S3 access for validators — lists miner files via presigned URLs."""
 
-    def __init__(self, wallet: bt.wallet, s3_auth_url: str, debug: bool = False):
+    def __init__(self, wallet: bt.Wallet, s3_auth_url: str, debug: bool = False):
         self.wallet = wallet
         self.s3_auth_url = s3_auth_url
         self._signer = TaoSigner(keypair=wallet.hotkey)


### PR DESCRIPTION
## Problem (live now)

The finney runtime upgrade re-typed `netuid` as a `NetUid(u16)` composite. bittensor 9.x cannot decode it, so every netuid-parameterized query dies:

```
ValueError: Invalid type for data: 13 of type <class 'int'>,
type_def: Composite(TypeDefComposite { fields: [Field { ... type_name: Some("u16") ... }] })
```

`metagraph_syncer.py:92` — validators/miners connect and read the block fine but **never sync the metagraph**, so scoring/weights stall. Reproduced live against finney on the installed SDK.

Subnet-owner guidance (Discord, Jul 16): upgrade to **10.3.0** — 10.2.0 still fails, so 10.3.0 is the floor.

## Fix

- **`bittensor==9.9.0 → 10.3.0`** in `requirements.txt`.
- **Lowercase class aliases removed in 10.x** → renamed the references the codebase used (type annotations + constructors only; `bt.logging` and `.config` attribute access untouched): `bt.subtensor→bt.Subtensor`, `bt.metagraph→bt.Metagraph`, `bt.wallet→bt.Wallet`, `bt.axon→bt.Axon`, `bt.dendrite→bt.Dendrite`, `bt.config(...)→bt.Config(...)`.
- **`substrate-interface` dropped.** 10.x no longer depends on it, and it drags in `scalecodec`, which conflicts with 10.x's `cyscale` and breaks `import bittensor` outright. `common/api_client.py` now imports `Keypair` from `bittensor_wallet` (fallback to the legacy package for older installs), and the stale `substrate-interface==1.7.11` pin is removed.

## Verification (end-to-end on 10.3.0, live finney)

- `MetagraphSyncer.do_initial_sync()` — the exact class in the stack trace — now succeeds: **netuid=13, n=256**. Fails on the installed 9.0.0.
- `common/api_client.py` auth signing (`TaoSigner`) verified with the `bittensor_wallet` Keypair — produces valid `X-Tao-Signature` headers.
- Confirmed the 10.3.0 environment has **no `scalecodec`** (only `cyscale`), so `import bittensor` is clean.
- All edited files compile on py3.11 and py3.13; `test_s3_validation_results_client.py` passes (4/4).

## Rollout safety

bittensor **9.0.0 already exposes the capitalized aliases**, so this code change is backward-compatible with the currently-installed SDK — the code and the `pip install` do **not** have to flip in the same instant. Deploy: merge → `pip install -r requirements.txt` on validator/miner hosts → restart.

> ⚠️ Major version jump (9→10). Recommend one validator host canary before fleet-wide restart, watching for a clean `Successfully synced metagraph for 13` and a normal weight-set cycle.

