### PR TITLE
fix(s3-validation): skip on transient failures instead of failing or scoring a partial view

### DIFF
--- a/tests/vali_utils/test_s3_transient_skip.py
+++ b/tests/vali_utils/test_s3_transient_skip.py
@@ -1,0 +1,449 @@
+"""S3 validation must SKIP on validator-side transient failures, never FAIL a
+miner and never score a PARTIAL view of its data.
+
+Two production incidents motivate these tests:
+
+  1. A 5xx from the presigned-URL auth API failed the whole validation run, so a
+     miner was penalised for our infrastructure being down.
+
+  2. A 5xx midway through paginating a miner's file listing silently returned the
+     pages fetched so far. A miner with 30k files listed as 7k, so its coverage
+     (and therefore its S3 score) collapsed toward zero.
+
+Both are now retried, and if they still cannot complete they raise
+S3ValidationSkip, which `_perform_s3_validation` converts into `None` — and
+`eval_miner` only scores S3 when the result is truthy, so the miner's S3 score
+and credibility are left exactly as they were.
+"""
+import asyncio
+import xml.etree.ElementTree as ET
+
+import pytest
+import requests as real_requests
+
+from vali_utils import s3_utils, validator_s3_access
+from vali_utils.miner_evaluator import MinerEvaluator
+from vali_utils.s3_utils import (
+    DuckDBSampledValidator,
+    S3ValidationSkip,
+    http_with_retry,
+)
+from vali_utils.validator_s3_access import ValidatorS3Access
+
+S3_NS = "http://s3.amazonaws.com/doc/2006-03-01/"
+
+
+# --------------------------------------------------------------------------- #
+# Doubles
+# --------------------------------------------------------------------------- #
+class _Resp:
+    """Minimal stand-in for requests.Response."""
+
+    def __init__(self, status_code=200, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+class _FakeRequests:
+    """Swaps out .post/.get while leaving the real exception classes reachable
+    (http_with_retry catches requests.Timeout / requests.ConnectionError)."""
+
+    def __init__(self, post=None, get=None):
+        self._post = post
+        self._get = get
+
+    def post(self, *args, **kwargs):
+        return self._post(*args, **kwargs)
+
+    def get(self, *args, **kwargs):
+        return self._get(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(real_requests, name)
+
+
+class _FakeSigner:
+    def headers(self, body):
+        return {}
+
+
+@pytest.fixture(autouse=True)
+def _no_backoff(monkeypatch):
+    """Retry tests should exercise the retry logic, not the sleep."""
+    monkeypatch.setattr(s3_utils, "_S3_RETRY_BACKOFF", 0)
+
+
+def _list_xml(keys, truncated=False, token=None, ns=S3_NS, hotkey="H"):
+    """Build a ListBucketResult page the way an S3-compatible backend does."""
+    xmlns = f' xmlns="{ns}"' if ns else ""
+    contents = "".join(
+        f"<Contents><Key>data/hotkey={hotkey}/job_id=j/{k}</Key>"
+        f"<Size>{100 + i}</Size>"
+        f"<LastModified>2026-07-0{(i % 9) + 1}T00:00:00.000Z</LastModified></Contents>"
+        for i, k in enumerate(keys)
+    )
+    trunc = "true" if truncated else "false"
+    next_tok = f"<NextContinuationToken>{token}</NextContinuationToken>" if token else ""
+    return (
+        f'<?xml version="1.0" encoding="UTF-8"?>'
+        f"<ListBucketResult{xmlns}>{contents}"
+        f"<IsTruncated>{trunc}</IsTruncated>{next_tok}</ListBucketResult>"
+    )
+
+
+def _reader(monkeypatch, pages):
+    """A ValidatorS3Access whose list pages come from `pages`.
+
+    Each entry is either a _Resp (the page body) or an Exception to raise. The
+    /get-miner-list call always succeeds; only page fetches vary.
+    """
+    reader = object.__new__(ValidatorS3Access)
+    reader.s3_auth_url = "https://auth.test"
+    reader._signer = _FakeSigner()
+
+    calls = {"list_url": 0, "page": 0}
+
+    def fake_post(url, **kwargs):
+        calls["list_url"] += 1
+        return _Resp(payload={"list_url": "https://r2.test/list?sig=x"})
+
+    def fake_get(url, **kwargs):
+        i = min(calls["page"], len(pages) - 1)
+        calls["page"] += 1
+        item = pages[i]
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    monkeypatch.setattr(
+        validator_s3_access, "requests", _FakeRequests(post=fake_post, get=fake_get)
+    )
+    return reader, calls
+
+
+# --------------------------------------------------------------------------- #
+# http_with_retry — the shared transient-failure policy
+# --------------------------------------------------------------------------- #
+def test_returns_immediately_when_the_first_attempt_succeeds():
+    calls = []
+
+    def send():
+        calls.append(1)
+        return _Resp(200, payload={"ok": True})
+
+    resp = asyncio.run(http_with_retry(send, what="probe"))
+
+    assert resp.json() == {"ok": True}
+    assert len(calls) == 1
+
+
+def test_recovers_from_a_transient_5xx():
+    responses = [_Resp(502), _Resp(503), _Resp(200, payload={"ok": True})]
+    calls = []
+
+    def send():
+        calls.append(1)
+        return responses[len(calls) - 1]
+
+    resp = asyncio.run(http_with_retry(send, what="probe"))
+
+    assert resp.status_code == 200
+    assert len(calls) == 3, "should have retried past both transient failures"
+
+
+def test_skips_rather_than_failing_when_5xx_persists():
+    calls = []
+
+    def send():
+        calls.append(1)
+        return _Resp(502)
+
+    with pytest.raises(S3ValidationSkip) as err:
+        asyncio.run(http_with_retry(send, what="get-file-presigned-urls"))
+
+    assert len(calls) == s3_utils._S3_RETRY_ATTEMPTS
+    assert "get-file-presigned-urls" in str(err.value)
+    assert "502" in str(err.value)
+
+
+def test_does_not_waste_retries_on_a_non_transient_status():
+    calls = []
+
+    def send():
+        calls.append(1)
+        return _Resp(403)
+
+    with pytest.raises(S3ValidationSkip):
+        asyncio.run(http_with_retry(send, what="probe"))
+
+    assert len(calls) == 1, "4xx cannot be fixed by retrying"
+
+
+def test_retries_network_errors_too():
+    calls = []
+
+    def send():
+        calls.append(1)
+        if len(calls) == 1:
+            raise real_requests.ConnectionError("connection reset")
+        return _Resp(200)
+
+    assert asyncio.run(http_with_retry(send, what="probe")).status_code == 200
+    assert len(calls) == 2
+
+
+# --------------------------------------------------------------------------- #
+# Incident 1 — presigned URLs for the sampled files
+# --------------------------------------------------------------------------- #
+def _validator():
+    v = object.__new__(DuckDBSampledValidator)
+    v.s3_auth_url = "https://auth.test"
+    v._signer = _FakeSigner()
+    return v
+
+
+def test_presigned_urls_survive_a_transient_api_failure(monkeypatch):
+    calls = []
+
+    def fake_post(url, **kwargs):
+        calls.append(1)
+        if len(calls) == 1:
+            return _Resp(502)
+        return _Resp(200, payload={"file_urls": {"a.parquet": "https://r2/a?sig=1"}})
+
+    monkeypatch.setattr(s3_utils, "requests", _FakeRequests(post=fake_post))
+
+    urls = asyncio.run(_validator()._get_presigned_urls_batch("H", ["a.parquet"]))
+
+    assert urls == {"a.parquet": "https://r2/a?sig=1"}
+
+
+def test_presigned_urls_skip_instead_of_validating_a_partial_sample(monkeypatch):
+    """A batch we cannot resolve must abort the run, not shrink the sample."""
+
+    def fake_post(url, **kwargs):
+        payload = {"file_urls": {"a.parquet": "https://r2/a?sig=1"}}
+        # First batch resolves, the second is permanently down.
+        return _Resp(200, payload=payload) if b'"a.parquet"' in kwargs["data"] else _Resp(502)
+
+    monkeypatch.setattr(s3_utils, "requests", _FakeRequests(post=fake_post))
+
+    with pytest.raises(S3ValidationSkip):
+        asyncio.run(
+            _validator()._get_presigned_urls_batch(
+                "H", ["a.parquet", "b.parquet"], batch_size=1
+            )
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Incident 2 — the file listing must be complete or not used at all
+# --------------------------------------------------------------------------- #
+def test_listing_paginates_to_completion(monkeypatch):
+    reader, _ = _reader(
+        monkeypatch,
+        [
+            _Resp(text=_list_xml(["p1a.parquet", "p1b.parquet"], truncated=True, token="t1")),
+            _Resp(text=_list_xml(["p2a.parquet"], truncated=False)),
+        ],
+    )
+
+    files = asyncio.run(reader.list_all_files_with_metadata("H"))
+
+    assert [f["key"].split("/")[-1] for f in files] == [
+        "p1a.parquet",
+        "p1b.parquet",
+        "p2a.parquet",
+    ]
+    assert files[0]["size"] == 100
+    assert files[0]["last_modified"] == "2026-07-01T00:00:00.000Z"
+
+
+def test_listing_retries_a_transient_page_and_still_returns_everything(monkeypatch):
+    reader, _ = _reader(
+        monkeypatch,
+        [
+            _Resp(text=_list_xml(["p1.parquet"], truncated=True, token="t1")),
+            _Resp(503),  # page 2 blips...
+            _Resp(text=_list_xml(["p2.parquet"], truncated=False)),  # ...then recovers
+        ],
+    )
+
+    files = asyncio.run(reader.list_all_files_with_metadata("H"))
+
+    assert len(files) == 2, "a recovered page must not truncate the listing"
+
+
+def test_listing_skips_instead_of_returning_the_pages_it_managed_to_fetch(monkeypatch):
+    """The 30k-files-listed-as-7k incident.
+
+    Returning the partial set understates the miner's coverage, which is scored
+    as if it were the whole truth. Aborting is the only safe outcome.
+    """
+    reader, _ = _reader(
+        monkeypatch,
+        [
+            _Resp(text=_list_xml(["p1.parquet"], truncated=True, token="t1")),
+            _Resp(500),  # page 2 never recovers
+        ],
+    )
+
+    with pytest.raises(S3ValidationSkip) as err:
+        asyncio.run(reader.list_all_files_with_metadata("H"))
+
+    assert "list page 2" in str(err.value)
+
+
+def test_listing_skips_when_the_page_body_is_not_xml(monkeypatch):
+    reader, _ = _reader(monkeypatch, [_Resp(text="502 Bad Gateway")])
+
+    with pytest.raises(S3ValidationSkip) as err:
+        asyncio.run(reader.list_all_files_with_metadata("H"))
+
+    assert "unparseable" in str(err.value)
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "<html>502 Bad Gateway</html>",
+        f'<Error xmlns="{S3_NS}"><Code>InternalError</Code></Error>',
+    ],
+    ids=["proxy-error-page", "s3-error-document"],
+)
+def test_listing_skips_when_the_page_is_well_formed_xml_but_not_a_listing(
+    monkeypatch, body
+):
+    """An error page parses as valid XML and simply has no <Contents>. Treating
+    that as an empty listing would fail the miner for a gateway hiccup."""
+    reader, _ = _reader(monkeypatch, [_Resp(text=body)])
+
+    with pytest.raises(S3ValidationSkip) as err:
+        asyncio.run(reader.list_all_files_with_metadata("H"))
+
+    assert "not a listing" in str(err.value)
+
+
+def test_listing_skips_when_the_list_url_cannot_be_obtained(monkeypatch):
+    reader = object.__new__(ValidatorS3Access)
+    reader.s3_auth_url = "https://auth.test"
+    reader._signer = _FakeSigner()
+
+    monkeypatch.setattr(
+        validator_s3_access,
+        "requests",
+        _FakeRequests(post=lambda url, **kw: _Resp(502)),
+    )
+
+    with pytest.raises(S3ValidationSkip) as err:
+        asyncio.run(reader.list_all_files_with_metadata("H"))
+
+    assert "get-miner-list" in str(err.value)
+
+
+def test_listing_skips_when_pagination_never_terminates(monkeypatch):
+    """Always-truncated pages mean we never saw the end of the listing."""
+    reader, calls = _reader(
+        monkeypatch, [_Resp(text=_list_xml(["p.parquet"], truncated=True, token="t"))]
+    )
+
+    with pytest.raises(S3ValidationSkip) as err:
+        asyncio.run(reader.list_all_files_with_metadata("H"))
+
+    assert "incomplete" in str(err.value)
+    assert calls["page"] == 200, "should stop at max_pages"
+
+
+def test_a_genuinely_empty_miner_is_not_a_skip(monkeypatch):
+    """An empty listing that COMPLETED is a real answer, and the caller is
+    entitled to fail the miner for it. Only incomplete listings skip."""
+    reader, _ = _reader(monkeypatch, [_Resp(text=_list_xml([], truncated=False))])
+
+    assert asyncio.run(reader.list_all_files_with_metadata("H")) == []
+
+
+@pytest.mark.parametrize(
+    "namespace",
+    [S3_NS, "", "http://doc.s3.cloudflare.com/2006-03-01/"],
+    ids=["aws-namespace", "no-namespace", "other-namespace"],
+)
+def test_listing_parses_the_xml_whatever_namespace_it_arrives_in(monkeypatch, namespace):
+    """Pinning the AWS namespace would match zero <Contents> if a backend ever
+    emitted a different one — the miner would look empty and be failed."""
+    reader, _ = _reader(
+        monkeypatch,
+        [_Resp(text=_list_xml(["a.parquet"], truncated=False, ns=namespace))],
+    )
+
+    files = asyncio.run(reader.list_all_files_with_metadata("H"))
+
+    assert len(files) == 1
+    assert files[0]["key"].endswith("a.parquet")
+    assert files[0]["size"] == 100
+
+
+# --------------------------------------------------------------------------- #
+# The skip has to survive all the way to the scorer
+# --------------------------------------------------------------------------- #
+def _evaluator(monkeypatch, validate):
+    """MinerEvaluator stub exposing just what _perform_s3_validation touches."""
+    ev = object.__new__(MinerEvaluator)
+    ev.uid = 89  # MACROCOSMOS_VALIDATOR_UID — runs validation locally
+    ev.wallet = object()
+    ev.s3_reader = object()
+    ev.s3_results_client = None
+
+    class _Cfg:
+        s3_auth_url = "https://auth.test"
+
+    ev.config = _Cfg()
+
+    stored = []
+
+    class _Storage:
+        def update_validation_info(self, *args):
+            stored.append(args)
+
+    ev.s3_storage = _Storage()
+
+    monkeypatch.setattr(s3_utils, "_S3_RETRY_BACKOFF", 0)
+    monkeypatch.setattr(
+        "vali_utils.miner_evaluator.validate_s3_miner_data", validate
+    )
+    monkeypatch.setattr(
+        "vali_utils.miner_evaluator.get_s3_validation_summary", lambda r: "summary"
+    )
+    return ev, stored
+
+
+def test_a_skip_leaves_the_miner_completely_unscored(monkeypatch):
+    async def validate(*args, **kwargs):
+        raise S3ValidationSkip("listing incomplete at page 8")
+
+    ev, stored = _evaluator(monkeypatch, validate)
+
+    result = asyncio.run(ev._perform_s3_validation(uid=7, hotkey="H", current_block=100))
+
+    # eval_miner guards on `if s3_validation_result:`, so None means the scorer
+    # is never told about S3 this round: no reward, no penalty, nothing decayed.
+    assert result is None
+    assert stored == [], "a skipped run must not advance validation bookkeeping"
+
+
+def test_a_real_validation_error_still_fails_the_miner(monkeypatch):
+    """Only transient/infrastructure faults skip. Everything else is unchanged."""
+
+    async def validate(*args, **kwargs):
+        raise ValueError("corrupt parquet footer")
+
+    ev, stored = _evaluator(monkeypatch, validate)
+
+    result = asyncio.run(ev._perform_s3_validation(uid=7, hotkey="H", current_block=100))
+
+    assert result is not None
+    assert result.is_valid is False
+    assert stored, "a real result still updates validation bookkeeping"

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -34,7 +34,7 @@ from vali_utils import metrics, utils as vali_utils
 
 from typing import Dict, List, Optional, Tuple
 from vali_utils.validator_s3_access import ValidatorS3Access
-from vali_utils.s3_utils import validate_s3_miner_data, get_s3_validation_summary, S3ValidationResult
+from vali_utils.s3_utils import validate_s3_miner_data, get_s3_validation_summary, S3ValidationResult, S3ValidationSkip
 from vali_utils.s3_logging_utils import log_s3_validation_table
 from vali_utils.s3_validation_results_client import (
     MACROCOSMOS_VALIDATOR_UID,
@@ -803,6 +803,14 @@ class MinerEvaluator:
 
             if not s3_validation_result.is_valid and s3_validation_result.validation_issues:
                 bt.logging.debug(f"{hotkey}: S3 validation issues: {', '.join(s3_validation_result.validation_issues[:3])}")
+
+        except S3ValidationSkip as e:
+            # Validator-side/infra transient failure (presigned-URL API 5xx after
+            # retries, or the file listing could not be paginated to completion).
+            # SKIP — return None so the caller leaves S3 score/credibility UNCHANGED
+            # (no reward, no penalty). The miner is not at fault for our infra.
+            bt.logging.warning(f"{hotkey}: S3 validation SKIPPED (transient/infra): {e} — no reward/penalty")
+            return None
 
         except Exception as e:
             bt.logging.error(f"{hotkey}: Error in S3 validation: {str(e)}")

--- a/vali_utils/s3_utils.py
+++ b/vali_utils/s3_utils.py
@@ -3,6 +3,7 @@ S3 validation utilities for enhanced miner data validation.
 Provides comprehensive validation of S3-stored miner data using metadata analysis.
 """
 
+import asyncio
 import hashlib
 import random
 import re
@@ -116,6 +117,61 @@ PREFERRED_SCRAPERS = {
     DataSource.X: ScraperId.X_APIDOJO,
     DataSource.REDDIT: ScraperId.REDDIT_MC,
 }
+
+
+class S3ValidationSkip(Exception):
+    """Raised when S3 validation cannot be COMPLETED due to a validator-side /
+    infrastructure transient failure — e.g. the presigned-URL auth API keeps
+    returning 5xx after retries, or the miner's file listing could not be
+    paginated to completion (a mid-listing 5xx would otherwise return a PARTIAL
+    file set and crater the miner's coverage/score).
+
+    The caller must treat this as SKIP — neither reward nor penalty, S3
+    credibility/score left unchanged — NOT as a validation FAILURE. It is our
+    infrastructure that failed, not the miner's data. (Same spirit as the OD
+    'validator-side download failure' skip, #805.)
+    """
+
+
+# Transient HTTP/network conditions worth retrying, then skipping (not failing).
+_S3_RETRY_STATUS = {429, 500, 502, 503, 504}
+_S3_RETRY_ATTEMPTS = 4          # 1 try + 3 retries
+_S3_RETRY_BACKOFF = 2.0         # seconds, exponential: 2, 4, 8
+
+
+async def http_with_retry(send, what: str) -> "requests.Response":
+    """Run a blocking request with retries, or raise S3ValidationSkip.
+
+    `send` is a zero-arg callable returning a requests.Response; it is executed
+    in the default executor so a slow endpoint never blocks the event loop.
+
+    Retries transient failures (5xx/429, timeouts, connection errors) with
+    exponential backoff. Anything that is still unresolved — including a
+    non-transient status, which retrying cannot fix — raises S3ValidationSkip:
+    we could not obtain the data, so the run must be SKIPPED rather than scored
+    against the miner.
+    """
+    loop = asyncio.get_running_loop()
+    last_err = None
+
+    for attempt in range(_S3_RETRY_ATTEMPTS):
+        try:
+            response = await loop.run_in_executor(None, send)
+            if response.status_code == 200:
+                return response
+            last_err = f"HTTP {response.status_code}"
+            if response.status_code not in _S3_RETRY_STATUS:
+                break  # non-transient (4xx): retrying cannot help
+        except (requests.Timeout, requests.ConnectionError) as e:
+            last_err = f"{type(e).__name__}: {e}"
+        except Exception as e:
+            last_err = scrub_log(str(e))
+
+        if attempt < _S3_RETRY_ATTEMPTS - 1:
+            await asyncio.sleep(_S3_RETRY_BACKOFF * (2 ** attempt))
+
+    raise S3ValidationSkip(f"{what} failed after {_S3_RETRY_ATTEMPTS} attempt(s): {last_err}")
+
 
 class DuckDBSampledValidator:
     """
@@ -425,7 +481,10 @@ class DuckDBSampledValidator:
             presigned_urls = await self._get_presigned_urls_batch(miner_hotkey, file_keys)
 
             if not presigned_urls:
-                return self._create_failed_result("Failed to get presigned URLs")
+                # Could not obtain ANY presigned URLs (transient exhaustion is
+                # already raised inside the batch helper; this covers the all-4xx
+                # / empty case) — can't validate, so SKIP rather than fail.
+                raise S3ValidationSkip("no presigned URLs obtained for sampled files")
 
             # Step 4: Lightweight DuckDB validation (sampled - memory safe)
             bt.logging.info(f"{miner_hotkey}: Running sampled DuckDB validation...")
@@ -577,6 +636,10 @@ class DuckDBSampledValidator:
                 job_coverage_rate=job_coverage_rate
             )
 
+        except S3ValidationSkip:
+            # Validator-side/infra transient failure — propagate so the caller
+            # SKIPS (neutral), instead of turning it into a FAILED result.
+            raise
         except Exception as e:
             bt.logging.error(scrub_log(f"{miner_hotkey}: DuckDB validation error: {str(e)}"))
             return self._create_failed_result(f"Validation error: {str(e)}")
@@ -594,41 +657,35 @@ class DuckDBSampledValidator:
         for i in range(0, len(file_keys), batch_size):
             batch = file_keys[i:i + batch_size]
 
-            try:
-                # TODO: decrease back to 1h once validation runtimes stabilise. Bumped to 3h
-                # because long validation passes (large miners + retries) were hitting 403s
-                # on presigned URLs minted at the start of the run.
-                payload = {
-                    "miner_hotkey": miner_hotkey,
-                    "file_keys": batch,
-                    "expiry_hours": 3
-                }
+            # TODO: decrease back to 1h once validation runtimes stabilise. Bumped to 3h
+            # because long validation passes (large miners + retries) were hitting 403s
+            # on presigned URLs minted at the start of the run.
+            payload = {
+                "miner_hotkey": miner_hotkey,
+                "file_keys": batch,
+                "expiry_hours": 3
+            }
+            body = json.dumps(payload).encode()
+            headers = self._signer.headers(body)
+            headers["Content-Type"] = "application/json"
 
-                body = json.dumps(payload).encode()
-                headers = self._signer.headers(body)
-                headers["Content-Type"] = "application/json"
-
-                response = requests.post(
+            # A batch we cannot resolve raises S3ValidationSkip: dropping it would
+            # leave us validating a PARTIAL sample, which understates the miner.
+            response = await http_with_retry(
+                lambda: requests.post(
                     f"{self.s3_auth_url}/get-file-presigned-urls",
                     data=body,
                     headers=headers,
-                    timeout=120
-                )
+                    timeout=120,
+                ),
+                what=f"get-file-presigned-urls ({len(batch)} keys)",
+            )
 
-                if response.status_code == 200:
-                    file_urls = response.json().get('file_urls', {})
-                    for key, data in file_urls.items():
-                        if isinstance(data, dict) and 'presigned_url' in data:
-                            all_urls[key] = data['presigned_url']
-                        elif isinstance(data, str):
-                            all_urls[key] = data
-                else:
-                    bt.logging.warning(
-                        f"get-file-presigned-urls failed: {response.status_code}"
-                    )
-
-            except Exception as e:
-                bt.logging.warning(scrub_log(f"Presigned URL batch error: {e}"))
+            for key, data in response.json().get('file_urls', {}).items():
+                if isinstance(data, dict) and 'presigned_url' in data:
+                    all_urls[key] = data['presigned_url']
+                elif isinstance(data, str):
+                    all_urls[key] = data
 
         return all_urls
 
@@ -2240,6 +2297,10 @@ async def validate_s3_miner_data(
         )
         return result
 
+    except S3ValidationSkip:
+        # Transient/infra skip — propagate to _perform_s3_validation, which
+        # returns None (no reward, no penalty).
+        raise
     except Exception as e:
         bt.logging.error(f"DuckDB validation failed for {miner_hotkey}: {str(e)}")
         return S3ValidationResult(

--- a/vali_utils/validator_s3_access.py
+++ b/vali_utils/validator_s3_access.py
@@ -4,9 +4,36 @@ import bittensor as bt
 from typing import Optional, Any, List
 import xml.etree.ElementTree as ET
 import urllib.parse
-import asyncio
 
 from common.api_client import TaoSigner
+
+
+# The listing XML is parsed WITHOUT pinning the S3 namespace URI.
+#
+# `http://s3.amazonaws.com/doc/2006-03-01/` is an XML namespace identifier, not an
+# endpoint, and S3-compatible backends (R2 included) emit it for compatibility —
+# so hardcoding it works today. It is still the wrong thing to depend on: if a
+# backend or proxy ever returns the listing under a different namespace, or with
+# none at all, a namespace-pinned lookup silently matches ZERO <Contents>. The XML
+# still parses, so the listing looks like a completed "miner has no files" result
+# and the miner is FAILED for an infrastructure quirk. Matching on the local tag
+# name removes that failure mode entirely.
+def _local_name(tag: str) -> str:
+    """'{http://...}Contents' -> 'Contents' (unqualified tags pass through)."""
+    return tag.rsplit("}", 1)[-1]
+
+
+def _findall(parent, name: str) -> List[Any]:
+    """Every descendant with this local tag name, in any (or no) namespace."""
+    return [el for el in parent.iter() if _local_name(el.tag) == name]
+
+
+def _find(parent, name: str, recursive: bool = False):
+    """First direct child (or descendant, if recursive) with this local name."""
+    for el in (parent.iter() if recursive else parent):
+        if _local_name(el.tag) == name:
+            return el
+    return None
 
 
 class ValidatorS3Access:
@@ -19,40 +46,36 @@ class ValidatorS3Access:
 
     async def _request_presigned_list_url(
         self, miner_hotkey: str, continuation_token: Optional[str] = None
-    ) -> Optional[str]:
-        """Request presigned list URL from /get-miner-list using Tao v2 auth."""
-        try:
-            payload = {"miner_hotkey": miner_hotkey}
-            if continuation_token:
-                payload["continuation_token"] = continuation_token
+    ) -> str:
+        """Request a presigned list URL from /get-miner-list using Tao v2 auth.
 
-            body = json.dumps(payload).encode()
-            headers = self._signer.headers(body)
-            headers["Content-Type"] = "application/json"
+        Retries transient failures; raises S3ValidationSkip if the URL cannot be
+        obtained, because without it the listing would be incomplete.
+        """
+        from vali_utils.s3_utils import S3ValidationSkip, http_with_retry
 
-            loop = asyncio.get_event_loop()
-            response = await loop.run_in_executor(
-                None,
-                lambda: requests.post(
-                    f"{self.s3_auth_url.rstrip('/')}/get-miner-list",
-                    data=body,
-                    headers=headers,
-                    timeout=30,
-                ),
-            )
+        payload = {"miner_hotkey": miner_hotkey}
+        if continuation_token:
+            payload["continuation_token"] = continuation_token
 
-            if response.status_code != 200:
-                bt.logging.warning(
-                    f"get-miner-list failed: {response.status_code}"
-                )
-                return None
+        body = json.dumps(payload).encode()
+        headers = self._signer.headers(body)
+        headers["Content-Type"] = "application/json"
 
-            data = response.json()
-            return data.get("list_url", "")
+        response = await http_with_retry(
+            lambda: requests.post(
+                f"{self.s3_auth_url.rstrip('/')}/get-miner-list",
+                data=body,
+                headers=headers,
+                timeout=30,
+            ),
+            what="get-miner-list",
+        )
 
-        except Exception as e:
-            bt.logging.error(f"get-miner-list exception: {e}")
-            return None
+        list_url = response.json().get("list_url", "")
+        if not list_url:
+            raise S3ValidationSkip("get-miner-list returned no list_url")
+        return list_url
 
     async def list_all_files_with_metadata(
         self, miner_hotkey: str
@@ -63,6 +86,10 @@ class ValidatorS3Access:
 
         Returns list of dicts: {'key': str, 'size': int, 'last_modified': str}
         """
+        # Lazy import (keeps this leaf module free of the heavy s3_utils import
+        # chain at load time and avoids any import cycle).
+        from vali_utils.s3_utils import S3ValidationSkip, http_with_retry
+
         try:
             target_prefix = f"data/hotkey={miner_hotkey}/"
 
@@ -70,34 +97,40 @@ class ValidatorS3Access:
             continuation_token = None
             page = 1
             max_pages = 200
-
-            loop = asyncio.get_event_loop()
+            completed = False
 
             while page <= max_pages:
+                # Each step retries internally and raises S3ValidationSkip when it
+                # cannot succeed, so a mid-listing failure aborts the whole listing
+                # instead of returning a PARTIAL file set (which would understate
+                # coverage and crater the miner's S3 score).
                 presigned_url = await self._request_presigned_list_url(
                     miner_hotkey, continuation_token
                 )
-                if not presigned_url:
-                    break
-
-                response = await loop.run_in_executor(
-                    None, lambda: requests.get(presigned_url, timeout=60)
+                response = await http_with_retry(
+                    lambda u=presigned_url: requests.get(u, timeout=60),
+                    what=f"s3 list page {page}",
                 )
-                if response.status_code != 200:
-                    break
-
                 try:
                     root = ET.fromstring(response.text)
-                except Exception:
-                    break
+                except ET.ParseError as e:
+                    raise S3ValidationSkip(f"s3 list page {page} returned unparseable XML: {e}")
 
-                namespaces = {"s3": "http://s3.amazonaws.com/doc/2006-03-01/"}
+                # An error page ("<html>502 Bad Gateway</html>") or an S3 <Error>
+                # document parses as perfectly good XML — it just contains no
+                # <Contents>. Without this check the page reads as a completed,
+                # empty listing and the miner is failed for having "no files".
+                if _local_name(root.tag) != "ListBucketResult":
+                    raise S3ValidationSkip(
+                        f"s3 list page {page} is not a listing "
+                        f"(root element <{_local_name(root.tag)}>)"
+                    )
 
                 page_files = 0
-                for content in root.findall(".//s3:Contents", namespaces):
-                    key_elem = content.find("s3:Key", namespaces)
-                    size_elem = content.find("s3:Size", namespaces)
-                    modified_elem = content.find("s3:LastModified", namespaces)
+                for content in _findall(root, "Contents"):
+                    key_elem = _find(content, "Key")
+                    size_elem = _find(content, "Size")
+                    modified_elem = _find(content, "LastModified")
 
                     if key_elem is not None and key_elem.text:
                         decoded_key = urllib.parse.unquote(key_elem.text)
@@ -122,22 +155,38 @@ class ValidatorS3Access:
                     f"S3 list page {page}: {page_files} files (total: {len(all_files)}) for {miner_hotkey}"
                 )
 
-                is_trunc = root.find(".//s3:IsTruncated", namespaces)
+                is_trunc = _find(root, "IsTruncated", recursive=True)
                 if is_trunc is None or str(is_trunc.text).lower() != "true":
+                    completed = True  # reached the genuine end of the listing
                     break
 
-                token_elem = root.find(".//s3:NextContinuationToken", namespaces)
+                token_elem = _find(root, "NextContinuationToken", recursive=True)
                 if token_elem is None or not token_elem.text:
+                    completed = True
                     break
 
                 continuation_token = token_elem.text
                 page += 1
+
+            if not completed:
+                # Ran off max_pages while still truncated → incomplete listing.
+                raise S3ValidationSkip(
+                    f"file listing exceeded {max_pages} pages for {miner_hotkey} — incomplete"
+                )
 
             bt.logging.info(
                 f"S3 listing complete: {len(all_files)} files across {page} pages for {miner_hotkey}"
             )
             return all_files
 
+        except S3ValidationSkip:
+            # Incomplete listing (transient/infra) — propagate so the caller SKIPS
+            # (neutral). NEVER fall through to returning a partial or empty set,
+            # which would be scored as authoritative.
+            raise
         except Exception as e:
+            # Any other unexpected listing failure is also validator-side; treat it
+            # as a skip rather than returning [] (which the caller reads as
+            # "No files found" → a FAIL that drops the miner's score).
             bt.logging.error(f"Exception in list_all_files_with_metadata: {str(e)}")
-            return []
+            raise S3ValidationSkip(f"file listing failed for {miner_hotkey}: {e}")


### PR DESCRIPTION
## Problem

S3 validation turns validator-side infrastructure faults into miner penalties. There are two independent paths, and both are silent — the miner sees a score drop with no signal that anything on our side went wrong.

### 1. A 5xx from the presigned-URL API fails the whole run

`DuckDBSampledValidator._get_presigned_urls_batch` had no retry. A non-200 from `/get-file-presigned-urls` was logged and the batch was dropped:

```python
else:
    bt.logging.warning(f"get-file-presigned-urls failed: {response.status_code}")
except Exception as e:
    bt.logging.warning(scrub_log(f"Presigned URL batch error: {e}"))
```

If no batch resolved, the caller returned a **failed result**:

```python
if not presigned_urls:
    return self._create_failed_result("Failed to get presigned URLs")
```

That is a validation FAILURE — `validation_passed=False` reaches `update_s3_effective_size`, and the miner takes the S3 credibility hit. Nothing about it reflects the miner's data. A brief 502 on our auth service penalises every miner evaluated during the window.

### 2. A 5xx midway through pagination silently truncates the file listing

`ValidatorS3Access.list_all_files_with_metadata` paginates with `break`-on-error:

```python
if not presigned_url:
    break
response = await loop.run_in_executor(None, lambda: requests.get(presigned_url, timeout=60))
if response.status_code != 200:
    break
try:
    root = ET.fromstring(response.text)
except Exception:
    break
...
return all_files          # returns whatever was collected, as if complete
```

The partial list is returned **indistinguishably from a complete one**. The caller then computes `total_size_bytes`, `job_coverage_rate` and `effective_size_bytes` from it and scores them as authoritative.

Concretely: a miner with 30k files whose listing fails after 7k is validated as a miner with 7k files. Coverage is computed against jobs it appears not to have uploaded, and its S3 score collapses from a healthy value toward zero — for one page fetch that 5xx'd. The outer handler is no better: it returns `[]`, which the caller reads as `"No files found"` — also a FAIL.

**A short file list is not a smaller answer. It is a wrong one, and it is scored as if it were true.**

## Changes

### Retry, then skip — never fail, never partial

A shared `http_with_retry(send, what)` in `s3_utils.py` retries transient conditions (5xx/429, timeouts, connection errors) with exponential backoff, and raises the new `S3ValidationSkip` when the call still cannot complete. Non-transient statuses (4xx) fail fast rather than burning the backoff budget — retrying cannot fix them — but they still skip, because we still could not obtain the data.

Both call sites use it:

- **Presigned URLs** — an unresolvable batch raises rather than shrinking the sample. Validating on a partial sample understates the miner just as a partial listing does.
- **File listing** — `_request_presigned_list_url` and each page fetch retry internally and raise on exhaustion, so a mid-listing failure aborts the listing rather than returning what it managed to collect. Exceeding `max_pages` while still `IsTruncated` is also a skip: we never saw the end.

### The skip reaches the scorer as a no-op

`S3ValidationSkip` propagates through `validate_s3_miner_data` and is caught in `MinerEvaluator._perform_s3_validation`, which returns `None`. `eval_miner` already guards on `if s3_validation_result:` before calling `update_s3_effective_size`, so the miner's S3 score and credibility are left exactly as they were: **no reward, no penalty**.

The early return also happens before `s3_storage.update_validation_info()` and before UID 89 publishes to `s3_validation_results_client`, so a skipped run neither advances validation bookkeeping nor publishes a result other validators would consume.

This mirrors the existing treatment of validator-side OD download failures (#805, and the same reasoning as #844 and #849).

### Two related hardenings

Both are the same bug class — an infrastructure quirk read as a miner failure — and both were reachable on the path being fixed:

- **The listing XML is no longer parsed against a pinned namespace URI.** `http://s3.amazonaws.com/doc/2006-03-01/` is an XML namespace identifier rather than an endpoint, and S3-compatible backends emit it for compatibility, so pinning it works today. It is still the wrong thing to depend on: a backend or proxy emitting a different namespace (or none) makes a namespace-pinned lookup match **zero** `<Contents>`. The XML parses, so the page reads as a completed, empty listing and the miner is failed for having no files. Matching on local tag names removes the failure mode.

- **A well-formed XML body that is not a listing is now a skip.** `<html>502 Bad Gateway</html>` and an S3 `<Error>` document both parse cleanly and simply contain no `<Contents>` — previously indistinguishable from an empty listing, and scored as one. The root element is now checked.

### Incidental

`http_with_retry` runs these `requests` calls in the default executor. They were blocking the event loop — up to 120s for the presigned-URL call.

## Non-goals

Genuine validation failures are untouched. Only transient/infrastructure faults skip; a corrupt parquet, a scraper mismatch, or a listing that legitimately completes with zero files all behave exactly as before.

## Testing

New: `tests/vali_utils/test_s3_transient_skip.py` — 21 cases.

```
pytest tests/vali_utils/test_s3_transient_skip.py -q
```

Covers:

| Area | Cases |
| --- | --- |
| Retry policy | first-attempt success; recovery after 502/503; skip after exhausting attempts; 4xx fails fast without burning retries; connection errors retried |
| Presigned URLs | recovery from a transient failure; skip instead of validating a partial sample |
| Listing | multi-page listing completes; a transient page failure recovers and still returns the complete set; **skip instead of returning the pages it managed to fetch**; unparseable body; list-URL unobtainable; pagination that never terminates; a genuinely empty miner is *not* a skip |
| Hardening | listing parses under the AWS namespace, no namespace, and a foreign namespace; proxy error pages and S3 `<Error>` documents skip |
| Scoring | a skip returns `None` and leaves validation bookkeeping untouched; a real error still fails the miner |

One of these cases caught a live bug during development: `<html>502 Bad Gateway</html>` parses as valid XML, so the initial version of this fix would still have failed the miner for "no files". That is what the root-element check is for.

Regression check against `dev` — no tests newly broken:

```
pytest tests/vali_utils -q
  dev:        79 passed, 6 failed
  this branch: 100 passed, 6 failed      (+21 new; identical 6 pre-existing failures)
```

The 6 pre-existing failures (`test_eval_batch_concurrency`, `test_od_flow`, `test_vali_utils`) reproduce unmodified on `dev` and are unrelated to this change.

## Target branch

`dev`, per CONTRIBUTING.md.