### PR TITLE
fix(od): treat scraper ERRORS as "no evidence" instead of miner failures

### DIFF
--- a/tests/vali_utils/test_od_scraper_error_neutral.py
+++ b/tests/vali_utils/test_od_scraper_error_neutral.py
@@ -1,0 +1,102 @@
+"""A scraper ERROR must not be scored as a miner failure.
+
+`_validate_with_scraper` previously returned a bare bool, so an Apify actor timeout,
+an empty result set or a missing scraper were indistinguishable from "the miner sent
+bad data" — each costing od_boost x0.70 and od_cred -0.05. These tests pin the
+three-state contract: True / False / None(no evidence), and confirm that a GENUINE
+content mismatch is still reported as a failure.
+"""
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from common.data import DataEntity, DataSource
+from scraping.scraper import ValidationResult
+from vali_utils.on_demand.on_demand_validation import (
+    OnDemandValidator,
+    ValidationContext,
+    SCRAPER_ERROR_REASON_PREFIXES,
+)
+
+
+def _entity():
+    return MagicMock(spec=DataEntity, content_size_bytes=100)
+
+
+def _ctx():
+    ctx = MagicMock(spec=ValidationContext)
+    ctx.source = "reddit"
+    return ctx
+
+
+class TestScraperErrorIsNeutral(unittest.TestCase):
+    def setUp(self):
+        self.v = OnDemandValidator.__new__(OnDemandValidator)
+
+    def _run(self, scraper):
+        self.v._get_scraper = MagicMock(return_value=scraper)
+        return asyncio.run(
+            self.v._validate_with_scraper(_ctx(), _entity(), "t3_abc123")
+        )
+
+    def _scraper_returning(self, result):
+        s = MagicMock()
+        s.validate = AsyncMock(return_value=[result] if result is not None else [])
+        return s
+
+    # --- errors: must be None ("no evidence"), never False ---
+
+    def test_scraper_raises_is_neutral(self):
+        s = MagicMock()
+        s.validate = AsyncMock(side_effect=TimeoutError("actor timed out"))
+        self.assertIsNone(self._run(s))
+
+    def test_empty_results_is_neutral(self):
+        self.assertIsNone(self._run(self._scraper_returning(None)))
+
+    def test_missing_scraper_is_neutral(self):
+        self.v._get_scraper = MagicMock(return_value=None)
+        self.assertIsNone(
+            asyncio.run(self.v._validate_with_scraper(_ctx(), _entity(), "t3_abc123"))
+        )
+
+    def test_scraper_self_reported_error_is_neutral(self):
+        """The real-world case: reddit_mc_scraper catches its own exception and
+        returns it as an is_valid=False RESULT, not a raise."""
+        for prefix in SCRAPER_ERROR_REASON_PREFIXES:
+            with self.subTest(prefix=prefix):
+                r = ValidationResult(
+                    is_valid=False,
+                    reason=f"{prefix} connection reset by peer",
+                    content_size_bytes_validated=100,
+                )
+                self.assertIsNone(self._run(self._scraper_returning(r)))
+
+    # --- genuine verdicts: must still be True/False ---
+
+    def test_real_content_mismatch_still_fails(self):
+        r = ValidationResult(
+            is_valid=False,
+            reason="Text does not match",
+            content_size_bytes_validated=100,
+        )
+        self.assertIs(self._run(self._scraper_returning(r)), False)
+
+    def test_removed_post_still_fails(self):
+        r = ValidationResult(
+            is_valid=False,
+            reason="URL not found or inaccessible.",
+            content_size_bytes_validated=100,
+        )
+        self.assertIs(self._run(self._scraper_returning(r)), False)
+
+    def test_valid_content_passes(self):
+        r = ValidationResult(
+            is_valid=True, reason="", content_size_bytes_validated=100
+        )
+        self.assertIs(self._run(self._scraper_returning(r)), True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -534,6 +534,19 @@ class MinerEvaluator:
             is_valid = await self.on_demand_validator._validate_entity(
                 ctx, entity, post_id, uid
             )
+            if is_valid is None:
+                # The validator's own scraping failed, so there is no verdict about
+                # this post. Skip neutrally rather than penalising the miner — same
+                # treatment as the validator-side network error handled below (#805).
+                # This matters disproportionately because Phase 3 samples exactly ONE
+                # entity, so a single transient scraper fault would otherwise condemn
+                # the whole job (od_boost x0.70 + od_cred -0.05) with no sampling to
+                # damp it.
+                bt.logging.warning(
+                    f"UID:{uid} - OD validate: SCRAPER ERROR (no verdict) for job "
+                    f"{job_id}, post {post_id} — skipping, not penalising"
+                )
+                return None, 0
             if not is_valid:
                 bt.logging.warning(
                     f"UID:{uid} - OD validate: SCRAPER FAILED for job {job_id}, "

--- a/vali_utils/on_demand/on_demand_validation.py
+++ b/vali_utils/on_demand/on_demand_validation.py
@@ -28,6 +28,16 @@ from vali_utils.metrics import ORGANIC_MINER_RESULTS
 SPEED_GRACE_S = 30.0
 SPEED_HALF_LIFE_S = 45.0
 SPEED_FLOOR = 0.3
+
+# Reasons a scraper emits when IT failed, as opposed to a verdict about the
+# miner's data. Scrapers return their own faults as is_valid=False *results*
+# rather than raising (e.g. scraping/reddit/reddit_mc_scraper.py builds
+# reason=f"Validation error: {e}" inside its except block), so without this
+# an Apify actor timeout is scored identically to fabricated content.
+SCRAPER_ERROR_REASON_PREFIXES = (
+    "Validation error:",
+    "UNFETCHABLE",
+)
 VOLUME_SHORTFALL_EXPONENT = 1.3
 VOLUME_OVER_LOG_COEF = 0.15
 VOLUME_OVER_BONUS_CAP = 0.25
@@ -200,7 +210,9 @@ class OnDemandValidator:
         entity: DataEntity,
         post_id: str,
         miner_uid: int,
-    ) -> bool:
+    ) -> Optional[bool]:
+        """True = valid, False = genuinely invalid, None = no evidence (see
+        _validate_with_scraper). None must not be scored as a miner failure."""
         try:
             # Phase 1: Request field validation
             if not self._validate_request_fields(ctx, entity, miner_uid):
@@ -229,10 +241,11 @@ class OnDemandValidator:
             )
 
         except Exception as e:
+            # Validator-side fault while validating — no evidence either way.
             bt.logging.error(
                 f"Miner {miner_uid}:{self.metagraph.hotkeys[miner_uid]} validation error for {post_id}: {str(e)}"
             )
-            return False
+            return None
 
     # ------------------------------------------------------------------
     # Request-field validation
@@ -425,12 +438,20 @@ class OnDemandValidator:
 
     async def _validate_with_scraper(
         self, ctx: ValidationContext, data_entity: DataEntity, post_id: str
-    ) -> bool:
+    ) -> Optional[bool]:
+        """Re-fetch the post and compare it with what the miner submitted.
+
+        Returns True (content matches), False (content genuinely does not match —
+        removed, edited, wrong fields), or **None meaning "no evidence"**: the
+        validator could not reach a verdict because its own scraping failed.
+        None must NOT be scored as a miner failure; see the caller.
+        """
         try:
             scraper = self._get_scraper(ctx.source)
             if not scraper:
+                # Validator-side configuration gap, not a statement about the data.
                 bt.logging.warning(f"No scraper available for {ctx.source}")
-                return False
+                return None
 
             if ctx.source.upper() == "X":
                 results = await scraper.validate(
@@ -444,18 +465,31 @@ class OnDemandValidator:
                 is_valid = (
                     result.is_valid if hasattr(result, "is_valid") else bool(result)
                 )
+                reason = getattr(result, "reason", "") or ""
                 if not is_valid:
+                    # Scrapers report their OWN failures as is_valid=False *results*
+                    # rather than raising, so an actor timeout or transport fault is
+                    # otherwise indistinguishable from "the miner sent bad data".
+                    # e.g. scraping/reddit/reddit_mc_scraper.py builds
+                    # reason=f"Validation error: {e}" inside its except block.
+                    if reason.startswith(SCRAPER_ERROR_REASON_PREFIXES):
+                        bt.logging.warning(
+                            f"Post {post_id}: scraper error, no verdict — {reason}"
+                        )
+                        return None
                     bt.logging.error(
-                        f"Post {post_id} failed scraper validation: {getattr(result, 'reason', 'Unknown')}"
+                        f"Post {post_id} failed scraper validation: {reason or 'Unknown'}"
                     )
                 return is_valid
             else:
+                # An empty result list is a failure to obtain evidence, not
+                # evidence of failure.
                 bt.logging.error(f"No scraper validation results for {post_id}")
-                return False
+                return None
 
         except Exception as e:
             bt.logging.error(f"Scraper validation error for {post_id}: {str(e)}")
-            return False
+            return None
 
     def _get_scraper(self, source: str):
         try:


### PR DESCRIPTION
Sibling of #849, which does the same thing for the S3 leg. This one covers on-demand.

## Problem

OD Phase 3 scores a failure of the **validator's own scraping** identically to a genuine content failure: `od_boost x0.70` and `od_cred -0.05`.

Scrapers report their own faults as `is_valid=False` **results** rather than raising, so the two are indistinguishable downstream. `scraping/reddit/reddit_mc_scraper.py` builds `ValidationResult(is_valid=False, reason=f"Validation error: {e}")` inside its `except` block when the Apify actor times out or the dataset read fails. `_validate_with_scraper` returned a bare `bool`, and `_validate_od_submission` mapped any falsy value to `return False` → penalty.

This is amplified because **Phase 3 samples exactly one entity** (`entity = random.choice(schema_sample)`), so a single transient scraper fault condemns the whole job with no sampling to damp it.

Reported on Discord with a reproduction: three Reddit posts a miner served were penalised as `SCRAPER FAILED`, yet re-running `macrocosmos/reddit-scraper` on the same `validate()` input (`{"url": ...}`) returned full content for all three, and all three posts were still live afterwards.

## Why this shape of fix

`_validate_od_submission` **already has the right concept twelve lines below** the site being changed — a validator-side `httpx` error while downloading the submission returns `None` and is skipped neutrally, commented *"neutral, not miner's fault (#805)"*. This applies that existing, accepted treatment to the re-fetch leg.

## Changes

- `_validate_with_scraper` → `Optional[bool]`. Returns `None` ("no evidence") when the scraper is missing, returns no results, raises, or returns a result whose `reason` marks a scraper-side error. `True`/`False` still mean a real verdict.
- `_validate_entity` → `Optional[bool]`, propagating `None`; its own `except` now returns `None`, since a fault *while validating* is not evidence about the data.
- `_validate_od_submission` skips neutrally on `None`, matching #805.

`_validate_entity` has exactly one caller, and the `_validate_with_scraper` in `s3_utils.py` is a different method on `DuckDBSampledValidator` — unaffected.

## Deliberately NOT changed

A real content verdict still fails. `"URL not found or inaccessible."` (the actor returning zero items) **remains a failure**: it is genuinely ambiguous between a deleted post and a fetch miss, and narrowing it would need a signal the scraper does not currently emit. I did not want to weaken a real check on a guess — happy to follow up if you'd prefer that path distinguished too.

## Tests

7 new in `tests/vali_utils/test_od_scraper_error_neutral.py`, pinning all three states — including that a genuine mismatch and a removed post **still fail**.

Full `tests/vali_utils` suite: **79 passed / 6 failed before** this change, **86 passed / 6 failed after** — the same 6 pre-existing failures on `dev`, 7 added.