### PR TITLE
feat(od): continuous coverage-ratio multiplier — skipping jobs now costs score

### DIFF
--- a/rewards/miner_scorer.py
+++ b/rewards/miner_scorer.py
@@ -100,9 +100,10 @@ class MinerScorer:
             (num_neurons, 1), MinerScorer.STARTING_ONDEMAND_CREDIBILITY, dtype=torch.float32
         )
 
-        # OD abstention multiplier: 1.0 for miners that submit to jobs on every
-        # judgeable platform, OD_ABSTAIN_MULT^k for k abstained platforms.
-        # Set each eval from coverage measurement; scales od_component only.
+        # OD coverage multiplier: 1.0 for full coverage on every judgeable
+        # platform, scaled down for abstention or low coverage. Scales
+        # od_component; via the S3<=2xOD and P2P<=S3+OD caps a low mult
+        # also drags the composite score.
         self.od_coverage_mult = torch.ones(num_neurons, dtype=torch.float32)
 
         # Competition-based S3 scoring: stores effective_size for each miner
@@ -235,13 +236,37 @@ class MinerScorer:
             self.effective_sizes[uid] = 0.0
 
     def set_od_coverage_mult(self, uid: int, mult: float) -> None:
-        """Sets the OD abstention multiplier from the coverage measurement."""
+        """Sets the OD coverage multiplier from the coverage measurement.
+
+        A drop moves halfway toward the target per eval; an improvement
+        applies instantly.
+        """
         with self.lock:
             old = float(self.od_coverage_mult[uid])
-            self.od_coverage_mult[uid] = max(0.0, min(1.0, mult))
+            target = max(0.0, min(1.0, mult))
+            applied = target if target >= old else (old + target) / 2
+            self.od_coverage_mult[uid] = applied
             if old != float(self.od_coverage_mult[uid]):
                 bt.logging.info(json.dumps({
                     "event": "od_coverage_mult",
+                    "uid": uid,
+                    "before": round(old, 4),
+                    "target": round(target, 4),
+                    "after": round(float(self.od_coverage_mult[uid]), 4),
+                }))
+
+    def relax_od_coverage_mult(self, uid: int) -> None:
+        """Moves the OD coverage multiplier halfway back toward 1.0.
+
+        Called when coverage cannot be judged this eval, so a stale
+        penalty doesn't stick.
+        """
+        with self.lock:
+            old = float(self.od_coverage_mult[uid])
+            if old < 1.0:
+                self.od_coverage_mult[uid] = (old + 1.0) / 2
+                bt.logging.info(json.dumps({
+                    "event": "od_coverage_mult_relaxed",
                     "uid": uid,
                     "before": round(old, 4),
                     "after": round(float(self.od_coverage_mult[uid]), 4),

--- a/tests/vali_utils/test_od_coverage_shadow.py
+++ b/tests/vali_utils/test_od_coverage_shadow.py
@@ -1,9 +1,11 @@
-"""Tests for the OD coverage shadow measurement (log-only, no scoring impact).
+"""Tests for OD coverage measurement and the coverage multiplier.
 
 Covers:
 - _log_od_coverage_shadow: per-platform numerators, thin-window skip, clamping
 - _get_od_jobs_stats: caching across calls, failure tolerance
-- _evaluate_od: reward path still restricted to the since-last-eval window
+- _evaluate_od: abstention penalty, coverage-ratio multiplier (skipping
+  penalty), full-page truncation failsafe, reward path still restricted to
+  the since-last-eval window
 """
 
 import asyncio
@@ -126,14 +128,17 @@ class TestStatsCache(unittest.TestCase):
         self.assertIsNotNone(asyncio.run(self.ev._get_od_jobs_stats(client)))
 
 
-class TestAbstentionPenalty(unittest.TestCase):
-    def _run_eval(self, jobs, stats):
+class _EvaluateOdTestBase(unittest.TestCase):
+    def _run_eval(self, jobs, stats, fetch_error=None):
         ev = _stub_evaluator()
         ev.scorer = MagicMock()
         resp = MagicMock()
         resp.jobs = jobs
         client = MagicMock()
-        client.validator_list_miner_jobs = AsyncMock(return_value=resp)
+        if fetch_error is not None:
+            client.validator_list_miner_jobs = AsyncMock(side_effect=fetch_error)
+        else:
+            client.validator_list_miner_jobs = AsyncMock(return_value=resp)
         client.__aenter__ = AsyncMock(return_value=client)
         client.__aexit__ = AsyncMock(return_value=False)
         ev._on_demand_client = MagicMock(return_value=client)
@@ -146,12 +151,14 @@ class TestAbstentionPenalty(unittest.TestCase):
         asyncio.run(ev._evaluate_od(1, "hk"))
         return ev
 
+
+class TestAbstentionPenalty(_EvaluateOdTestBase):
     def test_x_abstainer_penalized(self):
-        """Reddit-only miner gets OD_ABSTAIN_MULT when doable X jobs existed."""
+        """Full-coverage reddit miner gets OD_ABSTAIN_MULT when doable X jobs existed."""
         from rewards.miner_scorer import MinerScorer
 
         now = dt.datetime.now(dt.timezone.utc)
-        jobs = [_job("reddit", now - dt.timedelta(hours=1))]
+        jobs = [_job("reddit", now - dt.timedelta(hours=1)) for _ in range(20)]
         ev = self._run_eval(jobs, _stats(reddit=(90, 85), x=(60, 4)))
         ev.scorer.set_od_coverage_mult.assert_called_once_with(
             1, MinerScorer.OD_ABSTAIN_MULT
@@ -169,54 +176,193 @@ class TestAbstentionPenalty(unittest.TestCase):
     def test_thin_platform_not_judged_for_abstention(self):
         """X with fewer doable jobs than OD_ABSTAIN_MIN_PLATFORM_JOBS is skipped."""
         now = dt.datetime.now(dt.timezone.utc)
-        jobs = [_job("reddit", now - dt.timedelta(hours=1))]
+        jobs = [_job("reddit", now - dt.timedelta(hours=1)) for _ in range(20)]
         ev = self._run_eval(jobs, _stats(reddit=(90, 85), x=(60, 2)))
         ev.scorer.set_od_coverage_mult.assert_called_once_with(1, 1.0)
 
     def test_participant_restored_to_full_mult(self):
         now = dt.datetime.now(dt.timezone.utc)
-        jobs = [
-            _job("reddit", now - dt.timedelta(hours=1)),
+        jobs = [_job("reddit", now - dt.timedelta(hours=1)) for _ in range(20)] + [
             _job("x", now - dt.timedelta(hours=1)),
         ]
         ev = self._run_eval(jobs, _stats(reddit=(90, 85), x=(60, 4)))
         ev.scorer.set_od_coverage_mult.assert_called_once_with(1, 1.0)
 
 
+class TestCoverageRatioMult(_EvaluateOdTestBase):
+    """Low coverage of doable jobs scales the OD multiplier (skipping penalty)."""
+
+    def _mult(self, ev):
+        return ev.scorer.set_od_coverage_mult.call_args.args[1]
+
+    def _reddit_jobs(self, n):
+        now = dt.datetime.now(dt.timezone.utc)
+        return [_job("reddit", now - dt.timedelta(hours=1)) for _ in range(n)] + [
+            _job("x", now - dt.timedelta(hours=1))
+        ]
+
+    def test_coverage_at_threshold_gets_full_mult(self):
+        """coverage == OD_COVERAGE_FULL_MULT_AT -> 1.0 (15/100 doable)."""
+        ev = self._run_eval(self._reddit_jobs(15), _stats(reddit=(110, 100), x=(60, 4)))
+        self.assertAlmostEqual(self._mult(ev), 1.0, places=4)
+
+    def test_coverage_below_threshold_scales_linearly(self):
+        """10/100 doable -> 0.10 coverage -> 0.10/0.15 mult."""
+        ev = self._run_eval(self._reddit_jobs(10), _stats(reddit=(110, 100), x=(60, 4)))
+        self.assertAlmostEqual(self._mult(ev), 0.10 / 0.15, places=4)
+
+    def test_minimal_complier_floored_at_abstain_mult(self):
+        """1/100 doable -> ratio would be 0.067 but floors at OD_ABSTAIN_MULT."""
+        from rewards.miner_scorer import MinerScorer
+
+        ev = self._run_eval(self._reddit_jobs(1), _stats(reddit=(110, 100), x=(60, 4)))
+        self.assertAlmostEqual(self._mult(ev), MinerScorer.OD_ABSTAIN_MULT, places=4)
+
+    def test_thin_platform_participant_not_ratio_judged(self):
+        """X participant with doable < OD_COVERAGE_MIN_PLATFORM_JOBS: no ratio penalty."""
+        now = dt.datetime.now(dt.timezone.utc)
+        jobs = [_job("reddit", now - dt.timedelta(hours=1)) for _ in range(20)] + [
+            _job("x", now - dt.timedelta(hours=1))
+        ]
+        ev = self._run_eval(jobs, _stats(reddit=(90, 85), x=(60, 19)))
+        self.assertAlmostEqual(self._mult(ev), 1.0, places=4)
+
+    def test_full_fetch_page_resolves_in_miners_favor(self):
+        """A full page (possible truncation) -> mult 1.0, no coverage/abstention judged."""
+        now = dt.datetime.now(dt.timezone.utc)
+        # 1000 reddit jobs, zero x jobs: without the failsafe this would be
+        # ratio-judged on a truncated numerator AND x-abstention-penalized.
+        jobs = [
+            _job("reddit", now - dt.timedelta(hours=1))
+            for _ in range(MinerEvaluator.OD_JOBS_FETCH_LIMIT)
+        ]
+        ev = self._run_eval(jobs, _stats(reddit=(9000, 8500), x=(60, 4)))
+        ev.scorer.set_od_coverage_mult.assert_called_once_with(1, 1.0)
+
+    def test_out_of_window_jobs_do_not_count_toward_coverage(self):
+        """Jobs older than the coverage window are excluded from the numerator."""
+        from rewards.miner_scorer import MinerScorer
+
+        now = dt.datetime.now(dt.timezone.utc)
+        jobs = [_job("reddit", now - dt.timedelta(hours=5)) for _ in range(50)] + [
+            _job("reddit", now - dt.timedelta(hours=1)),
+            _job("x", now - dt.timedelta(hours=1)),
+        ]
+        ev = self._run_eval(jobs, _stats(reddit=(110, 100), x=(60, 4)))
+        self.assertAlmostEqual(self._mult(ev), MinerScorer.OD_ABSTAIN_MULT, places=4)
+
+    def test_empty_submissions_dodge_abstention_but_not_ratio(self):
+        """0-byte submissions count against abstention but earn no coverage."""
+        from rewards.miner_scorer import MinerScorer
+
+        now = dt.datetime.now(dt.timezone.utc)
+        jobs = [
+            _job("reddit", now - dt.timedelta(hours=1), content_length=0)
+            for _ in range(30)
+        ] + [_job("x", now - dt.timedelta(hours=1))]
+        ev = self._run_eval(jobs, _stats(reddit=(110, 100), x=(60, 4)))
+        # No abstention (they did submit), but ratio coverage is 0 -> floor.
+        self.assertAlmostEqual(self._mult(ev), MinerScorer.OD_ABSTAIN_MULT, places=4)
+
+    def test_full_page_of_old_jobs_still_resolves_in_miners_favor(self):
+        """The failsafe keys off the RAW page length, not the window-filtered count."""
+        now = dt.datetime.now(dt.timezone.utc)
+        jobs = [
+            _job("reddit", now - dt.timedelta(hours=8))
+            for _ in range(MinerEvaluator.OD_JOBS_FETCH_LIMIT)
+        ]
+        ev = self._run_eval(jobs, _stats(reddit=(9000, 8500), x=(60, 4)))
+        ev.scorer.set_od_coverage_mult.assert_called_once_with(1, 1.0)
+
+    def test_zero_doable_platform_is_ignored(self):
+        """A platform with zero doable jobs neither penalizes nor divides by zero."""
+        now = dt.datetime.now(dt.timezone.utc)
+        jobs = [_job("reddit", now - dt.timedelta(hours=1)) for _ in range(20)]
+        ev = self._run_eval(jobs, _stats(reddit=(90, 85), x=(60, 0)))
+        self.assertAlmostEqual(self._mult(ev), 1.0, places=4)
+
+    def test_threshold_adapts_when_doable_exceeds_fetch_cap(self):
+        """With doable >> fetch limit, the full-mult bar caps at 0.5*limit/doable."""
+        now = dt.datetime.now(dt.timezone.utc)
+        # doable=8000 -> full_at = min(0.15, 500/8000) = 0.0625.
+        jobs = [_job("reddit", now - dt.timedelta(hours=1)) for _ in range(600)] + [
+            _job("x", now - dt.timedelta(hours=1))
+        ]
+        ev = self._run_eval(jobs, _stats(reddit=(9000, 8000), x=(60, 4)))
+        # 600/8000 = 0.075 >= 0.0625 -> full mult despite being far below 0.15.
+        self.assertAlmostEqual(self._mult(ev), 1.0, places=4)
+
+    def test_stats_none_relaxes_instead_of_judging(self):
+        """No stats -> relax toward 1.0; never judge, never hold a stale penalty."""
+        now = dt.datetime.now(dt.timezone.utc)
+        jobs = [_job("reddit", now - dt.timedelta(hours=1))]
+        ev = self._run_eval(jobs, None)
+        ev.scorer.set_od_coverage_mult.assert_not_called()
+        ev.scorer.relax_od_coverage_mult.assert_called_once_with(1)
+
+    def test_fetch_failure_relaxes_instead_of_holding_penalty(self):
+        """Jobs-fetch failure -> relax toward 1.0 and skip the eval."""
+        ev = self._run_eval([], _stats(), fetch_error=RuntimeError("boom"))
+        ev.scorer.set_od_coverage_mult.assert_not_called()
+        ev.scorer.relax_od_coverage_mult.assert_called_once_with(1)
+
+
 class TestScorerCoverageMult(unittest.TestCase):
-    def test_mult_scales_od_and_drags_caps(self):
+    def _scorer(self, n=2):
         from rewards.data_value_calculator import DataValueCalculator
         from rewards.miner_scorer import MinerScorer
-        import torch
 
-        scorer = MinerScorer(2, DataValueCalculator())
+        return MinerScorer(n, DataValueCalculator())
+
+    def test_mult_scales_od_and_drags_caps(self):
+        from rewards.miner_scorer import MinerScorer
+
+        scorer = self._scorer()
         for uid in (0, 1):
             scorer.ondemand_boosts[uid] = 100.0
             scorer.ondemand_credibility[uid] = 1.0
             scorer.s3_boosts[uid] = 1000.0
             scorer.s3_credibility[uid] = 1.0
 
+        # First drop smooths halfway: 1.0 -> 0.65; converge with repeats.
         scorer.set_od_coverage_mult(1, MinerScorer.OD_ABSTAIN_MULT)
+        self.assertAlmostEqual(float(scorer.od_coverage_mult[1]), 0.65, places=4)
         scores = scorer.get_scores_for_weights()
 
-        # uid0: od=100, s3 capped at 200 -> 300. uid1: od=30, s3 capped at 60 -> 90.
+        # uid0: od=100, s3 capped at 200 -> 300. uid1: od=65, s3 capped at 130 -> 195.
         self.assertAlmostEqual(float(scores[0]), 300.0, places=2)
-        self.assertAlmostEqual(float(scores[1]), 90.0, places=2)
+        self.assertAlmostEqual(float(scores[1]), 195.0, places=2)
+
+    def test_penalty_phases_in_recovery_is_instant(self):
+        scorer = self._scorer()
+        scorer.set_od_coverage_mult(0, 0.3)
+        self.assertAlmostEqual(float(scorer.od_coverage_mult[0]), 0.65, places=4)
+        scorer.set_od_coverage_mult(0, 0.3)
+        self.assertAlmostEqual(float(scorer.od_coverage_mult[0]), 0.475, places=4)
+        # Improvement applies instantly.
+        scorer.set_od_coverage_mult(0, 1.0)
+        self.assertAlmostEqual(float(scorer.od_coverage_mult[0]), 1.0, places=4)
+
+    def test_relax_moves_halfway_to_full(self):
+        scorer = self._scorer()
+        scorer.set_od_coverage_mult(0, 0.0)  # -> 0.5 (smoothed)
+        scorer.relax_od_coverage_mult(0)
+        self.assertAlmostEqual(float(scorer.od_coverage_mult[0]), 0.75, places=4)
+        scorer.relax_od_coverage_mult(1)  # already 1.0 -> no-op
+        self.assertAlmostEqual(float(scorer.od_coverage_mult[1]), 1.0, places=4)
 
     def test_state_roundtrip_preserves_mult(self):
         import os
         import tempfile
-        from rewards.data_value_calculator import DataValueCalculator
-        from rewards.miner_scorer import MinerScorer
 
-        scorer = MinerScorer(4, DataValueCalculator())
-        scorer.set_od_coverage_mult(2, 0.3)
+        scorer = self._scorer(4)
+        scorer.set_od_coverage_mult(2, 0.3)  # smoothed: 1.0 -> 0.65
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, "scorer.pickle")
             scorer.save_state(path)
-            loaded = MinerScorer(4, DataValueCalculator())
+            loaded = self._scorer(4)
             loaded.load_state(path)
-        self.assertAlmostEqual(float(loaded.od_coverage_mult[2]), 0.3, places=4)
+        self.assertAlmostEqual(float(loaded.od_coverage_mult[2]), 0.65, places=4)
         self.assertAlmostEqual(float(loaded.od_coverage_mult[0]), 1.0, places=4)
 
 

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -170,11 +170,19 @@ class MinerEvaluator:
     OD_COVERAGE_WINDOW_HOURS = 3
     OD_COVERAGE_MIN_SUBMITTERS = 5
     # Below this many doable jobs on a platform the window is too thin to
-    # judge a coverage RATIO (shadow logging only).
+    # judge a coverage RATIO (gates both the shadow log and the live
+    # coverage-ratio penalty below).
     OD_COVERAGE_MIN_PLATFORM_JOBS = 20
     # Total ABSTENTION (zero submissions) is a much stronger signal — it is
     # penalized once at least this many doable jobs existed on the platform.
     OD_ABSTAIN_MIN_PLATFORM_JOBS = 3
+    # At or above this share of a platform's doable jobs the coverage
+    # multiplier is 1.0; below it, it scales down linearly (floored at
+    # OD_ABSTAIN_MULT, so participating is never worse than abstaining).
+    OD_COVERAGE_FULL_MULT_AT = 0.15
+    # Per-miner jobs fetch page size. A full page may truncate the coverage
+    # numerator — coverage is then resolved in the miner's favor.
+    OD_JOBS_FETCH_LIMIT = 1000
     # Stats are identical for every miner in a batch — cache and refetch rarely.
     OD_STATS_CACHE_TTL_SECS = 600
 
@@ -205,6 +213,29 @@ class MinerEvaluator:
             self._od_stats_cache = (now, resp)
             return resp
 
+    @staticmethod
+    def _od_submission_counts(
+        all_jobs: List["MinerJobForValidation"], coverage_since: dt.datetime
+    ) -> Dict[str, Dict[str, int]]:
+        """Per-platform submission counts for the coverage window.
+
+        Shared numerator for the coverage log and the scoring block.
+        'nonempty' counts submissions whose bytes landed in S3.
+        """
+        counts: Dict[str, Dict[str, int]] = {}
+        for j in all_jobs:
+            exp = j.job.expire_at
+            if exp is not None and exp < coverage_since:
+                continue
+            platform = j.job.job.platform
+            c = counts.setdefault(platform, {"any": 0, "nonempty": 0, "bytes": 0})
+            length = j.submission.s3_content_length or 0
+            c["any"] += 1
+            if length > 0:
+                c["nonempty"] += 1
+                c["bytes"] += length
+        return counts
+
     def _log_od_coverage_shadow(
         self,
         uid: int,
@@ -213,20 +244,10 @@ class MinerEvaluator:
         stats: Optional[OnDemandJobsStatsResponse],
         coverage_since: dt.datetime,
     ) -> None:
-        """Shadow-log per-platform OD coverage. Measurement only — no score impact."""
+        """Log per-platform OD coverage with the same numerator the scoring uses."""
         if stats is None:
             return
-        submitted: Dict[str, int] = {}
-        volume_bytes: Dict[str, int] = {}
-        for j in all_jobs:
-            exp = j.job.expire_at
-            if exp is None or exp < coverage_since:
-                continue
-            platform = j.job.job.platform
-            submitted[platform] = submitted.get(platform, 0) + 1
-            volume_bytes[platform] = volume_bytes.get(platform, 0) + (
-                j.submission.s3_content_length or 0
-            )
+        counts = self._od_submission_counts(all_jobs, coverage_since)
 
         event = {
             "event": "od_coverage_shadow",
@@ -235,20 +256,20 @@ class MinerEvaluator:
             "window_hours": self.OD_COVERAGE_WINDOW_HOURS,
         }
         for platform, pstats in stats.platforms.items():
-            done = submitted.get(platform, 0)
+            c = counts.get(platform, {"any": 0, "nonempty": 0, "bytes": 0})
             coverage = (
-                round(min(1.0, done / pstats.doable_jobs), 4)
+                round(min(1.0, c["nonempty"] / pstats.doable_jobs), 4)
                 if pstats.doable_jobs >= self.OD_COVERAGE_MIN_PLATFORM_JOBS
                 else None  # too few jobs this window to judge
             )
-            total_bytes = volume_bytes.get(platform, 0)
             event[platform] = {
-                "submitted": done,
+                "submitted": c["any"],
+                "nonempty": c["nonempty"],
                 "doable": pstats.doable_jobs,
                 "total": pstats.total_jobs,
                 "coverage": coverage,
-                "bytes": total_bytes,
-                "avg_bytes": round(total_bytes / done) if done else 0,
+                "bytes": c["bytes"],
+                "avg_bytes": round(c["bytes"] / c["nonempty"]) if c["nonempty"] else 0,
             }
         bt.logging.info(json.dumps(event))
 
@@ -279,35 +300,52 @@ class MinerEvaluator:
                         miner_hotkey=hotkey,
                         expired_since=fetch_since,
                         expired_until=now,
-                        limit=1000,
+                        limit=self.OD_JOBS_FETCH_LIMIT,
                     )
                 )
                 stats = await self._get_od_jobs_stats(client)
         except Exception as e:
             bt.logging.warning(f"UID:{uid} - HOTKEY:{hotkey}: OD API fetch failed: {e}")
+            # Can't judge coverage this eval — don't hold a stale penalty.
+            self.scorer.relax_od_coverage_mult(uid)
             return
 
         self._last_od_eval_at[hotkey] = now
 
         self._log_od_coverage_shadow(uid, hotkey, resp.jobs, stats, coverage_since)
 
-        # Abstention penalty: zero submissions on a platform where doable jobs
-        # existed scales od_component down (recovers on next participation).
-        # Runs BEFORE the empty-jobs early return so fully-absent miners are hit.
-        if stats is not None:
-            submitted_platforms = {
-                j.job.job.platform
-                for j in resp.jobs
-                if j.job.expire_at is None or j.job.expire_at >= coverage_since
-            }
+        # Coverage multiplier: abstention (zero submissions) and low coverage
+        # of doable jobs both scale od_component down. Any submission counts
+        # against abstention; only submissions with bytes in S3 count toward
+        # the ratio. Runs BEFORE the empty-jobs early return. A full fetch
+        # page may truncate the numerator — resolved in the miner's favor.
+        if stats is not None and len(resp.jobs) >= self.OD_JOBS_FETCH_LIMIT:
+            self.scorer.set_od_coverage_mult(uid, 1.0)
+        elif stats is not None:
+            counts = self._od_submission_counts(resp.jobs, coverage_since)
             mult = 1.0
             for platform, pstats in stats.platforms.items():
-                if (
-                    pstats.doable_jobs >= self.OD_ABSTAIN_MIN_PLATFORM_JOBS
-                    and platform not in submitted_platforms
-                ):
-                    mult *= MinerScorer.OD_ABSTAIN_MULT
+                c = counts.get(platform, {"any": 0, "nonempty": 0})
+                if c["any"] == 0:
+                    if pstats.doable_jobs >= self.OD_ABSTAIN_MIN_PLATFORM_JOBS:
+                        mult *= MinerScorer.OD_ABSTAIN_MULT
+                elif pstats.doable_jobs >= self.OD_COVERAGE_MIN_PLATFORM_JOBS:
+                    # Cap the full-mult bar at half the max observable
+                    # coverage so it stays reachable at any job volume.
+                    full_at = min(
+                        self.OD_COVERAGE_FULL_MULT_AT,
+                        0.5 * self.OD_JOBS_FETCH_LIMIT / pstats.doable_jobs,
+                    )
+                    coverage = min(1.0, c["nonempty"] / pstats.doable_jobs)
+                    if coverage < full_at:
+                        mult *= max(
+                            MinerScorer.OD_ABSTAIN_MULT,
+                            coverage / full_at,
+                        )
             self.scorer.set_od_coverage_mult(uid, mult)
+        else:
+            # Stats unavailable — can't judge; don't hold a stale penalty.
+            self.scorer.relax_od_coverage_mult(uid)
 
         # Reward path: unchanged semantics — only jobs from the since-last-eval window.
         jobs = [


### PR DESCRIPTION
## Problem

The OD abstention penalty is binary: one submission per platform clears it. Most miners minimal-comply — a single job per window — while a minority serves 20-50% of jobs.

## Change

Per platform with ≥20 doable jobs: `coverage = nonempty_submissions / doable_jobs`. Below 15%, the od_component multiplier scales down linearly, floored at 0.3 (participating is never worse than abstaining). Zero-submission abstention unchanged. `doable_jobs` counts only jobs that ≥5 distinct miners served, so no one is penalized for jobs that had no data.

## Safeguards

- Only submissions with verified bytes in S3 count toward the ratio; any submission still counts against abstention (empty results on dataless jobs don't mark a miner absent).
- A multiplier drop phases in halfway per eval; improvement applies instantly — one bad window costs ×0.65 once, not ×0.3.
- If stats or the jobs fetch fail, the multiplier relaxes halfway toward 1.0 instead of freezing a stale penalty.
- A full fetch page (possible numerator truncation) resolves to ×1.0 in the miner's favor.
- The full-mult bar adapts to `min(0.15, 0.5·fetch_limit/doable)` so it stays reachable at any job volume.
- Shadow log and scoring share one numerator helper.

## Tests

27 tests in `test_od_coverage_shadow.py`: ratio boundaries, empty-submission handling, truncation failsafe, fetch-failure relax, zero-doable platform, adaptive threshold, smoothing, state roundtrip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)