### PR TITLE
fix(od-validation): don't penalize miners when the upload leg fails

### DIFF
--- a/tests/vali_utils/test_od_not_uploaded_neutral.py
+++ b/tests/vali_utils/test_od_not_uploaded_neutral.py
@@ -1,0 +1,121 @@
+"""A submission whose body never reached S3 must not be penalized.
+
+`s3_content_length == 0` is unreachable from a completed upload — the smallest
+well-formed payload a miner can PUT is `{"data_entities": []}` (21 bytes). Zero
+therefore means the submit leg created the record but the upload leg failed, which
+is infrastructure, not the miner's answer.
+
+The penalty is multiplicative and compounds (`od_boost *= 0.7` per occurrence), so
+one API incident is geometric in the number of jobs in flight.
+"""
+
+import asyncio
+import datetime as dt
+import threading
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from common.api_client import (
+    MinerJobForValidation,
+    OnDemandJob,
+    OnDemandJobSubmission,
+    OnDemandJobsStatsResponse,
+    PlatformJobStats,
+)
+from vali_utils.miner_evaluator import MinerEvaluator
+
+
+def _stub_evaluator():
+    ev = MinerEvaluator.__new__(MinerEvaluator)
+    ev._od_stats_cache = None
+    ev._od_stats_lock = threading.Lock()
+    ev._last_od_eval_at = {}
+    ev.on_demand_validator = MagicMock()
+    return ev
+
+
+def _job(platform: str, expire_at: dt.datetime, content_length: int) -> MinerJobForValidation:
+    return MinerJobForValidation(
+        job=OnDemandJob(
+            id="j", expire_at=expire_at, job={"platform": platform, "keywords": ["k"]}
+        ),
+        submission=OnDemandJobSubmission(job_id="j", s3_content_length=content_length),
+    )
+
+
+def _stats() -> OnDemandJobsStatsResponse:
+    return OnDemandJobsStatsResponse(
+        platforms={
+            "reddit": PlatformJobStats(total_jobs=90, doable_jobs=85),
+            "x": PlatformJobStats(total_jobs=60, doable_jobs=4),
+        }
+    )
+
+
+class TestNotUploadedIsNeutral(unittest.TestCase):
+    def _run(self, jobs):
+        ev = _stub_evaluator()
+        ev.scorer = MagicMock()
+        resp = MagicMock()
+        resp.jobs = jobs
+        client = MagicMock()
+        client.validator_list_miner_jobs = AsyncMock(return_value=resp)
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+        ev._on_demand_client = MagicMock(return_value=client)
+        ev._get_od_jobs_stats = AsyncMock(return_value=_stats())
+        ev._log_od_coverage_shadow = MagicMock()
+        ev._validate_od_submission = AsyncMock(return_value=(True, 10))
+        ev.on_demand_validator.calculate_ondemand_reward_multipliers = MagicMock(
+            return_value=(1.0, 1.0)
+        )
+        asyncio.run(ev._evaluate_od(1, "hk"))
+        return ev
+
+    def test_zero_byte_submissions_are_not_penalized(self):
+        """The regression: 9 failed uploads must not fire 9 penalties."""
+        now = dt.datetime.now(dt.timezone.utc)
+        jobs = [_job("reddit", now - dt.timedelta(hours=1), 0) for _ in range(9)]
+        jobs += [_job("x", now - dt.timedelta(hours=1), 500)]
+
+        ev = self._run(jobs)
+
+        ev.scorer.apply_ondemand_penalty.assert_not_called()
+
+    def test_all_uploads_failed_is_a_no_op(self):
+        """Nothing landed: no reward, no penalty — same as never answering."""
+        now = dt.datetime.now(dt.timezone.utc)
+        jobs = [_job("reddit", now - dt.timedelta(hours=1), 0) for _ in range(5)]
+
+        ev = self._run(jobs)
+
+        ev.scorer.apply_ondemand_penalty.assert_not_called()
+        ev.scorer.apply_ondemand_reward.assert_not_called()
+
+    def test_uploaded_submissions_still_scored(self):
+        """A body that DID land is still validated and rewarded — no regression."""
+        now = dt.datetime.now(dt.timezone.utc)
+        jobs = [_job("reddit", now - dt.timedelta(hours=1), 500) for _ in range(3)]
+        jobs += [_job("x", now - dt.timedelta(hours=1), 500)]
+
+        ev = self._run(jobs)
+
+        self.assertTrue(ev._validate_od_submission.await_count >= 1)
+        ev.scorer.apply_ondemand_penalty.assert_not_called()
+
+    def test_deliberate_empty_answer_still_reaches_validation(self):
+        """21-byte `{"data_entities": []}` is a real answer, not a failed upload.
+
+        It must land in the validated path, where check_data_exists() decides —
+        not be silently reclassified as an infrastructure failure.
+        """
+        now = dt.datetime.now(dt.timezone.utc)
+        jobs = [_job("reddit", now - dt.timedelta(hours=1), 21) for _ in range(2)]
+
+        ev = self._run(jobs)
+
+        self.assertTrue(ev._validate_od_submission.await_count >= 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -356,22 +356,42 @@ class MinerEvaluator:
         if not jobs:
             return
 
-        # Single-pass partition into empty vs non-empty submissions
-        empty, non_empty = [], []
+        # Single-pass partition into non-empty vs never-uploaded submissions.
+        #
+        # `s3_content_length == 0` is not reachable from any completed upload: the
+        # smallest well-formed payload a miner can PUT is `{"data_entities": []}`
+        # (21 bytes). Zero therefore means the submission record was created by
+        # POST /on-demand/miner/jobs/submit but the body never landed in S3 — the
+        # upload leg failed. That is our infrastructure, not the miner's answer.
+        #
+        # A miner that deliberately answers "nothing here" uploads those 21 bytes,
+        # lands in `non_empty`, and is judged on the merits by
+        # _validate_od_submission (which already forgives an empty answer when
+        # check_data_exists() confirms there was nothing to return). Penalising the
+        # zero-byte case here inverted that: the miner who could not control the
+        # outcome was charged, while the deliberate empty answer was forgiven.
+        #
+        # The penalty also compounds — apply_ondemand_penalty multiplies od_boost by
+        # (1 - ondemand_alpha) = 0.7 per occurrence — so a single API incident is
+        # geometric in the number of jobs in flight. Observed on mainnet 2026-07-26:
+        # nine failed uploads inside one eval window took a miner's od_boost from
+        # 83.4M to 1.19M (0.7^9 = 0.040) and its emission from 0.145 to 0.0025.
+        #
+        # Treat a never-uploaded submission the same way an unanswered job is
+        # treated: no reward, no penalty. Consistent with #844 (OD download
+        # failures) and #849 (S3 scraper failures).
+        not_uploaded, non_empty = [], []
         for j in jobs:
             if (j.submission.s3_content_length or 0) > 0:
                 non_empty.append(j)
             else:
-                empty.append(j)
-
-        for j in empty:
-            self.scorer.apply_ondemand_penalty(uid=uid, mult_factor=1.0)
+                not_uploaded.append(j)
 
         if not non_empty:
-            if empty:
+            if not_uploaded:
                 bt.logging.info(
-                    f"UID:{uid} - HOTKEY:{hotkey}: OD — {len(empty)} empty submissions penalized, "
-                    f"0 non-empty"
+                    f"UID:{uid} - HOTKEY:{hotkey}: OD — {len(not_uploaded)} submission(s) "
+                    f"with no uploaded body (upload leg failed; not penalized), 0 non-empty"
                 )
             return
 
@@ -447,7 +467,8 @@ class MinerEvaluator:
         bt.logging.info(
             f"UID:{uid} - HOTKEY:{hotkey}: OD summary — "
             f"{len(non_empty)} non-empty (validated: {validated_pass} pass, {validated_fail} fail, "
-            f"{not_sampled_count} credibility-bumped), {len(empty)} empty penalized"
+            f"{not_sampled_count} credibility-bumped), "
+            f"{len(not_uploaded)} not uploaded (skipped, not penalized)"
         )
 
     async def _validate_od_submission(


### PR DESCRIPTION
## Problem

`s3_content_length == 0` is not reachable from a completed upload. The smallest well-formed payload a miner can PUT is `{"data_entities": []}` — 21 bytes:

```python
>>> OnDemandMinerUpload(data_entities=[]).model_dump_json()
'{"data_entities": []}'   # 21 bytes
```

So zero means `POST /on-demand/miner/jobs/submit` created the submission record but the body never landed in S3 — `miner_submit_and_upload` is two legs, and the second one failed. That is infrastructure, not the miner's answer.

`miner_evaluator.py` currently charges that case:

```python
for j in empty:
    self.scorer.apply_ondemand_penalty(uid=uid, mult_factor=1.0)
```

`apply_ondemand_penalty` is **multiplicative** (`ondemand_boosts[uid] *= 1 - ondemand_alpha`, i.e. `x0.7`) and applied **per occurrence**, so one API incident is geometric in the number of jobs a miner had in flight.

## This inverts the intended treatment of empty answers

A miner that deliberately answers "nothing here" uploads those 21 bytes, lands in `non_empty`, and is judged on the merits by `_validate_od_submission` — which already forgives an empty answer when `check_data_exists()` confirms there was nothing to return:

```python
else:
    bt.logging.info(f"... empty submission, data doesn't exist for job {job_id} — acceptable")
    return True, 0
```

The miner whose upload was killed by a 5xx or a transport error — the one outcome it cannot influence — is the only one charged. And since skipping a job is already free, **a failed upload is currently strictly worse than never answering**, which penalises exactly the miners who did the work.

## Observed impact

During the API incident on 2026-07-26, nine failed uploads inside a single eval window:

```
83,430,448             od_boost, healthy
  x 0.7^9 = 3,366,719  9 zero-byte submission records   <- matches logged boost_before
  EMA     = 2,432,060  1 pass at volume_mult 0.0025     <- matches logged boost_after
  x 0.7^2 = 1,191,709  2 scraper failures               <- matches final breakdown
```

Emission went 0.145 -> 0.0025. The arithmetic reproduces the validator's own logged `boost_before` / `boost_after` to within 0.01%.

## Fix

Treat a never-uploaded submission the way an unanswered job is treated: no reward, no penalty. The functional change is removing the two-line penalty loop; the rest is naming (`empty` -> `not_uploaded`), the log lines, and a comment explaining why zero bytes is diagnostic.

Consistent with #844 (OD download failures, merged) and #849 (S3 scraper failures, open) — validator- and API-side failures should be scoring-neutral for the miner.

## Tests

Adds `tests/vali_utils/test_od_not_uploaded_neutral.py` (4 cases). Verified both directions:

- **2 fail on `main`, pass with this change** — `test_zero_byte_submissions_are_not_penalized`, `test_all_uploads_failed_is_a_no_op`
- **2 pass both ways** — guards against over-correcting: bodies that *did* land, including a deliberate 21-byte empty answer, still reach `_validate_od_submission`

Full `tests/vali_utils/` suite: **6 failures before this change, the same 6 after** (81 passed -> 83 passed; the delta is only the 2 new cases flipping). No new breakage.

### Disclosure on the pre-existing failures

Three of those pre-existing failures are in `test_od_flow.py`, and one is named `test_empty_submissions_penalized_immediately` — which reads as though this PR contradicts it. It does not: those three already fail on unmodified `main`. They drive a removed cache-based path (`CachedMinerODResult`, `self.cache.add_results`) that `_evaluate_od` no longer reads — it now fetches via `validator_list_miner_jobs` — so nothing runs and credibility stays at its initial value:

```
E  AssertionError: 0.5 not less than 0.5
tests/vali_utils/test_od_flow.py:206
```

I have left them untouched rather than delete the one whose name conflicts with this change. Happy to remove or port them in a follow-up if you'd prefer — they look vestigial, but that is your call, not mine.
