### PR TITLE
Fix/s3 cred and scraper sampling

### DIFF
--- a/rewards/miner_scorer.py
+++ b/rewards/miner_scorer.py
@@ -389,12 +389,28 @@ class MinerScorer:
         This rewards miners who have MORE data than others (squared advantage).
 
         FORGIVING APPROACH (like P2P credibility):
-        - On success: update effective_size; credibility EMAs toward the OBSERVED
-          scraper pass rate, not 1.0 — 16/20 and 20/20 no longer pay the same.
-          If claimed size grew, credibility is first scaled by
-          (old/new)^(1/_CREDIBILITY_EXP) (same "prove it" rule as P2P in
-          on_miner_evaluated) so new volume earns nothing until it survives
-          validation.
+        - On success: update effective_size and EMA credibility toward 1.0.
+          Passing IS the quality signal. validate_miner_s3_data only reports
+          is_valid=True when every gate held — combined scraper success >=
+          MIN_SCRAPER_SUCCESS, the same bar again per platform, job-content
+          match, dedup, and the structural checks. Grading the EMA target by
+          the observed pass rate on top of that gate charged a passing miner
+          twice for the same sample: 20 scraper lookups carry enough natural
+          noise (deleted posts, rate-limited or flaky third-party calls) that
+          19/20 is a normal honest cycle, yet it pushed credibility DOWN toward
+          0.95 and kept it there. The bar decides pass/fail; credibility tracks
+          how consistently the miner clears it.
+        - Claimed-size growth does NOT scale credibility down. The S3 boost is
+          already capped at 2x the OD component before credibility is applied
+          (see _s3_component), so extra volume cannot inflate the reward it
+          feeds. Taxing the multiplier for growth on top of that cap meant a
+          miner doing exactly what the subnet asks — crawling the desirability
+          list and uploading every cycle — lost S3 score for each upload while
+          the capped boost stayed flat: strictly negative return on new data,
+          before anything is known about whether it is real. The
+          (old/new)^(1/_CREDIBILITY_EXP) "prove it" rule stays where it belongs,
+          on P2P in on_miner_evaluated, where the score is NOT capped and grows
+          directly with claimed bytes.
         - On failure: KEEP previous effective_size, decrease credibility via EMA.
           Every detection type routes here, including structural ones: those
           depend on the validator reading the miner's parquet successfully, so a
@@ -406,7 +422,9 @@ class MinerScorer:
             effective_size: total_size_bytes × coverage² (calculated from current validation)
             validation_passed: Whether the miner passed quality validation
             pass_rate: Observed scraper pass fraction (0..1), or None if no
-                entities were scraper-validated this cycle
+                entities were scraper-validated this cycle. Telemetry only —
+                it is published to follower validators and logged, but it does
+                not move credibility; MIN_SCRAPER_SUCCESS already gates on it.
         """
         with self.lock:
             old_effective = float(self.effective_sizes[uid])
@@ -414,20 +432,12 @@ class MinerScorer:
 
             # Update S3 credibility based on validation result
             if validation_passed:
-                # "Prove new volume": growth in claimed size scales credibility
-                # down so the boost is unchanged until the new volume also
-                # passes validation (mirrors the P2P rule in on_miner_evaluated).
-                if old_effective > 0 and effective_size > old_effective:
-                    self.s3_credibility[uid] *= (old_effective / effective_size) ** (
-                        1 / MinerScorer._CREDIBILITY_EXP
-                    )
-                # Success: Update effective_size and move credibility toward the
-                # observed pass rate (1.0 when nothing was scraper-checked).
+                # Success: Update effective_size and increase credibility
+                # EMA toward 1.0: new_cred = alpha * 1.0 + (1-alpha) * old_cred
                 self.effective_sizes[uid] = effective_size
-                target = 1.0 if pass_rate is None else max(0.0, min(1.0, pass_rate))
                 self.s3_credibility[uid] = min(
                     1.0,
-                    self.s3_cred_alpha * target + (1 - self.s3_cred_alpha) * float(self.s3_credibility[uid]),
+                    self.s3_cred_alpha + (1 - self.s3_cred_alpha) * float(self.s3_credibility[uid]),
                 )
             else:
                 # Failure: KEEP previous effective_size, reduce credibility via EMA
@@ -452,7 +462,8 @@ class MinerScorer:
                 f"effective_size={new_effective/(1024*1024):.1f}MB (was {old_effective/(1024*1024):.1f}MB), "
                 f"s3_boost={float(self.s3_boosts[uid]):.0f}, "
                 f"s3_cred={new_cred:.4f} (was {old_cred:.4f}), "
-                f"passed={validation_passed}"
+                f"passed={validation_passed}, "
+                f"scraper_pass_rate={'n/a' if pass_rate is None else f'{pass_rate:.2f}'}"
             )
 
     def _recalculate_s3_boosts_internal(self) -> None:

--- a/tests/rewards/test_s3_quality_scoring.py
+++ b/tests/rewards/test_s3_quality_scoring.py
@@ -38,15 +38,32 @@ class TestS3QualityScoring(unittest.TestCase):
         scores = self.scorer.get_scores_for_weights()
         self.assertEqual(float(scores[uid]), 0.0)
 
-    def test_pass_ema_targets_observed_rate(self):
-        """16/20 must not pay like 20/20: credibility converges to 0.8, not 1.0."""
+    def test_pass_ema_targets_one_whatever_the_pass_rate(self):
+        """Passing is the signal; the observed rate must not grade it again.
+
+        MIN_SCRAPER_SUCCESS already refuses anything under 80% (per platform and
+        combined), so a reported pass means the sample cleared the bar. Grading
+        the EMA target by the rate on top of that made an honest 19/20 cycle —
+        one deleted post, one rate-limited lookup — pull credibility DOWN.
+        """
         uid = 0
         for _ in range(50):
             self.scorer.update_s3_effective_size(
-                uid, effective_size=1000.0, validation_passed=True, pass_rate=0.8
+                uid, effective_size=1000.0, validation_passed=True, pass_rate=0.95
             )
-        cred = float(self.scorer.s3_credibility[uid])
-        self.assertAlmostEqual(cred, 0.8, delta=0.001)
+        self.assertAlmostEqual(float(self.scorer.s3_credibility[uid]), 1.0, delta=0.001)
+
+    def test_pass_rate_is_telemetry_only(self):
+        """Two miners that both PASS end at the same credibility."""
+        graded, ungraded = 0, 1
+        for _ in range(10):
+            self.scorer.update_s3_effective_size(graded, 1000.0, True, pass_rate=0.8)
+            self.scorer.update_s3_effective_size(ungraded, 1000.0, True, pass_rate=1.0)
+        self.assertAlmostEqual(
+            float(self.scorer.s3_credibility[graded]),
+            float(self.scorer.s3_credibility[ungraded]),
+            places=6,
+        )
 
     def test_pass_without_scraper_sample_targets_one(self):
         uid = 0
@@ -83,21 +100,54 @@ class TestS3QualityScoring(unittest.TestCase):
         self.assertEqual(float(self.scorer.effective_sizes[uid]), 1000.0)
         self.assertLess(expected ** MinerScorer._CREDIBILITY_EXP, 0.03)
 
-    def test_prove_new_volume_scales_credibility(self):
-        """Doubling claimed size must scale cred by 0.5^(1/2.5) before the EMA,
-        so new volume earns nothing until it survives validation."""
+    def test_growth_does_not_scale_credibility(self):
+        """Doubling claimed size on a PASS must not tax the multiplier.
+
+        The S3 boost is capped at 2x OD before credibility (_s3_component), so
+        the extra volume cannot inflate the reward it feeds — scaling cred down
+        for it was a pure loss on new data.
+        """
         uid = 0
         self.scorer.update_s3_effective_size(uid, 1000.0, True, pass_rate=1.0)
         cred_before = float(self.scorer.s3_credibility[uid])
         alpha = self.scorer.s3_cred_alpha
 
         self.scorer.update_s3_effective_size(uid, 2000.0, True, pass_rate=1.0)
-        scaled = cred_before * (0.5 ** (1 / MinerScorer._CREDIBILITY_EXP))
-        expected = min(1.0, alpha * 1.0 + (1 - alpha) * scaled)
+        expected = min(1.0, alpha + (1 - alpha) * cred_before)
         self.assertAlmostEqual(float(self.scorer.s3_credibility[uid]), expected, places=5)
         self.assertEqual(float(self.scorer.effective_sizes[uid]), 2000.0)
 
-    def test_same_size_pass_has_no_prove_it_penalty(self):
+    def test_growth_and_flat_volume_reach_the_same_credibility(self):
+        grower, flat = 0, 1
+        size = 1000.0
+        for _ in range(20):
+            size *= 1.2  # keeps crawling and uploading, as the subnet asks
+            self.scorer.update_s3_effective_size(grower, size, True, pass_rate=1.0)
+            self.scorer.update_s3_effective_size(flat, 1000.0, True, pass_rate=1.0)
+        self.assertAlmostEqual(
+            float(self.scorer.s3_credibility[grower]),
+            float(self.scorer.s3_credibility[flat]),
+            places=6,
+        )
+        self.assertAlmostEqual(float(self.scorer.s3_credibility[grower]), 1.0, delta=0.01)
+
+    def test_capped_s3_component_never_grows_with_volume(self):
+        """The cap is why growth needs no credibility tax: past 2x OD, more
+        effective_size buys nothing, so it cannot be gamed for reward."""
+        uid = 0
+        self.scorer.ondemand_boosts[uid] = 100_000_000.0
+        self.scorer.ondemand_credibility[uid] = 1.0
+        self.scorer.s3_credibility[uid] = 1.0
+
+        self.scorer.update_s3_effective_size(uid, 1e12, True, pass_rate=1.0)
+        small = float(self.scorer.get_scores_for_weights()[uid])
+        self.scorer.update_s3_effective_size(uid, 1e15, True, pass_rate=1.0)
+        huge = float(self.scorer.get_scores_for_weights()[uid])
+
+        self.assertAlmostEqual(small, huge, delta=small * 1e-6)
+        self.assertAlmostEqual(huge, 3 * 100_000_000.0, delta=1.0)  # OD + 2xOD
+
+    def test_repeated_pass_climbs_toward_one(self):
         uid = 0
         self.scorer.update_s3_effective_size(uid, 1000.0, True, pass_rate=1.0)
         cred_before = float(self.scorer.s3_credibility[uid])
@@ -105,6 +155,7 @@ class TestS3QualityScoring(unittest.TestCase):
         self.scorer.update_s3_effective_size(uid, 1000.0, True, pass_rate=1.0)
         expected = min(1.0, alpha + (1 - alpha) * cred_before)
         self.assertAlmostEqual(float(self.scorer.s3_credibility[uid]), expected, places=5)
+        self.assertGreater(expected, cred_before)
 
 
 class TestPerPlatformBar(unittest.TestCase):

--- a/tests/vali_utils/test_committed_sampling.py
+++ b/tests/vali_utils/test_committed_sampling.py
@@ -107,6 +107,50 @@ class TestSeededRowGroupRead(unittest.TestCase):
         self.assertEqual(out1['url'].tolist(), out2['url'].tolist())
         self.assertNotEqual(out1['url'].tolist(), out3['url'].tolist())
 
+    def test_duplicate_url_padding_cannot_make_a_file_unsampleable(self):
+        """A row group with fewer unique URLs than max_rows must return the
+        unique rows — not raise into the broad except and skip the file.
+
+        The old n=min(max_rows, len(pre-dedup)) made sample() raise here, so a
+        miner could pad one row group with duplicate URLs (group-level dup
+        share of a big file stays under the 1% within-job gate) and that file
+        silently escaped job-content matching and scraper validation."""
+        df = pd.DataFrame({
+            'url': [f'https://x.com/u/status/{i % 3}' for i in range(200)],
+            'text': [f'tweet {i}' for i in range(200)],
+        })
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'padded.parquet')
+            df.to_parquet(path, row_group_size=200)
+            out = read_random_row_group(path, 0, max_rows=5, rng=random.Random(1))
+        self.assertIsNotNone(out, "duplicate-URL padding silently skipped the file")
+        self.assertEqual(len(out), 3)
+        self.assertEqual(out['url'].nunique(), 3)
+
+    def test_short_row_group_is_still_deduped(self):
+        """A group with <= max_rows rows used to skip dedup entirely, letting
+        copies of one real row fill the caller's whole per-file quota."""
+        df = pd.DataFrame({
+            'url': ['https://x.com/u/status/1'] * 4,
+            'text': ['tweet'] * 4,
+        })
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'short.parquet')
+            df.to_parquet(path, row_group_size=10)
+            out = read_random_row_group(path, 0, max_rows=5, rng=random.Random(1))
+        self.assertIsNotNone(out)
+        self.assertEqual(len(out), 1)
+
+    def test_frames_without_url_column_keep_plain_sampling(self):
+        df = pd.DataFrame({'text': [f'tweet {i}' for i in range(50)]})
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'nourl.parquet')
+            df.to_parquet(path, row_group_size=50)
+            out = read_random_row_group(path, 0, columns=['text'],
+                                        max_rows=5, rng=random.Random(1))
+        self.assertIsNotNone(out)
+        self.assertEqual(len(out), 5)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/vali_utils/test_scraper_entity_sampling.py
+++ b/tests/vali_utils/test_scraper_entity_sampling.py
@@ -1,0 +1,254 @@
+"""Tests for the entity draw in DuckDBSampledValidator._perform_scraper_validation.
+
+The draw must not be steerable by the row counts a miner declares. Before the
+uniform-file / fixed-quota rule, the phase ordered files by claimed rows and gave
+each file a row-proportional budget (up to 20 rows), so a miner could shrink its X
+jobs until Reddit held nearly all claimed rows: two huge Reddit files then filled
+the whole 40-row pool and all 20 scraper-validated entities were Reddit. The X leg
+went unchecked, and the per-platform bar was vacuous because no X entity ever
+entered the pool.
+
+These tests run against real parquet files on disk (registered in the validator's
+local-file cache, exactly as the download phase does) with only the scraper call
+itself mocked.
+"""
+
+import asyncio
+import datetime as dt
+import os
+import random
+import tempfile
+import unittest
+from unittest.mock import AsyncMock, patch
+
+import pandas as pd
+
+from scraping.scraper import ValidationResult
+from vali_utils.s3_utils import DuckDBSampledValidator
+
+
+def _reddit_frame(n: int, tag: str) -> pd.DataFrame:
+    now = dt.datetime(2026, 8, 1, tzinfo=dt.timezone.utc)
+    return pd.DataFrame({
+        'datetime': [now] * n,
+        'label': ['r/test'] * n,
+        'id': [f't3_{tag}{i}' for i in range(n)],
+        'username': [f'user{i}' for i in range(n)],
+        'communityName': ['r/test'] * n,
+        'body': [f'body {tag} {i}' for i in range(n)],
+        'title': [f'title {tag} {i}' for i in range(n)],
+        'createdAt': [now] * n,
+        'dataType': ['post'] * n,
+        'parentId': [None] * n,
+        'url': [f'https://reddit.com/r/test/comments/{tag}{i}' for i in range(n)],
+        'media': [None] * n,
+        'is_nsfw': [False] * n,
+        'score': [1] * n,
+        'upvote_ratio': [0.9] * n,
+        'num_comments': [0] * n,
+        'scrapedAt': [now] * n,
+    })
+
+
+def _x_frame(n: int, tag: str) -> pd.DataFrame:
+    now = dt.datetime(2026, 8, 1, tzinfo=dt.timezone.utc)
+    return pd.DataFrame({
+        'datetime': [now] * n,
+        'label': ['#test'] * n,
+        'username': [f'@user{i}' for i in range(n)],
+        'text': [f'tweet {tag} {i}' for i in range(n)],
+        'tweet_hashtags': [['#test'] for _ in range(n)],
+        'timestamp': [now] * n,
+        'url': [f'https://x.com/user{i}/status/19{tag}{i:04d}' for i in range(n)],
+        'media': [None] * n,
+        'user_id': [f'{i}' for i in range(n)],
+        'user_display_name': [f'User {i}' for i in range(n)],
+        'user_verified': [False] * n,
+        'tweet_id': [f'19{tag}{i:04d}' for i in range(n)],
+        'is_reply': [False] * n,
+        'is_quote': [False] * n,
+        'conversation_id': [f'19{tag}{i:04d}' for i in range(n)],
+        'in_reply_to_user_id': [None] * n,
+        'language': ['en'] * n,
+        'in_reply_to_username': [None] * n,
+        'quoted_tweet_id': [None] * n,
+        'like_count': [1] * n,
+        'retweet_count': [0] * n,
+        'reply_count': [0] * n,
+        'quote_count': [0] * n,
+        'view_count': [10] * n,
+        'bookmark_count': [0] * n,
+        'user_blue_verified': [False] * n,
+        'user_description': ['bio'] * n,
+        'user_location': ['earth'] * n,
+        'profile_image_url': ['https://x.com/img.png'] * n,
+        'cover_picture_url': ['https://x.com/cover.png'] * n,
+        'user_followers_count': [5] * n,
+        'user_following_count': [5] * n,
+        'scraped_at': [now] * n,
+    })
+
+
+class ScraperSamplingFixture(unittest.TestCase):
+    """Builds a miner layout on disk: a few huge Reddit files plus small X files."""
+
+    # 3M claimed Reddit rows vs 1k claimed X rows — the skew a manipulating
+    # miner would arrange. The draw must still reach the X files.
+    REDDIT_CLAIMED_ROWS = 3_000_000
+    X_CLAIMED_ROWS = 1_000
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+
+        self.validator = object.__new__(DuckDBSampledValidator)
+        self.validator._rng = random.Random(1234)
+        self.validator._local_files = {}
+        self.validator._cached_bytes = 0
+
+        self.expected_jobs = {}
+        self.files = []
+
+        # 3 big Reddit files (the ballast) + 6 small X files.
+        for i in range(3):
+            self._add_file('reddit', f'redditjob{i}', self.REDDIT_CLAIMED_ROWS,
+                           _reddit_frame(60, f'rd{i}'))
+        for i in range(6):
+            self._add_file('x', f'xjob{i}', self.X_CLAIMED_ROWS,
+                           _x_frame(60, f'{i}'))
+
+    def _add_file(self, platform: str, job_id: str, claimed_rows: int, df: pd.DataFrame):
+        name = f'data_20260801_120000_{claimed_rows}_{"a" * 16}.parquet'
+        key = f'data/hotkey=hk/job_id={job_id}/{name}'
+        path = os.path.join(self.tmpdir.name, f'{job_id}_{name}')
+        # Small row groups so read_random_row_group has several to choose from.
+        df.to_parquet(path, row_group_size=20)
+        self.files.append({'key': key, 'size': os.path.getsize(path)})
+        self.validator._local_files[key] = path
+        self.expected_jobs[job_id] = {'params': {'platform': platform}}
+
+    def _run(self, num_entities: int = 20):
+        """Run the phase with the scraper stubbed to pass everything."""
+        async def _all_valid(entities, platform):
+            return [ValidationResult(is_valid=True, reason='ok',
+                                     content_size_bytes_validated=10)
+                    for _ in entities]
+
+        with patch.object(DuckDBSampledValidator, '_validate_with_scraper',
+                          new=AsyncMock(side_effect=_all_valid)):
+            return asyncio.run(self.validator._perform_scraper_validation(
+                'hk', list(self.files), self.expected_jobs,
+                # Presigned URLs are unused: every key is in the local cache.
+                {f['key']: 'https://unused.invalid' for f in self.files},
+                num_entities=num_entities,
+            ))
+
+
+class TestPlatformCoverage(ScraperSamplingFixture):
+    def test_x_leg_is_checked_despite_reddit_row_dominance(self):
+        """Reddit claims 99.98% of the rows; X must still be scraper-validated."""
+        result = self._run()
+        stats = result['platform_stats']
+        self.assertIn('x', stats, f"X was never scraper-checked: {stats}")
+        self.assertGreaterEqual(
+            stats['x']['validated'],
+            DuckDBSampledValidator.SCRAPER_PLATFORM_MIN_ENTITIES,
+            f"X below the per-platform floor, so the bar is vacuous: {stats}",
+        )
+        self.assertIn('reddit', stats)
+        self.assertEqual(result['entities_validated'], 20)
+
+    def test_coverage_holds_across_seeds(self):
+        """Not a lucky seed: every RNG seed must reach both platforms."""
+        for seed in range(12):
+            with self.subTest(seed=seed):
+                self.validator._rng = random.Random(seed)
+                stats = self._run()['platform_stats']
+                self.assertGreaterEqual(
+                    stats.get('x', {}).get('validated', 0),
+                    DuckDBSampledValidator.SCRAPER_PLATFORM_MIN_ENTITIES,
+                )
+                self.assertGreaterEqual(stats.get('reddit', {}).get('validated', 0), 1)
+
+    def test_no_single_file_owns_the_pool(self):
+        """The entity pool must be spread over files, not filled by one or two.
+
+        Each file yields at most SCRAPER_ROWS_PER_FILE rows, so filling a pool of
+        2 x num_entities takes at least 8 distinct files.
+        """
+        seen_files = []
+        real_reader = DuckDBSampledValidator._perform_scraper_validation
+
+        import vali_utils.s3_utils as s3_utils
+        original = s3_utils.read_random_row_group
+
+        def _spy(source, size, **kwargs):
+            seen_files.append(source)
+            self.assertEqual(kwargs.get('max_rows'),
+                             DuckDBSampledValidator.SCRAPER_ROWS_PER_FILE)
+            return original(source, size, **kwargs)
+
+        with patch.object(s3_utils, 'read_random_row_group', side_effect=_spy):
+            self._run()
+
+        self.assertGreaterEqual(len(set(seen_files)), 8)
+        self.assertIs(real_reader, DuckDBSampledValidator._perform_scraper_validation)
+
+
+class TestPerFileQuota(ScraperSamplingFixture):
+    def _quotas_seen(self):
+        """Every max_rows the phase asks for, one entry per file read."""
+        import vali_utils.s3_utils as s3_utils
+        original = s3_utils.read_random_row_group
+        quotas = []
+
+        def _spy(source, size, **kwargs):
+            quotas.append(kwargs.get('max_rows'))
+            return original(source, size, **kwargs)
+
+        with patch.object(s3_utils, 'read_random_row_group', side_effect=_spy):
+            self._run()
+        return quotas
+
+    def test_quota_is_identical_for_every_file(self):
+        """The Reddit files claim 3000x the rows of the X files; the quota the
+        phase asks each of them for must be the same number."""
+        quotas = self._quotas_seen()
+        self.assertGreater(len(quotas), 1)
+        self.assertEqual(len(set(quotas)), 1, f"per-file quota varied: {quotas}")
+        self.assertEqual(quotas[0], DuckDBSampledValidator.SCRAPER_ROWS_PER_FILE)
+
+    def test_small_miner_still_gets_a_full_sample(self):
+        """A miner with too few files to fill the pool at 5 rows each must not
+        end up with a SMALLER scraper sample than the row-proportional rule
+        used to give it. The quota rises; it stays uniform across files."""
+        self.files = self.files[:3]  # the 3 Reddit files — 3 x 5 < 40-row pool
+        quotas = self._quotas_seen()
+        self.assertEqual(len(set(quotas)), 1, f"per-file quota varied: {quotas}")
+        self.assertGreaterEqual(quotas[0], DuckDBSampledValidator.SCRAPER_ROWS_PER_FILE)
+        # 3 files x quota must still cover the 2 x num_entities pool.
+        self.assertGreaterEqual(quotas[0] * 3, 40)
+        self.assertEqual(self._run()['entities_validated'], 20)
+
+
+class TestBudgetInvariants(ScraperSamplingFixture):
+    def test_never_validates_more_than_requested(self):
+        result = self._run(num_entities=7)
+        self.assertLessEqual(result['entities_validated'], 7)
+
+    def test_success_rate_matches_tallies(self):
+        result = self._run()
+        expected = result['entities_passed'] / result['entities_validated'] * 100
+        self.assertAlmostEqual(result['success_rate'], expected, places=6)
+
+    def test_seeded_draw_is_reproducible(self):
+        """Committed sampling: the same seed must replay the same entity draw."""
+        self.validator._rng = random.Random(99)
+        first = self._run()
+        self.validator._rng = random.Random(99)
+        second = self._run()
+        self.assertEqual(first['sample_results'], second['sample_results'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vali_utils/parquet_reader.py
+++ b/vali_utils/parquet_reader.py
@@ -132,8 +132,22 @@ def read_random_row_group(
         table = pf.read_row_group(rg_idx, columns=columns)
         df = table.to_pandas()
 
-        if max_rows and len(df) > max_rows:
-            df = df.drop_duplicates(subset=['url']).sample(n=min(max_rows, len(df)), random_state=r.randint(0, 2**31))
+        if max_rows and 'url' in df.columns:
+            # Dedup by URL BEFORE deciding the sample size, and always — not
+            # only when the group exceeds max_rows. The old form,
+            #   sample(n=min(max_rows, len(df)))  on the deduped frame,
+            # took n from the PRE-dedup length: a row group padded with
+            # duplicate URLs (few uniques, group-level dup share of a big file
+            # stays under the 1% within-job gate) made sample() raise, the
+            # broad except below returned None, and the caller silently
+            # skipped the file — a miner-craftable "unsampleable file". And a
+            # group with <= max_rows rows skipped dedup entirely, so copies of
+            # one real row could fill a caller's whole per-file quota.
+            df = df.drop_duplicates(subset=['url'])
+            if len(df) > max_rows:
+                df = df.sample(n=max_rows, random_state=r.randint(0, 2**31))
+        elif max_rows and len(df) > max_rows:
+            df = df.sample(n=max_rows, random_state=r.randint(0, 2**31))
 
         return df
 

--- a/vali_utils/s3_utils.py
+++ b/vali_utils/s3_utils.py
@@ -253,6 +253,13 @@ class DuckDBSampledValidator:
     # held to MIN_SCRAPER_SUCCESS on its own rather than in a combined rate.
     SCRAPER_PLATFORM_MIN_ENTITIES = 5
 
+    # Rows drawn from each file during the scraper phase. Small and FIXED, not
+    # proportional to the file's claimed rows: filling the entity pool then
+    # requires at least ceil(2 * num_entities / SCRAPER_ROWS_PER_FILE) DISTINCT
+    # files, which is what stops one oversized file from owning every
+    # scraper-checked entity. See _perform_scraper_validation.
+    SCRAPER_ROWS_PER_FILE = 5
+
     # File size limits - prevent empty file exploit and oversized file OOM
     MIN_FILE_SIZE_BYTES = 15_000                   # 15KB - empty parquet header ≈ 8KB
     MAX_FILE_SIZE_BYTES = 1024 * 1024 * 1024       # 1GB - single file cap
@@ -1930,39 +1937,45 @@ class DuckDBSampledValidator:
         """
         all_entities = []
 
-        # Row-weighted random ordering: each file's rank is exponential(weight=claimed
-        # rows), NOT bytes. Bytes track compression, not the scored quantity; a fab
-        # file that compresses small (~52 B/row) got few scraper rows under byte-share
-        # even though it claims the same rows as a real file. Files claiming more rows
-        # (which drive effective_size) come first on average; tiny files retain a real
-        # probability of inspection.
-        def _claimed_rows_for(f):
-            r = self._parse_row_count_from_filename(f.get('key', ''))
-            return r if r and r > 0 else 1
+        # UNIFORM random file order + a small FIXED per-file row quota.
+        #
+        # File *selection* is already row-weighted, and force-includes the top-5
+        # files by claimed rows (see validate_miner_s3_data), so the files that
+        # drive effective_size are guaranteed to be in `sampled_files` before we
+        # get here. Weighting a second time — a row-weighted order plus a
+        # row-proportional per-file budget — let the single largest file absorb
+        # the entire pool: at 20 rows/file the 40-row pool was full after two
+        # files, so all 20 validated entities came from one or two files of one
+        # platform. That is steerable on purpose: shrink the X jobs until Reddit
+        # holds nearly all claimed rows and the X leg is never scraper-checked
+        # at all, which also makes the per-platform bar vacuous (a platform with
+        # no entities in the pool has nothing to hold to MIN_SCRAPER_SUCCESS).
+        #
+        # Uniform over files with <= SCRAPER_ROWS_PER_FILE rows each needs at
+        # least 8 distinct files to fill the pool, so every sampled job has a
+        # real chance of contributing and the per-platform floor below has
+        # something to draw from. Large files keep their advantage where it is
+        # earned: they are far more likely to be *selected* in the first place.
+        sampled_files = list(sampled_files)
+        self._rng.shuffle(sampled_files)
 
-        file_weights = [_claimed_rows_for(f) for f in sampled_files]
-        ranked = _weighted_sample_without_replacement(
-            sampled_files, file_weights, len(sampled_files), rng=self._rng
-        )
-        sampled_files = ranked
+        # Pool target: twice the number of entities we finally validate, so the
+        # per-platform floor and the random draw below have slack to work with.
+        entity_pool_target = num_entities * 2
 
-        # Row-proportional per-file budget: a file holding 50% of the CLAIMED ROWS
-        # contributes ~50% of the rows we sample. Total entity budget is
-        # `num_entities * 2` (the existing pool-size target); allocate it pro-rata by
-        # claimed-row share so scraper effort tracks the effective_size claim.
-        sample_total_rows = max(sum(file_weights), 1)
-        entity_budget = num_entities * 2
-        MIN_ROWS_PER_FILE = 2
-        MAX_ROWS_PER_FILE = 20
-
-        def _rows_for_file(f):
-            share = _claimed_rows_for(f) / sample_total_rows
-            target = int(round(share * entity_budget))
-            return max(MIN_ROWS_PER_FILE, min(MAX_ROWS_PER_FILE, target))
+        # The quota is raised only when the sample holds too few files to fill
+        # the pool at the base rate — a small miner (fewer than 10 files in
+        # total) must not end up with a SMALLER scraper sample than before this
+        # change. It stays the same number for every file either way: what
+        # makes the draw unsteerable is that no file's share depends on the row
+        # count the miner declares, not the size of the share itself.
+        rows_per_file = self.SCRAPER_ROWS_PER_FILE
+        if sampled_files and len(sampled_files) * rows_per_file < entity_pool_target:
+            rows_per_file = math.ceil(entity_pool_target / len(sampled_files))
 
         for file_info in sampled_files:
 
-            if len(all_entities) >= num_entities * 2:
+            if len(all_entities) >= entity_pool_target:
                 break
 
             # Skip oversized files to prevent OOM
@@ -2022,10 +2035,11 @@ class DuckDBSampledValidator:
                 if required - available_cols:
                     continue
 
-                # Read 1 random row group; sample size scales with file's byte share.
+                # Read 1 random row group and draw a flat quota of random rows
+                # from it — same quota for every file, big or small.
                 df = read_random_row_group(
                     read_source, file_size,
-                    columns=None, max_rows=_rows_for_file(file_info),
+                    columns=None, max_rows=rows_per_file,
                     rng=self._rng
                 )
 
@@ -2107,7 +2121,14 @@ class DuckDBSampledValidator:
         # Fill the rest of the budget with a random draw over everything not yet picked.
         remaining = [it for it in all_entities if id(it) not in selected_ids]
         fill = max(0, target - len(selected))
-        selected.extend(self._rng.sample(remaining, min(fill, len(remaining))))
+        if fill > 0:
+            selected.extend(self._rng.sample(remaining, min(fill, len(remaining))))
+        else:
+            # The floors alone already over-subscribed the budget (enough
+            # platforms x SCRAPER_PLATFORM_MIN_ENTITIES > target). Shuffle
+            # before truncating so the platforms that survive the cut are drawn
+            # at random rather than by dict insertion order.
+            self._rng.shuffle(selected)
         entities_to_validate = selected[:target]
 
         sample_results = []


### PR DESCRIPTION
## Summary

Three follow-ups to the S3 quality-scoring rollout (#901 / #902), all about the *mechanism*, not the thresholds. **The 2× OD cap on the raw S3 boost is untouched**, and so is the failure path (retain `effective_size`, decay credibility geometrically).

| # | Problem | Fix |
|---|---|---|
| 1 | `update_s3_effective_size` lowers credibility on cycles where the miner **passed** validation — once for an imperfect scraper pass rate, once again for having uploaded new data | On PASS, EMA credibility toward 1.0 (pre-rollout rule). `pass_rate` stays as telemetry |
| 2 | The scraper entity draw is **steerable by the miner**: file order and per-file row budget both derive from the row counts the miner declares in its own filenames, so 20/20 validated entities can come from 1–2 files of one platform | Uniform shuffle over sampled files + flat per-file row quota; the per-platform floor can then actually bind |
| 3 | A row group padded with duplicate URLs makes `read_random_row_group` raise → return `None` → the file is **silently skipped** by job-content matching and scraper validation | Dedup before sizing the draw; the unique rows come back and get validated |

## 1. Passing validation must not cost credibility

`rewards/miner_scorer.py::update_s3_effective_size`

### Problem

**a) The pass EMA targeted the observed scraper pass rate.** `MIN_SCRAPER_SUCCESS` (80%, combined *and* per platform since #901) already decides pass/fail on that exact sample — grading the EMA target by the same number charges the miner twice for one sample. And 20 live scraper lookups carry irreducible noise (deleted posts, rate-limited or flaky third-party calls), so 18–19/20 is a normal honest cycle. It reported `is_valid=True` and still pulled credibility down.

**b) Claimed-size growth scaled credibility by `(old/new)^(1/2.5)`.** That rule is P2P's, where score grows directly with claimed bytes and the tax is what stops volume inflation. S3 is shaped differently: the boost is capped at 2×OD **before** credibility (`_s3_component`), so past the cap extra volume buys nothing. Meanwhile miners are *supposed* to keep crawling the desirability list and uploading — so `new > old` on virtually every honest pass. Result: the multiplier shrank every cycle while the capped boost stayed flat. **Uploading more data was strictly negative EV, judged before anything is known about whether the data is real.** Fabricated volume is what the validation gate and the failure path are for.

Steady-state numbers for an honest miner growing 8%/cycle (EMA α=0.30, exponent 2.5):

| scraper result each cycle | old: cred → S3 multiplier | new: cred → multiplier |
|---|---|---|
| 19/20 (honest noise) | 0.887 → **0.741** | 1.0 → 1.0 |
| 20/20 (perfect) | 0.934 → **0.843** | 1.0 → 1.0 |

A permanently-passing miner was permanently docked 16–26% of its capped S3 component, and the only way to stop the growth tax was to stop uploading.

### Solution

On PASS: update `effective_size`, EMA credibility toward 1.0 — the rule from before the rollout. Passing *is* the quality signal; the bar decides pass/fail, credibility tracks how consistently the miner clears it. Removed both new penalties for S3; P2P's prove-it rule in `on_miner_evaluated` is unchanged. `pass_rate` remains on the result, in the published blob and in the scorer log — telemetry only, so follower validators stay consistent with the primary. **No state reset**: depressed credibilities recover through the normal EMA within a few cycles, which is gentler than resetting everyone to `STARTING_S3_CREDIBILITY = 0.1`.

## 2. The entity draw must not be steerable by declared row counts

`vali_utils/s3_utils.py::_perform_scraper_validation`

### Problem

The phase ordered sampled files by claimed rows (weighted ranking), then gave each file a row-proportional budget of up to 20 rows — both knobs read the row count the **miner** writes into its own filenames. So: keep Reddit jobs huge, shrink X jobs, and the one or two biggest Reddit files sort first *and* take 20 rows each, filling the 40-row pool before any other file is opened. All 20 validated entities come from 1–2 Reddit files; **no X entity ever enters the pool**. The per-platform bar from #901 can't catch it — a platform with zero entities in the pool has nothing to hold to `MIN_SCRAPER_SUCCESS` — so an entire platform's data goes unvalidated *by construction* while still earning row credit toward `effective_size`.

Monte-Carlo over the draw (3 Reddit files claiming 3M rows each vs 6 X files claiming 1k, 2000 cycles):

| | X entities among the 20 validated | cycles where X misses its 5-entity floor |
|---|---|---|
| old draw | mean 2.0 (0 with only 2 mega-files) | 100% |
| new draw | mean 12.1, min 8 | 0% |

### Solution

Make the draw independent of everything the miner declares:

- **File order**: `rng.shuffle` — uniform. Taking the prefix of a shuffle until the pool fills is a uniform random subset; no sort key exists for the miner to feed.
- **Per-file quota**: flat `SCRAPER_ROWS_PER_FILE = 5` for every file, so filling the 2×`num_entities` pool needs ≥8 **distinct** files and no single file can own the sample. If the cycle's sample holds too few files to fill the pool at 5 each (a small miner), the quota rises to `ceil(pool/len(files))` — still identical for every file. What makes the draw unsteerable is that no file's share depends on its claimed rows, not the size of the share.
- **Final selection**: unchanged — per-platform floors first (claimed rows used only as a boolean "has rows", never as a weight), then a uniform random fill; when floors alone over-subscribe the budget, the selection is shuffled before truncation so survivors are random rather than dict-insertion order.
- **Committed sampling preserved end to end**: every draw (shuffle, row group, rows, floors, fill) goes through `self._rng`, seeded from H(block hash ‖ hotkey ‖ manifest) — unpredictable at upload time, exactly reproducible afterwards.

Large files keep the advantage they earned at the right layer: file *selection* in `validate_miner_s3_data` is already row-weighted and force-includes the top-5 by claimed rows, so they're far more likely to be in `sampled_files` at all. Weighting them a second time inside this phase was double counting — and it was the half the miner could steer.

**Cost:** the phase reads ~8–15 files instead of ~2–3, but those files are already in the eval-scoped local cache from the dedup phase (`_local_files`) — local reads, not extra network round trips.

## 3. Duplicate-URL padding must not make a file unsampleable

`vali_utils/parquet_reader.py::read_random_row_group`

### Problem

The row draw was sized from the **pre-dedup** frame:

```python
df.drop_duplicates(subset=['url']).sample(n=min(max_rows, len(df)), ...)
```

If the drawn row group holds fewer unique URLs than `max_rows`, `sample()` raises, the function's broad `except` returns `None`, and the caller silently skips the file. One padded row group (10k rows, a handful of unique URLs) is ~0.3% of a 3M-row file — **under the 1% within-job duplicate gate** — yet whenever the group draw lands on it, that file escapes both job-content matching (`max_rows=100`) and scraper validation. A craftable "unsampleable file", in the phase whose stated invariant is that sampled rows never disappear silently. Separately, a group with ≤ `max_rows` rows skipped dedup entirely, so copies of one real row could fill a file's whole quota.

### Solution

Dedup first, always (when a `url` column is present), and size the draw from the deduped frame. The unique rows now come back and get validated — pointing the scrapers at exactly the rows the miner tried to hide behind padding. Frames read without a `url` column keep plain sampling.

## Testing

```bash
python -m pytest tests/rewards/test_s3_quality_scoring.py \
                 tests/vali_utils/test_scraper_entity_sampling.py \
                 tests/vali_utils/test_committed_sampling.py \
                 tests/vali_utils/test_index_fail_freeze.py \
                 tests/vali_utils/test_s3_latest_per_job.py \
                 tests/vali_utils/test_s3_x_snowflake.py \
                 tests/rewards/test_miner_scorer_state.py -q
```

**New — `tests/vali_utils/test_scraper_entity_sampling.py`** (8 tests, 12 subtests). Builds the manipulation from §2 on real parquet files on disk — 3 Reddit files claiming 3,000,000 rows each vs 6 X files claiming 1,000 — registered in the validator's local-file cache exactly as the download phase does; only `_validate_with_scraper` is mocked. Asserts:
- X clears the per-platform 5-entity floor on **all 12 RNG seeds** (on pre-fix code this fails on every seed with `x: validated=2`);
- ≥8 distinct files feed the pool, so no file owns the sample;
- the per-file quota is byte-for-byte identical across files despite the 3000× claimed-row skew;
- a 3-file miner still fills the full 20-entity sample (quota rises uniformly);
- the draw replays exactly under a fixed committed seed.

**Extended — `tests/vali_utils/test_committed_sampling.py`**: a duplicate-URL-padded row group returns its unique rows instead of `None`; a short row group is still deduped; frames without a `url` column keep plain sampling. The first two fail on pre-fix code.

**Updated — `tests/rewards/test_s3_quality_scoring.py`**: pass-rate independence (two passing miners with different observed rates end at identical credibility), growth-vs-flat credibility parity over 20 cycles, and proof that the capped S3 component is flat in volume (1e12 → 1e15 `effective_size`, identical score) — which is exactly why growth needs no credibility tax. The #901/#902 tests for cap-before-credibility ordering, `S3=0` without OD, the per-platform bar, and failure decay (geometric, volume retained) are unchanged and still pass.

**Full suites** (`tests/rewards` + `tests/vali_utils`): 143 passed, 8 failed — the identical 8 fail on an unmodified `dev` checkout (`test_data_value_calculator` ×4, `test_eval_batch_concurrency` ×1, `test_od_flow` ×3), and `tests/rewards/test_miner_scorer.py` errors at collection on `dev` (`module 'rewards.data_value_calculator' has no attribute 'dt'`). None touch this diff. `tests/common` + `tests/storage` also match the `dev` baseline exactly.
