### PR TITLE
fix(s3): drop hard-invalid quarantine, let credibility do the work

### DIFF
--- a/rewards/miner_scorer.py
+++ b/rewards/miner_scorer.py
@@ -376,7 +376,6 @@ class MinerScorer:
         effective_size: float,
         validation_passed: bool,
         pass_rate: Optional[float] = None,
-        hard_invalid: bool = False,
     ) -> None:
         """
         Update miner's effective_size for S3 competition scoring.
@@ -389,7 +388,7 @@ class MinerScorer:
 
         This rewards miners who have MORE data than others (squared advantage).
 
-        FORGIVING APPROACH (like P2P credibility), with two exceptions:
+        FORGIVING APPROACH (like P2P credibility):
         - On success: update effective_size; credibility EMAs toward the OBSERVED
           scraper pass rate, not 1.0 — 16/20 and 20/20 no longer pay the same.
           If claimed size grew, credibility is first scaled by
@@ -397,10 +396,10 @@ class MinerScorer:
           on_miner_evaluated) so new volume earns nothing until it survives
           validation.
         - On failure: KEEP previous effective_size, decrease credibility via EMA.
-        - On hard_invalid (provable fabrication — Snowflake/URL-ID/row-count/
-          compression): QUARANTINE — effective_size is zeroed, not retained.
-          Retention is forgiveness for unproven failures; it must not apply to
-          proven fraud.
+          Every detection type routes here, including structural ones: those
+          depend on the validator reading the miner's parquet successfully, so a
+          flaky read must not cost a miner its volume outright. Repeated
+          detections drive credibility down geometrically instead.
 
         Args:
             uid: Miner UID
@@ -408,23 +407,13 @@ class MinerScorer:
             validation_passed: Whether the miner passed quality validation
             pass_rate: Observed scraper pass fraction (0..1), or None if no
                 entities were scraper-validated this cycle
-            hard_invalid: Whether the failure included provable fabrication
         """
         with self.lock:
             old_effective = float(self.effective_sizes[uid])
             old_cred = float(self.s3_credibility[uid])
 
             # Update S3 credibility based on validation result
-            if hard_invalid:
-                # Provable fabrication: quarantine the volume, don't retain it.
-                self.effective_sizes[uid] = 0.0
-                self.s3_credibility[uid] = (1 - self.s3_cred_alpha) * self.s3_credibility[uid]
-                bt.logging.info(
-                    f"S3 hard-invalid for miner {uid}: quarantining "
-                    f"effective_size={old_effective/(1024*1024):.1f}MB -> 0, "
-                    f"credibility {old_cred:.4f} -> {float(self.s3_credibility[uid]):.4f}"
-                )
-            elif validation_passed:
+            if validation_passed:
                 # "Prove new volume": growth in claimed size scales credibility
                 # down so the boost is unchanged until the new volume also
                 # passes validation (mirrors the P2P rule in on_miner_evaluated).

--- a/tests/rewards/test_s3_quality_scoring.py
+++ b/tests/rewards/test_s3_quality_scoring.py
@@ -68,14 +68,20 @@ class TestS3QualityScoring(unittest.TestCase):
             places=5,
         )
 
-    def test_hard_invalid_quarantines_effective_size(self):
-        """Provable fabrication must not enjoy the forgiving retention rule."""
+    def test_repeated_failures_decay_credibility_geometrically(self):
+        """Structural detections route through the forgiving path — a flaky
+        validator-side read must not cost a miner its volume outright — so
+        credibility, not quarantine, does the work over repeated cycles."""
         uid = 0
         self.scorer.update_s3_effective_size(uid, 1000.0, True, pass_rate=1.0)
+        cred = float(self.scorer.s3_credibility[uid])
+        for _ in range(5):
+            self.scorer.update_s3_effective_size(uid, 0.0, False, pass_rate=0.0)
+        expected = cred * (1 - self.scorer.s3_cred_alpha) ** 5
+        self.assertAlmostEqual(float(self.scorer.s3_credibility[uid]), expected, places=5)
+        # Volume is retained; the multiplier is what collapses.
         self.assertEqual(float(self.scorer.effective_sizes[uid]), 1000.0)
-        self.scorer.update_s3_effective_size(uid, 0.0, False, pass_rate=0.0, hard_invalid=True)
-        self.assertEqual(float(self.scorer.effective_sizes[uid]), 0.0)
-        self.assertEqual(float(self.scorer.s3_boosts[uid]), 0.0)
+        self.assertLess(expected ** MinerScorer._CREDIBILITY_EXP, 0.03)
 
     def test_prove_new_volume_scales_credibility(self):
         """Doubling claimed size must scale cred by 0.5^(1/2.5) before the EMA,

--- a/tests/vali_utils/test_index_fail_freeze.py
+++ b/tests/vali_utils/test_index_fail_freeze.py
@@ -62,7 +62,7 @@ class TestEvalMinerS3BeforeIndex(unittest.TestCase):
         ev._perform_s3_validation.assert_awaited_once()
         ev.scorer.update_s3_effective_size.assert_called_once_with(
             uid=0, effective_size=123_456, validation_passed=False,
-            pass_rate=None, hard_invalid=False,
+            pass_rate=None,
         )
         # The no-index path still reports the failed validation to the scorer.
         ev.scorer.on_miner_evaluated.assert_called_once()

--- a/vali_utils/miner_evaluator.py
+++ b/vali_utils/miner_evaluator.py
@@ -660,7 +660,6 @@ class MinerEvaluator:
                 effective_size=s3_validation_result.effective_size_bytes,
                 validation_passed=s3_validation_result.is_valid,
                 pass_rate=s3_validation_result.pass_rate,
-                hard_invalid=s3_validation_result.hard_invalid,
             )
 
         # Query the miner for the latest index.

--- a/vali_utils/s3_utils.py
+++ b/vali_utils/s3_utils.py
@@ -204,9 +204,9 @@ class S3ValidationResult:
     effective_size_bytes: float = 0.0
     job_coverage_rate: float = 0.0
 
-    # Provable fabrication detected by structural checks (row-count lie,
-    # uncompressed padding, Snowflake mismatch, URL↔tweet_id mismatch).
-    # The scorer quarantines effective_size instead of retaining it.
+    # Structural detection (row-count mismatch, uncompressed file, Snowflake
+    # mismatch, URL↔tweet_id mismatch). Telemetry only — scoring treats it as
+    # a normal failure; see update_s3_effective_size.
     hard_invalid: bool = False
 
     # Observed scraper pass fraction (0..1); None when no entities were
@@ -664,11 +664,10 @@ class DuckDBSampledValidator:
 
             is_valid = len(issues) == 0
 
-            # Provable fabrication (structural evidence), as opposed to
-            # unverifiable content ("URL not found" may be honest deletion).
-            # The scorer quarantines effective_size on hard_invalid instead of
-            # retaining the previous value. Snowflake / URL↔tweet_id detections
-            # set the structured flag at their point of detection.
+            # Structural detection, as opposed to unverifiable content
+            # ("URL not found" may be honest deletion). Telemetry only —
+            # scoring treats it as a normal failure. Snowflake / URL↔tweet_id
+            # checks set the structured flag at their point of detection.
             hard_invalid = (
                 row_count_mismatches > 0
                 or compression_failures > 0


### PR DESCRIPTION
Follow-up to #901.

## Problem

#901 added a quarantine path: on `hard_invalid` (row-count mismatch, uncompressed file, Snowflake timestamp mismatch, URL↔tweet_id mismatch) the miner's `effective_size` was zeroed instead of retained.

Every one of those signals is derived from the validator reading the miner's parquet — footer metadata at `s3_utils.py:1200-1242` and row-group reads for the X checks. A flaky or partial read on **our** side therefore produces a false "proven fabrication" and instantly wipes a miner's entire volume for something they don't control. Too blunt a penalty for a detection path we can't guarantee.

## Change

All failures now route through the existing forgiving path: `effective_size` is retained, credibility decays via EMA. Repeated detections still collapse the reward, just geometrically instead of instantly:

$$c_n = c_0 (1 - \alpha)^n \quad\Rightarrow\quad c_5 \approx 0.17 c_0, \qquad c_5^{2.5} \approx 0.01285097

Five caught cycles leave ~1% of the capped S3 component, while a single false positive self-heals on the next clean pass.

- `hard_invalid` parameter removed from `update_s3_effective_size` and its call site (it no longer changes behavior).
- The flag stays on `S3ValidationResult` and in the published score blob as **telemetry** — how often structural detections fire is one of the signals that would justify per-stratum scoring later.

## Testing

`test_hard_invalid_quarantines_effective_size` replaced by `test_repeated_failures_decay_credibility_geometrically`, which pins the decay curve and asserts volume retention. 40 tests pass across the scorer, sampling, state-migration, and results-client suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)