### PR TITLE
feat(s3): validate X tweet IDs against Snowflake-encoded timestamps

### DIFF
--- a/tests/vali_utils/test_s3_x_snowflake.py
+++ b/tests/vali_utils/test_s3_x_snowflake.py
@@ -1,0 +1,47 @@
+import datetime as dt
+
+import pandas as pd
+
+from vali_utils.s3_utils import _is_x_snowflake_timestamp_consistent
+
+
+def test_modern_x_snowflake_matches_claimed_minute():
+    assert _is_x_snowflake_timestamp_consistent(
+        "1748585332935622672",
+        dt.datetime(2024, 1, 20, 5, 56, tzinfo=dt.timezone.utc),
+    )
+
+
+def test_synthetic_x_id_does_not_match_modern_timestamp():
+    assert not _is_x_snowflake_timestamp_consistent(
+        "1090517116589",
+        dt.datetime(2026, 4, 10, 12, 15, tzinfo=dt.timezone.utc),
+    )
+
+
+def test_non_numeric_x_id_is_invalid_for_modern_timestamp():
+    assert not _is_x_snowflake_timestamp_consistent(
+        "not-a-tweet-id",
+        dt.datetime(2026, 4, 10, 12, 15, tzinfo=dt.timezone.utc),
+    )
+
+
+def test_pre_snowflake_tweet_is_not_rejected():
+    assert _is_x_snowflake_timestamp_consistent(
+        "12345",
+        dt.datetime(2009, 4, 10, 12, 15, tzinfo=dt.timezone.utc),
+    )
+
+
+def test_nat_datetime_is_rejected_not_raised():
+    assert not _is_x_snowflake_timestamp_consistent("1748585332935622672", pd.NaT)
+
+
+def test_none_datetime_is_rejected():
+    assert not _is_x_snowflake_timestamp_consistent("1748585332935622672", None)
+
+
+def test_null_tweet_id_with_modern_timestamp_is_rejected():
+    ts = dt.datetime(2026, 4, 10, 12, 15, tzinfo=dt.timezone.utc)
+    assert not _is_x_snowflake_timestamp_consistent(None, ts)
+    assert not _is_x_snowflake_timestamp_consistent(float("nan"), ts)

--- a/vali_utils/s3_utils.py
+++ b/vali_utils/s3_utils.py
@@ -71,6 +71,46 @@ def _weighted_sample_without_replacement(items, weights, k):
     return [it for _, it in keys[:k]]
 
 
+_X_SNOWFLAKE_EPOCH_MS = 1_288_834_974_657
+_X_SNOWFLAKE_CUTOFF = pd.Timestamp(
+    _X_SNOWFLAKE_EPOCH_MS, unit="ms", tz="UTC"
+)
+_X_SNOWFLAKE_TIMESTAMP_TOLERANCE_MS = 60_000
+
+
+def _is_x_snowflake_timestamp_consistent(tweet_id: object, timestamp: object) -> bool:
+    """Return whether a modern X ID encodes the claimed creation minute."""
+    try:
+        claimed = pd.Timestamp(timestamp)
+        if claimed.tzinfo is None:
+            claimed = claimed.tz_localize("UTC")
+        else:
+            claimed = claimed.tz_convert("UTC")
+    except (TypeError, ValueError):
+        return False
+    # NaT survives Timestamp() construction; without this guard it falls through
+    # to .timestamp() and raises, which the caller's broad except turns into a
+    # silent file skip — one null datetime per file would evade the check.
+    if pd.isna(claimed):
+        return False
+
+    # X/Twitter used sequential IDs before Snowflake. Do not apply the modern
+    # invariant to historical rows from before the migration.
+    if claimed < _X_SNOWFLAKE_CUTOFF:
+        return True
+
+    try:
+        numeric_id = int(str(tweet_id))
+    except (TypeError, ValueError):
+        return False
+    if numeric_id <= 0:
+        return False
+
+    encoded_ms = (numeric_id >> 22) + _X_SNOWFLAKE_EPOCH_MS
+    claimed_ms = claimed.timestamp() * 1000
+    return abs(encoded_ms - claimed_ms) <= _X_SNOWFLAKE_TIMESTAMP_TOLERANCE_MS
+
+
 @dataclass
 class S3ValidationResult:
     """S3 validation result structure"""
@@ -1205,7 +1245,10 @@ class DuckDBSampledValidator:
 
                 # --- PyArrow row-group read for empty/missing content check ---
                 if platform in ['x', 'twitter']:
-                    read_cols = ['url', 'text', 'view_count', 'tweet_id', 'username']
+                    read_cols = [
+                        'url', 'text', 'view_count', 'tweet_id', 'username',
+                        'datetime',
+                    ]
                 else:
                     read_cols = ['url', 'body', 'title', 'id']
                 read_cols = [c for c in read_cols if c in available_columns]
@@ -1292,6 +1335,39 @@ class DuckDBSampledValidator:
                             ids = rg_df['tweet_id'].dropna().astype(str)
                             total_content_id_rows += len(ids)
                             unique_content_ids.update(ids.tolist())
+
+                            # Modern X IDs are Snowflakes whose high bits encode
+                            # creation time. This catches synthetic IDs locally,
+                            # before fake rows can be hidden behind scraper-valid
+                            # ballast from another platform.
+                            if 'datetime' in rg_df.columns:
+                                check_df = rg_df[['tweet_id', 'datetime']]
+                                snowflake_mismatches = sum(
+                                    not _is_x_snowflake_timestamp_consistent(
+                                        r['tweet_id'], r['datetime']
+                                    )
+                                    for _, r in check_df.iterrows()
+                                )
+                                if snowflake_mismatches > 0:
+                                    mismatch_rate = (
+                                        snowflake_mismatches / len(check_df) * 100
+                                    )
+                                    bt.logging.warning(
+                                        f"X Snowflake timestamp mismatch: "
+                                        f"{snowflake_mismatches}/{len(check_df)} "
+                                        f"sampled rows ({mismatch_rate:.1f}%)"
+                                    )
+                                    return {
+                                        "success": False,
+                                        "duplicate_rate_within_job": 100.0,
+                                        "empty_rate": 100.0,
+                                        "total_rows": 0,
+                                        "reason": (
+                                            "X tweet ID timestamp mismatch in "
+                                            f"{snowflake_mismatches} sampled rows "
+                                            f"({mismatch_rate:.1f}%)"
+                                        ),
+                                    }
 
                             # URL↔tweet_id consistency: status ID in URL must match tweet_id
                             if 'url' in rg_df.columns:


### PR DESCRIPTION
## What

Adds a local structural check to S3 validation for X data: modern X post IDs are Snowflakes whose high 41 bits encode the creation time in milliseconds since the Twitter epoch (`1288834974657`). Every sampled X row's `tweet_id` is decoded (`id >> 22`) and compared against the claimed `datetime`.

- **60s tolerance** to accommodate minute-level timestamp obfuscation (truncation drift is at most 59.999s).
- **Pre-Snowflake exemption**: rows claiming timestamps before the Nov 2010 Snowflake migration are not subject to the check (X used sequential IDs then).
- **Immediate hard fail**: any inconsistent sampled row fails S3 validation for the miner — a Snowflake mismatch is provable fabrication, not noise.
- **Poison-row hardening**: null/NaT `datetime` and unparseable/null `tweet_id` are treated as inconsistent rather than raising. Without this, one null-datetime row per file would throw inside the check, get swallowed by the caller's broad `except Exception`, and silently skip the file (and all downstream checks) without penalty.

## Why

The current fabrication wave uses synthetic tweet IDs that don't encode plausible timestamps. Scraper validation only samples 20 entities per cycle; this check runs locally on every sampled row group at negligible cost, before scraper checks, so fake X rows can't hide behind scraper-valid ballast from another platform.

This is a **cheap first-line structural filter, not the durable fix** — an attacker can generate timestamp-consistent Snowflake IDs. The durable fix (quality-adjusted volume scoring, cap-before-credibility, rolling pass-rate) is tracked separately.

## Testing

- `tests/vali_utils/test_s3_x_snowflake.py`: 7 tests — real ID vs its encoded minute, synthetic ID rejection, non-numeric/null/NaN IDs, NaT/None datetime, pre-Snowflake exemption. All pass.
- Verified against a real miner parquet (`tweet_id` string-typed, 10k rows): genuine rows pass; the observed fabricated dataset is rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)