### PR TITLE
fix: restore a small byte-diff tolerance in X (Twitter) content validation

### DIFF
--- a/scraping/x/utils.py
+++ b/scraping/x/utils.py
@@ -388,7 +388,15 @@ def validate_data_entity_fields(
         content_size_bytes=entity.content_size_bytes,
     )
 
-    byte_difference_allowed = 0
+    # Allow a small tolerance for benign serialized-size drift. Mutable tweet
+    # counters (like_count, view_count, retweet_count, reply_count, quote_count,
+    # follower counts) change between the miner's scrape and the validator's
+    # re-scrape, shifting the serialized JSON size by a byte or two purely from
+    # digit-count changes (e.g. view_count 1000 -> 999). This check only guards
+    # against *over-claiming* size (claimed > actual), so a small tolerance admits
+    # nothing fabricated while sparing honest, unmodified tweets. Mirrors the
+    # Reddit-side tolerance.
+    byte_difference_allowed = 10
 
     if (
         entity.content_size_bytes - tweet_entity.content_size_bytes


### PR DESCRIPTION
## Problem

`scraping/x/utils.py::validate_data_entity_fields()` compares a miner's stored `content_size_bytes` against a freshly re-scraped tweet with **zero tolerance**:

```python
byte_difference_allowed = 0
if (entity.content_size_bytes - tweet_entity.content_size_bytes) > byte_difference_allowed:
    return ValidationResult(is_valid=False, reason="The claimed bytes must not exceed the actual tweet size.", ...)
```

Tweet metadata counters (`like_count`, `view_count`, `retweet_count`, `reply_count`, `quote_count`, follower counts) naturally change between when a miner scrapes a tweet and when a validator re-scrapes it. A single digit-count change in any of these (e.g. `view_count` 1000 → 999) shifts the serialized JSON size by a byte or two — with zero tolerance this fails validation for honest, unmodified tweets whose content is entirely accurate.

## Fix

Set the tolerance to `10`, mirroring the Reddit-side companion (#882). The check only guards against **over-claiming** size (`claimed > actual`), so 10 bytes admits nothing fabricated while sparing honest tweets from benign counter drift. This is the direct X twin of the Reddit `byte_difference_allowed` issue.

```diff
-    byte_difference_allowed = 0
+    byte_difference_allowed = 10
```

## Credit

Reported by **DiegoTao** in the SN13 Discord (X-side follow-up to the Reddit report behind #882), with a reproducible example (miner UID 145, tweet id 2077724426540396816, claimed_size=2115 bytes failing despite clean bucket-level size validation and all other field checks).
