### PR TITLE
fix(od): speed multiplier grace window — stop punishing live scraping

### DIFF
--- a/tests/vali_utils/test_od_reward_multipliers.py
+++ b/tests/vali_utils/test_od_reward_multipliers.py
@@ -1,0 +1,53 @@
+"""Tests for the OD reward multiplier curves (speed grace window + floor)."""
+
+import unittest
+
+from vali_utils.on_demand.on_demand_validation import (
+    SPEED_FLOOR,
+    SPEED_GRACE_S,
+    SPEED_HALF_LIFE_S,
+    _speed_multiplier,
+    _volume_multiplier,
+)
+
+
+class TestSpeedMultiplier(unittest.TestCase):
+    def test_full_mult_within_grace_window(self):
+        for t in (0.0, 0.5, 5, 15, SPEED_GRACE_S):
+            self.assertEqual(_speed_multiplier(t), 1.0, f"t={t}")
+
+    def test_half_life_decay_past_grace(self):
+        self.assertAlmostEqual(
+            _speed_multiplier(SPEED_GRACE_S + SPEED_HALF_LIFE_S), 0.5, places=6
+        )
+        self.assertAlmostEqual(
+            _speed_multiplier(SPEED_GRACE_S + SPEED_HALF_LIFE_S / 2),
+            0.5 ** 0.5,
+            places=6,
+        )
+
+    def test_floor_never_undercut(self):
+        for t in (600, 3600, 86400):
+            self.assertEqual(_speed_multiplier(t), SPEED_FLOOR, f"t={t}")
+
+    def test_negative_upload_time_clamped(self):
+        """Clock skew can't produce a >1.0 multiplier."""
+        self.assertEqual(_speed_multiplier(-10), 1.0)
+
+    def test_monotonic_nonincreasing(self):
+        samples = [_speed_multiplier(t) for t in range(0, 1200, 30)]
+        self.assertEqual(samples, sorted(samples, reverse=True))
+
+
+class TestVolumeMultiplier(unittest.TestCase):
+    """Pins current volume behavior (unchanged in this PR)."""
+
+    def test_zero_returned_is_zero(self):
+        self.assertEqual(_volume_multiplier(0, 100), 0.0)
+
+    def test_full_limit_is_one(self):
+        self.assertEqual(_volume_multiplier(100, 100), 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vali_utils/on_demand/on_demand_validation.py
+++ b/vali_utils/on_demand/on_demand_validation.py
@@ -22,7 +22,12 @@ from vali_utils.metrics import ORGANIC_MINER_RESULTS
 
 
 # Reward multiplier tuning constants (see docs/od_reward_formula.md)
+# Speed: full multiplier within the grace window so live scraping isn't
+# out-scored by cached serving; half-life decay past it; floored so
+# late-but-delivered data still scores above not serving.
+SPEED_GRACE_S = 30.0
 SPEED_HALF_LIFE_S = 45.0
+SPEED_FLOOR = 0.3
 VOLUME_SHORTFALL_EXPONENT = 1.3
 VOLUME_OVER_LOG_COEF = 0.15
 VOLUME_OVER_BONUS_CAP = 0.25
@@ -31,9 +36,9 @@ VOLUME_OPEN_MAX = 1.5
 
 
 def _speed_multiplier(upload_seconds: float) -> float:
-    """Half-life decay; clamps to [0, 1]. See docs/od_reward_formula.md §3."""
+    """1.0 within the grace window, half-life decay past it, floored."""
     t = max(0.0, float(upload_seconds))
-    return min(1.0, 0.5 ** (t / SPEED_HALF_LIFE_S))
+    return max(SPEED_FLOOR, min(1.0, 0.5 ** ((t - SPEED_GRACE_S) / SPEED_HALF_LIFE_S)))
 
 
 def _volume_multiplier(returned: int, limit: Optional[int]) -> float:


### PR DESCRIPTION
## Problem

The speed multiplier decays from second zero (`0.5^(t/45s)`, no grace, no floor). A 90s live scrape earns 0.25× vs 0.93× for a cache hit, making fresh (uncached) queries irrational to serve — observed submission times cluster under 2s.

## Change

`speed = max(0.3, min(1.0, 0.5^((t − 30s)/45s)))`

| upload time | old | new |
|---|---|---|
| ≤30s | 0.63–1.0 | 1.0 |
| 45s | 0.50 | 0.79 |
| 75s | 0.31 | 0.50 |
| 110s+ | ≤0.18 | 0.3 floor |

- Full multiplier within the 30s grace window — live scraping is no longer out-scored by cached serving.
- Half-life decay past the grace window; floored at 0.3 so late-but-delivered data still scores above not serving.

## Risk

None for current traffic (all observed submissions ≤2s → stay at 1.0). Companion to #888.

## Tests

`tests/vali_utils/test_od_reward_multipliers.py`: grace-window equality, half-life points, floor, negative-time clamp, monotonicity — 7/7 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)