### PR TITLE
fix(od): keep failed uploads neutral without coverage credit

### DIFF
--- a/tests/vali_utils/test_od_coverage_shadow.py
+++ b/tests/vali_utils/test_od_coverage_shadow.py
@@ -251,8 +251,8 @@ class TestCoverageRatioMult(_EvaluateOdTestBase):
         ev = self._run_eval(jobs, _stats(reddit=(110, 100), x=(60, 4)))
         self.assertAlmostEqual(self._mult(ev), MinerScorer.OD_ABSTAIN_MULT, places=4)
 
-    def test_empty_submissions_dodge_abstention_but_not_ratio(self):
-        """0-byte submissions count against abstention but earn no coverage."""
+    def test_empty_submissions_count_as_abstention(self):
+        """0-byte submission records are equivalent to unanswered jobs."""
         from rewards.miner_scorer import MinerScorer
 
         now = dt.datetime.now(dt.timezone.utc)
@@ -261,18 +261,22 @@ class TestCoverageRatioMult(_EvaluateOdTestBase):
             for _ in range(30)
         ] + [_job("x", now - dt.timedelta(hours=1))]
         ev = self._run_eval(jobs, _stats(reddit=(110, 100), x=(60, 4)))
-        # No abstention (they did submit), but ratio coverage is 0 -> floor.
+        # Reddit abstention applies; the uploaded X submission avoids X abstention.
         self.assertAlmostEqual(self._mult(ev), MinerScorer.OD_ABSTAIN_MULT, places=4)
 
-    def test_full_page_of_old_jobs_still_resolves_in_miners_favor(self):
-        """The failsafe keys off the RAW page length, not the window-filtered count."""
+    def test_full_page_of_old_jobs_does_not_bypass_coverage(self):
+        """Only in-window uploaded bodies can trigger the truncation failsafe."""
+        from rewards.miner_scorer import MinerScorer
+
         now = dt.datetime.now(dt.timezone.utc)
         jobs = [
             _job("reddit", now - dt.timedelta(hours=8))
             for _ in range(MinerEvaluator.OD_JOBS_FETCH_LIMIT)
         ]
         ev = self._run_eval(jobs, _stats(reddit=(9000, 8500), x=(60, 4)))
-        ev.scorer.set_od_coverage_mult.assert_called_once_with(1, 1.0)
+        ev.scorer.set_od_coverage_mult.assert_called_once_with(
+            1, MinerScorer.OD_ABSTAIN_MULT ** 2
+        )
 
     def test_zero_doable_platform_is_ignored(self):
         """A platform with zero doable jobs neither penalizes nor divides by zero."""

--- a/tests/vali_utils/test_od_not_uploaded_neutral.py
+++ b/tests/vali_utils/test_od_not_uploaded_neutral.py
@@ -106,6 +106,23 @@ class TestNotUploadedIsNeutral(unittest.TestCase):
 
         ev.scorer.set_od_coverage_mult.assert_called_once_with(1, 0.3)
 
+    def test_full_page_of_zero_byte_submissions_does_not_bypass_coverage(self):
+        """Zero-byte spam cannot trigger the full-page truncation safeguard."""
+        now = dt.datetime.now(dt.timezone.utc)
+        jobs = [
+            _job("x", now - dt.timedelta(hours=1), 0)
+            for _ in range(MinerEvaluator.OD_JOBS_FETCH_LIMIT)
+        ]
+        stats = OnDemandJobsStatsResponse(
+            platforms={
+                "x": PlatformJobStats(total_jobs=100, doable_jobs=100),
+            }
+        )
+
+        ev = self._run(jobs, stats=stats)
+
+        ev.scorer.set_od_coverage_mult.assert_called_once_with(1, 0.3)
+
     def test_uploaded_submissions_still_scored(self):
         """A body that DID land is still validated and rewarded — no regression."""
         now = dt.datetime.now(dt.timezone.utc)

--- a/tests/vali_utils/test_od_not_uploaded_neutral.py
+++ b/tests/vali_utils/test_od_not_uploaded_neutral.py
@@ -53,7 +53,7 @@ def _stats() -> OnDemandJobsStatsResponse:
 
 
 class TestNotUploadedIsNeutral(unittest.TestCase):
-    def _run(self, jobs):
+    def _run(self, jobs, stats=None):
         ev = _stub_evaluator()
         ev.scorer = MagicMock()
         resp = MagicMock()
@@ -63,7 +63,7 @@ class TestNotUploadedIsNeutral(unittest.TestCase):
         client.__aenter__ = AsyncMock(return_value=client)
         client.__aexit__ = AsyncMock(return_value=False)
         ev._on_demand_client = MagicMock(return_value=client)
-        ev._get_od_jobs_stats = AsyncMock(return_value=_stats())
+        ev._get_od_jobs_stats = AsyncMock(return_value=stats or _stats())
         ev._log_od_coverage_shadow = MagicMock()
         ev._validate_od_submission = AsyncMock(return_value=(True, 10))
         ev.on_demand_validator.calculate_ondemand_reward_multipliers = MagicMock(
@@ -91,6 +91,20 @@ class TestNotUploadedIsNeutral(unittest.TestCase):
 
         ev.scorer.apply_ondemand_penalty.assert_not_called()
         ev.scorer.apply_ondemand_reward.assert_not_called()
+
+    def test_zero_byte_submission_does_not_avoid_abstention(self):
+        """A submission record without a body is not coverage participation."""
+        now = dt.datetime.now(dt.timezone.utc)
+        jobs = [_job("x", now - dt.timedelta(hours=1), 0)]
+        stats = OnDemandJobsStatsResponse(
+            platforms={
+                "x": PlatformJobStats(total_jobs=4, doable_jobs=4),
+            }
+        )
+
+        ev = self._run(jobs, stats=stats)
+
+        ev.scorer.set_od_coverage_mult.assert_called_once_with(1, 0.3)
 
     def test_uploaded_submissions_still_scored(self):
         """A body that DID land is still validated and rewarded — no regression."""

--- a/tests/vali_utils/test_od_not_uploaded_neutral.py
+++ b/tests/vali_utils/test_od_not_uploaded_neutral.py
@@ -1,0 +1,121 @@
+"""A submission whose body never reached S3 must not be penalized.
+
+`s3_content_length == 0` is unreachable from a completed upload — the smallest
+well-formed payload a miner can PUT is `{"data_entities": []}` (21 bytes). Zero
+therefore means the submit leg created the record but the upload leg failed, which
+is infrastructure, not the miner's answer.
+
+The penalty is multiplicative and compounds (`od_boost *= 0.7` per occurrence), so
+one API incident is geometric in the number of jobs in flight.
+"""
+
+import asyncio
+import datetime as dt
+import threading
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from common.api_client import (
+    MinerJobForValidation,
+    OnDemandJob,
+    OnDemandJobSubmission,
+    OnDemandJobsStatsResponse,
+    PlatformJobStats,
+)
+from vali_utils.miner_evaluator import MinerEvaluator
+
+
+def _stub_evaluator():
+    ev = MinerEvaluator.__new__(MinerEvaluator)
+    ev._od_stats_cache = None
+    ev._od_stats_lock = threading.Lock()
+    ev._last_od_eval_at = {}
+    ev.on_demand_validator = MagicMock()
+    return ev
+
+
+def _job(platform: str, expire_at: dt.datetime, content_length: int) -> MinerJobForValidation:
+    return MinerJobForValidation(
+        job=OnDemandJob(
+            id="j", expire_at=expire_at, job={"platform": platform, "keywords": ["k"]}
+        ),
+        submission=OnDemandJobSubmission(job_id="j", s3_content_length=content_length),
+    )
+
+
+def _stats() -> OnDemandJobsStatsResponse:
+    return OnDemandJobsStatsResponse(
+        platforms={
+            "reddit": PlatformJobStats(total_jobs=90, doable_jobs=85),
+            "x": PlatformJobStats(total_jobs=60, doable_jobs=4),
+        }
+    )
+
+
+class TestNotUploadedIsNeutral(unittest.TestCase):
+    def _run(self, jobs):
+        ev = _stub_evaluator()
+        ev.scorer = MagicMock()
+        resp = MagicMock()
+        resp.jobs = jobs
+        client = MagicMock()
+        client.validator_list_miner_jobs = AsyncMock(return_value=resp)
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+        ev._on_demand_client = MagicMock(return_value=client)
+        ev._get_od_jobs_stats = AsyncMock(return_value=_stats())
+        ev._log_od_coverage_shadow = MagicMock()
+        ev._validate_od_submission = AsyncMock(return_value=(True, 10))
+        ev.on_demand_validator.calculate_ondemand_reward_multipliers = MagicMock(
+            return_value=(1.0, 1.0)
+        )
+        asyncio.run(ev._evaluate_od(1, "hk"))
+        return ev
+
+    def test_zero_byte_submissions_are_not_penalized(self):
+        """The regression: 9 failed uploads must not fire 9 penalties."""
+        now = dt.datetime.now(dt.timezone.utc)
+        jobs = [_job("reddit", now - dt.timedelta(hours=1), 0) for _ in range(9)]
+        jobs += [_job("x", now - dt.timedelta(hours=1), 500)]
+
+        ev = self._run(jobs)
+
+        ev.scorer.apply_ondemand_penalty.assert_not_called()
+
+    def test_all_uploads_failed_is_a_no_op(self):
+        """Nothing landed: no reward, no penalty — same as never answering."""
+        now = dt.datetime.now(dt.timezone.utc)
+        jobs = [_job("reddit", now - dt.timedelta(hours=1), 0) for _ in range(5)]
+
+        ev = self._run(jobs)
+
+        ev.scorer.apply_ondemand_penalty.assert_not_called()
+        ev.scorer.apply_ondemand_reward.assert_not_called()
+
+    def test_uploaded_submissions_still_scored(self):
+        """A body that DID land is still validated and rewarded — no regression."""
+        now = dt.datetime.now(dt.timezone.utc)
+        jobs = [_job("reddit", now - dt.timedelta(hours=1), 500) for _ in range(3)]
+        jobs += [_job("x", now - dt.timedelta(hours=1), 500)]
+
+        ev = self._run(jobs)
+
+        self.assertTrue(ev._validate_od_submission.await_count >= 1)
+        ev.scorer.apply_ondemand_penalty.assert_not_called()
+
+    def test_deliberate_empty_answer_still_reaches_validation(self):
+        """21-byte `{"data_entities": []}` is a real answer, not a failed upload.
+
+        It must land in the validated path, where check_data_exists() decides —
+        not be silently reclassified as an infrastructure failure.
+        """
+        now = dt.datetime.now(dt.timezone.utc)
+        jobs = [_job("reddit", now - dt.timedelta(hours=1), 21) for _ in range(2)]
+
+        ev = self._run(jobs)
+
+        self.assertTrue(ev._validate_od_submission.await_count >= 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -356,22 +356,42 @@ class MinerEvaluator:
         if not jobs:
             return
 
-        # Single-pass partition into empty vs non-empty submissions
-        empty, non_empty = [], []
+        # Single-pass partition into non-empty vs never-uploaded submissions.
+        #
+        # `s3_content_length == 0` is not reachable from any completed upload: the
+        # smallest well-formed payload a miner can PUT is `{"data_entities": []}`
+        # (21 bytes). Zero therefore means the submission record was created by
+        # POST /on-demand/miner/jobs/submit but the body never landed in S3 — the
+        # upload leg failed. That is our infrastructure, not the miner's answer.
+        #
+        # A miner that deliberately answers "nothing here" uploads those 21 bytes,
+        # lands in `non_empty`, and is judged on the merits by
+        # _validate_od_submission (which already forgives an empty answer when
+        # check_data_exists() confirms there was nothing to return). Penalising the
+        # zero-byte case here inverted that: the miner who could not control the
+        # outcome was charged, while the deliberate empty answer was forgiven.
+        #
+        # The penalty also compounds — apply_ondemand_penalty multiplies od_boost by
+        # (1 - ondemand_alpha) = 0.7 per occurrence — so a single API incident is
+        # geometric in the number of jobs in flight. Observed on mainnet 2026-07-26:
+        # nine failed uploads inside one eval window took a miner's od_boost from
+        # 83.4M to 1.19M (0.7^9 = 0.040) and its emission from 0.145 to 0.0025.
+        #
+        # Treat a never-uploaded submission the same way an unanswered job is
+        # treated: no reward, no penalty. Consistent with #844 (OD download
+        # failures) and #849 (S3 scraper failures).
+        not_uploaded, non_empty = [], []
         for j in jobs:
             if (j.submission.s3_content_length or 0) > 0:
                 non_empty.append(j)
             else:
-                empty.append(j)
-
-        for j in empty:
-            self.scorer.apply_ondemand_penalty(uid=uid, mult_factor=1.0)
+                not_uploaded.append(j)
 
         if not non_empty:
-            if empty:
+            if not_uploaded:
                 bt.logging.info(
-                    f"UID:{uid} - HOTKEY:{hotkey}: OD — {len(empty)} empty submissions penalized, "
-                    f"0 non-empty"
+                    f"UID:{uid} - HOTKEY:{hotkey}: OD — {len(not_uploaded)} submission(s) "
+                    f"with no uploaded body (upload leg failed; not penalized), 0 non-empty"
                 )
             return
 
@@ -447,7 +467,8 @@ class MinerEvaluator:
         bt.logging.info(
             f"UID:{uid} - HOTKEY:{hotkey}: OD summary — "
             f"{len(non_empty)} non-empty (validated: {validated_pass} pass, {validated_fail} fail, "
-            f"{not_sampled_count} credibility-bumped), {len(empty)} empty penalized"
+            f"{not_sampled_count} credibility-bumped), "
+            f"{len(not_uploaded)} not uploaded (skipped, not penalized)"
         )
 
     async def _validate_od_submission(

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -220,20 +220,21 @@ class MinerEvaluator:
         """Per-platform submission counts for the coverage window.
 
         Shared numerator for the coverage log and the scoring block.
-        'nonempty' counts submissions whose bytes landed in S3.
+        Only submissions whose bodies landed in S3 count as participation.
         """
         counts: Dict[str, Dict[str, int]] = {}
         for j in all_jobs:
             exp = j.job.expire_at
             if exp is not None and exp < coverage_since:
                 continue
+            length = j.submission.s3_content_length or 0
+            if length <= 0:
+                continue
             platform = j.job.job.platform
             c = counts.setdefault(platform, {"any": 0, "nonempty": 0, "bytes": 0})
-            length = j.submission.s3_content_length or 0
             c["any"] += 1
-            if length > 0:
-                c["nonempty"] += 1
-                c["bytes"] += length
+            c["nonempty"] += 1
+            c["bytes"] += length
         return counts
 
     def _log_od_coverage_shadow(
@@ -316,8 +317,9 @@ class MinerEvaluator:
 
         # Coverage multiplier: abstention (zero submissions) and low coverage
         # of doable jobs both scale od_component down. Any submission counts
-        # against abstention; only submissions with bytes in S3 count toward
-        # the ratio. Runs BEFORE the empty-jobs early return. A full fetch
+        # against abstention only after their bodies land in S3; zero-byte
+        # submission records are equivalent to unanswered jobs. Runs BEFORE
+        # the empty-jobs early return. A full fetch
         # page may truncate the numerator — resolved in the miner's favor.
         if stats is not None and len(resp.jobs) >= self.OD_JOBS_FETCH_LIMIT:
             self.scorer.set_od_coverage_mult(uid, 1.0)

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -319,12 +319,13 @@ class MinerEvaluator:
         # of doable jobs both scale od_component down. Any submission counts
         # against abstention only after their bodies land in S3; zero-byte
         # submission records are equivalent to unanswered jobs. Runs BEFORE
-        # the empty-jobs early return. A full fetch
-        # page may truncate the numerator — resolved in the miner's favor.
-        if stats is not None and len(resp.jobs) >= self.OD_JOBS_FETCH_LIMIT:
+        # the empty-jobs early return. A full page of uploaded bodies may
+        # truncate the numerator — resolved in the miner's favor.
+        counts = self._od_submission_counts(resp.jobs, coverage_since)
+        nonempty_total = sum(c["nonempty"] for c in counts.values())
+        if stats is not None and nonempty_total >= self.OD_JOBS_FETCH_LIMIT:
             self.scorer.set_od_coverage_mult(uid, 1.0)
         elif stats is not None:
-            counts = self._od_submission_counts(resp.jobs, coverage_since)
             mult = 1.0
             for platform, pstats in stats.platforms.items():
                 c = counts.get(platform, {"any": 0, "nonempty": 0})


### PR DESCRIPTION
## Summary

Supersedes #891 with the complete coverage follow-up included.

- treats zero-byte OnDemand submission records as upload failures: no reward and no direct penalty
- excludes zero-byte records from the coverage participation numerator
- makes the full-page truncation safeguard depend on in-window non-empty uploads, so zero-byte or old-record spam cannot force coverage to 1.0
- preserves normal validation for uploaded bodies, including deliberate empty answers
- adds regression tests for the 3-19 doable-jobs abstention window and the 1,000-record truncation safeguard

## Why

A zero-byte record means no body landed in S3, so there is no miner data to judge. It must be scoring-neutral, but it must also behave like an unanswered job for coverage. Counting the record as participation allowed a miner to avoid the 0.3 abstention target on thin but judgeable platforms. Counting raw response rows in the truncation safeguard also allowed 1,000 zero-byte records to force coverage to 1.0.

## Tests

venv/bin/pytest -q tests/vali_utils/test_od_not_uploaded_neutral.py tests/vali_utils/test_od_coverage_shadow.py tests/vali_utils/test_od_reward_multipliers.py

40 passed.