### PR TITLE
fix(s3): stop penalizing honest miners; guarantee every platform is scraper-validated

### DIFF
--- a/tests/rewards/test_s3_quality_scoring.py
+++ b/tests/rewards/test_s3_quality_scoring.py
@@ -41,8 +41,9 @@ class TestS3QualityScoring(unittest.TestCase):
     def test_pass_ema_targets_one_whatever_the_pass_rate(self):
         """Passing is the signal; the observed rate must not grade it again.
 
-        MIN_SCRAPER_SUCCESS already refuses anything under 80% (per platform and
-        combined), so a reported pass means the sample cleared the bar. Grading
+        MIN_SCRAPER_SUCCESS already refuses anything under 80% combined (and
+        under 60% per platform), so a reported pass means the sample cleared
+        the bars. Grading
         the EMA target by the rate on top of that made an honest 19/20 cycle —
         one deleted post, one rate-limited lookup — pull credibility DOWN.
         """
@@ -163,20 +164,30 @@ class TestPerPlatformBar(unittest.TestCase):
         # _per_platform_issues only touches class constants; skip __init__.
         self.validator = object.__new__(DuckDBSampledValidator)
 
-    def test_dirty_x_leg_cannot_hide_behind_clean_reddit(self):
-        """3/5 X + 15/15 Reddit = 90% combined (passes the combined bar) but the
-        X leg alone is 60% — dirty X hidden behind clean Reddit ballast."""
+    def test_mostly_fabricated_platform_is_flagged(self):
+        """A platform BELOW the 60% per-platform bar (2/5 = 40%) is still
+        caught on its own, even hidden behind clean Reddit ballast."""
         issues = self.validator._per_platform_issues({
-            'x': {'validated': 5, 'passed': 3},
+            'x': {'validated': 5, 'passed': 2},          # 40% < 60%
             'reddit': {'validated': 15, 'passed': 15},
         })
         self.assertEqual(len(issues), 1)
         self.assertIn('x', issues[0])
-        self.assertIn('60.0', issues[0])
+        self.assertIn('40.0', issues[0])
+
+    def test_sixty_percent_leg_passes_per_platform_bar(self):
+        """3/5 = 60% is intentionally allowed at the per-platform level: on a
+        5-row sample it's within honest lookup noise. The combined 80% bar
+        (checked in validate_miner_s3_data, not here) remains the strict gate."""
+        issues = self.validator._per_platform_issues({
+            'x': {'validated': 5, 'passed': 3},          # 60% == bar
+            'reddit': {'validated': 15, 'passed': 15},
+        })
+        self.assertEqual(issues, [])
 
     def test_clean_platforms_produce_no_issues(self):
         issues = self.validator._per_platform_issues({
-            'x': {'validated': 5, 'passed': 4},       # 80% == bar
+            'x': {'validated': 5, 'passed': 4},         # 80%
             'reddit': {'validated': 15, 'passed': 14},  # 93%
         })
         self.assertEqual(issues, [])
@@ -188,6 +199,12 @@ class TestPerPlatformBar(unittest.TestCase):
             'x': {'validated': 2, 'passed': 0},
         })
         self.assertEqual(issues, [])
+
+    def test_combined_bar_unchanged_at_80(self):
+        """Guard: the split lowered only the per-platform constant. The combined
+        gate stays 80% so wholesale fabrication is still caught."""
+        self.assertEqual(DuckDBSampledValidator.MIN_SCRAPER_SUCCESS, 80.0)
+        self.assertEqual(DuckDBSampledValidator.MIN_SCRAPER_SUCCESS_PER_PLATFORM, 60.0)
 
 
 if __name__ == '__main__':

--- a/tests/vali_utils/test_scraper_entity_sampling.py
+++ b/tests/vali_utils/test_scraper_entity_sampling.py
@@ -19,7 +19,7 @@ import os
 import random
 import tempfile
 import unittest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pandas as pd
 
@@ -248,6 +248,93 @@ class TestBudgetInvariants(ScraperSamplingFixture):
         self.validator._rng = random.Random(99)
         second = self._run()
         self.assertEqual(first['sample_results'], second['sample_results'])
+
+
+class TestSelectionPlatformFloor(unittest.TestCase):
+    """The SELECTION stage (validate_miner_s3_data) must put files from every
+    active platform into the sample, even when a miner shrinks one platform's
+    claimed rows to near-zero. Without the per-platform file floor, the
+    row-weighted draw and the top-5 force-include pick only the high-volume
+    platform, so the minority platform's files never reach the scraper phase
+    at all — the observed '20/20 entities Reddit, no X' hole.
+
+    The read phases are mocked; the test asserts on the files handed to
+    _perform_scraper_validation.
+    """
+
+    N_REDDIT_JOBS = 30
+    N_X_JOBS = 2
+    REDDIT_CLAIMED = 100_000
+    X_CLAIMED = 50  # miner shrinks X to almost nothing
+
+    def _files(self):
+        files = []
+        expected_jobs = {}
+        for i in range(self.N_REDDIT_JOBS):
+            jid = f'redditjob{i}'
+            name = f'data_20260801_120000_{self.REDDIT_CLAIMED}_{"a" * 16}.parquet'
+            files.append({'key': f'data/hotkey=hk/job_id={jid}/{name}',
+                          'size': 8_000_000, 'last_modified': f'2026-08-01T00:00:{i:02d}Z'})
+            expected_jobs[jid] = {'params': {'platform': 'reddit'}}
+        for i in range(self.N_X_JOBS):
+            jid = f'xjob{i}'
+            name = f'data_20260801_120000_{self.X_CLAIMED}_{"b" * 16}.parquet'
+            files.append({'key': f'data/hotkey=hk/job_id={jid}/{name}',
+                          'size': 20_000, 'last_modified': f'2026-08-01T00:00:{i:02d}Z'})
+            expected_jobs[jid] = {'params': {'platform': 'x'}}
+        return files, expected_jobs
+
+    def _validator(self, seed):
+        v = DuckDBSampledValidator.__new__(DuckDBSampledValidator)
+        v.wallet = MagicMock()
+        v.sample_percent = 10.0
+        v._seed_material = seed  # deterministic committed RNG per seed
+        v._local_files = {}
+        v._cached_bytes = 0
+        return v
+
+    def _sampled_files_for(self, seed):
+        v = self._validator(seed)
+        files, expected_jobs = self._files()
+
+        captured = {}
+
+        async def _capture_scraper(hotkey, sampled_files, *a, **k):
+            captured['files'] = sampled_files
+            return {'entities_validated': 20, 'entities_passed': 20,
+                    'success_rate': 100.0, 'sample_results': [],
+                    'platform_stats': {'x': {'validated': 5, 'passed': 5},
+                                       'reddit': {'validated': 15, 'passed': 15}}}
+
+        v.s3_reader = MagicMock()
+        v.s3_reader.list_all_files_with_metadata = AsyncMock(return_value=files)
+        v._get_presigned_urls_batch = AsyncMock(
+            return_value={f['key']: 'https://unused.invalid' for f in files})
+        v._sampled_duckdb_validation = AsyncMock(return_value={
+            'duplicate_rate_within_job': 0.0, 'empty_rate': 0.0,
+            'compression_failures': 0, 'row_count_mismatches': 0,
+            'decode_ratio': 1.0,
+        })
+        v._perform_job_content_matching = AsyncMock(return_value={
+            'total_checked': 20, 'total_matched': 20, 'match_rate': 100.0,
+            'mismatch_samples': [],
+        })
+        v._perform_scraper_validation = _capture_scraper
+
+        asyncio.run(v.validate_miner_s3_data('hk', expected_jobs))
+        return captured['files'], expected_jobs
+
+    def test_x_files_survive_selection_despite_tiny_claimed_rows(self):
+        for seed in [f'0x{i:064x}' for i in range(15)]:
+            with self.subTest(seed=seed):
+                sampled, expected_jobs = self._sampled_files_for(seed)
+                x_files = [f for f in sampled
+                           if DuckDBSampledValidator._file_platform(f['key'], expected_jobs) == 'x']
+                self.assertGreaterEqual(
+                    len(x_files), DuckDBSampledValidator.SCRAPER_PLATFORM_MIN_FILES,
+                    f"X shut out of the sample (seed {seed}): "
+                    f"{[f['key'] for f in sampled]}",
+                )
 
 
 if __name__ == '__main__':

--- a/tests/vali_utils/test_single_platform_resistance.py
+++ b/tests/vali_utils/test_single_platform_resistance.py
@@ -1,0 +1,243 @@
+"""End-to-end resistance to the 'force all scraper validation onto one platform'
+manipulation.
+
+A miner shrinks the CLAIMED row counts of one platform's jobs (the number it
+writes into its own filenames) so the row-weighted file draw and the top-5
+force-include pick only the high-volume platform. Before the per-platform file
+floor (selection) + round-robin read (scraper phase), that left the minority
+platform with zero scraper-checked entities — its per-platform bar vacuous, all
+20/20 landing on the majority platform (observed live: all Reddit, no X).
+
+Unlike the focused tests in test_scraper_entity_sampling.py, these drive the
+WHOLE sampling path through validate_miner_s3_data on real parquet files: the
+selection stage AND the real scraper read both run, only the external scraper
+call (_validate_with_scraper) and the unrelated DuckDB/job-match phases are
+mocked. The spy on _validate_with_scraper records how many entities of each
+platform actually reached a scraper — the exact quantity the manipulation tried
+to drive to zero.
+
+Claim skew note: the validator rejects files whose size/claimed-rows ratio is
+below MIN_BYTES_PER_ROW (50), so a test cannot pair a 3M-row CLAIM with a tiny
+file the way production pairs it with a GB file. The layouts here keep the ratio
+valid and still make the majority platform's TOTAL claimed rows dwarf the
+minority's — which is all the row-weighted draw and the top-5 force-include key
+off, so the manipulation is faithfully reproduced.
+
+Only x and reddit are used: _create_data_entity builds entities for those two
+platforms (the subnet's scraper-validated sources); other labels would fail
+entity construction by design.
+"""
+
+import asyncio
+import datetime as dt
+import os
+import random
+import tempfile
+import unittest
+from collections import Counter
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pandas as pd
+
+from scraping.scraper import ValidationResult
+from vali_utils.s3_utils import DuckDBSampledValidator
+
+HEX = "0123456789abcdef"
+PHYSICAL_ROWS = 120  # rows actually written per file (keeps files > MIN_FILE_SIZE)
+
+
+def _reddit_frame(n: int, tag: str) -> pd.DataFrame:
+    now = dt.datetime(2026, 8, 1, tzinfo=dt.timezone.utc)
+    return pd.DataFrame({
+        'datetime': [now] * n, 'label': ['r/test'] * n,
+        'id': [f't3_{tag}{i}' for i in range(n)],
+        'username': [f'user{i}' for i in range(n)], 'communityName': ['r/test'] * n,
+        'body': [f'body {tag} {i} lorem ipsum dolor sit amet' for i in range(n)],
+        'title': [f'title {tag} {i} some longer heading text' for i in range(n)],
+        'createdAt': [now] * n, 'dataType': ['post'] * n, 'parentId': [None] * n,
+        'url': [f'https://reddit.com/r/test/comments/{tag}{i}' for i in range(n)],
+        'media': [None] * n, 'is_nsfw': [False] * n, 'score': [1] * n,
+        'upvote_ratio': [0.9] * n, 'num_comments': [0] * n, 'scrapedAt': [now] * n,
+    })
+
+
+def _x_frame(n: int, tag: str) -> pd.DataFrame:
+    now = dt.datetime(2026, 8, 1, tzinfo=dt.timezone.utc)
+    return pd.DataFrame({
+        'datetime': [now] * n, 'label': ['#test'] * n,
+        'username': [f'@user{i}' for i in range(n)],
+        'text': [f'tweet {tag} {i} lorem ipsum dolor sit amet consectetur' for i in range(n)],
+        'tweet_hashtags': [['#test'] for _ in range(n)], 'timestamp': [now] * n,
+        'url': [f'https://x.com/user{i}/status/19{tag}{i:04d}' for i in range(n)],
+        'media': [None] * n, 'user_id': [f'{i}' for i in range(n)],
+        'user_display_name': [f'User {i}' for i in range(n)], 'user_verified': [False] * n,
+        'tweet_id': [f'19{tag}{i:04d}' for i in range(n)],
+        'is_reply': [False] * n, 'is_quote': [False] * n,
+        'conversation_id': [f'19{tag}{i:04d}' for i in range(n)],
+        'in_reply_to_user_id': [None] * n, 'language': ['en'] * n,
+        'in_reply_to_username': [None] * n, 'quoted_tweet_id': [None] * n,
+        'like_count': [1] * n, 'retweet_count': [0] * n, 'reply_count': [0] * n,
+        'quote_count': [0] * n, 'view_count': [10] * n, 'bookmark_count': [0] * n,
+        'user_blue_verified': [False] * n, 'user_description': ['bio'] * n,
+        'user_location': ['earth'] * n, 'profile_image_url': ['https://x.com/i.png'] * n,
+        'cover_picture_url': ['https://x.com/c.png'] * n,
+        'user_followers_count': [5] * n, 'user_following_count': [5] * n,
+        'scraped_at': [now] * n,
+    })
+
+
+class ResistanceHarness(unittest.TestCase):
+    """Builds real parquet files ONCE per layout and drives
+    validate_miner_s3_data with only the scraper call + DuckDB/job-match mocked."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+
+    def _bundle(self, layout):
+        """layout: list of (platform, claimed_rows, count). Builds the files once.
+
+        physical rows are fixed (PHYSICAL_ROWS) so every file clears
+        MIN_FILE_SIZE and keeps size/claimed >= MIN_BYTES_PER_ROW; the CLAIM in
+        the filename is what the row-weighted draw and top-5 key off.
+        """
+        files_meta, expected_jobs, local_files = [], {}, {}
+        jid_n = 0
+        for platform, claimed, count in layout:
+            for _ in range(count):
+                jid_n += 1
+                jid = f'{platform}job{jid_n}'
+                hexs = ''.join(random.Random(jid_n).choice(HEX) for _ in range(16))
+                name = f'data_20260801_120000_{claimed}_{hexs}.parquet'
+                key = f'data/hotkey=hk/job_id={jid}/{name}'
+                path = os.path.join(self.tmp.name, f'{jid}.parquet')
+                frame = (_x_frame if platform == 'x' else _reddit_frame)(PHYSICAL_ROWS, f'{jid_n}')
+                frame.to_parquet(path, row_group_size=20)
+                files_meta.append({'key': key, 'size': os.path.getsize(path),
+                                   'last_modified': f'2026-08-01T00:00:{jid_n % 60:02d}Z'})
+                local_files[key] = path
+                expected_jobs[jid] = {'params': {'platform': platform}}
+        return files_meta, expected_jobs, local_files
+
+    def _run(self, bundle, seed):
+        files_meta, expected_jobs, local_files = bundle
+
+        v = DuckDBSampledValidator.__new__(DuckDBSampledValidator)
+        v.wallet = MagicMock()
+        v.sample_percent = 10.0
+        v._seed_material = seed
+        v._local_files = dict(local_files)
+        v._cached_bytes = 0
+        v.scraper_provider = MagicMock()
+        v.s3_reader = MagicMock()
+        v.s3_reader.list_all_files_with_metadata = AsyncMock(return_value=files_meta)
+        v._get_presigned_urls_batch = AsyncMock(
+            return_value={f['key']: 'https://unused.invalid' for f in files_meta})
+        v._sampled_duckdb_validation = AsyncMock(return_value={
+            'duplicate_rate_within_job': 0.0, 'empty_rate': 0.0,
+            'compression_failures': 0, 'row_count_mismatches': 0, 'decode_ratio': 1.0,
+        })
+        v._perform_job_content_matching = AsyncMock(return_value={
+            'total_checked': 20, 'total_matched': 20, 'match_rate': 100.0,
+            'mismatch_samples': [],
+        })
+
+        scraped = Counter()
+
+        async def _spy_scraper(entities, platform):
+            scraped[platform] += len(entities)
+            return [ValidationResult(is_valid=True, reason='ok',
+                                     content_size_bytes_validated=10) for _ in entities]
+
+        with patch.object(v, '_validate_with_scraper', side_effect=_spy_scraper):
+            result = asyncio.run(v.validate_miner_s3_data('hk', expected_jobs))
+        return scraped, result
+
+
+class TestEndToEndSinglePlatformResistance(ResistanceHarness):
+    FLOOR = DuckDBSampledValidator.SCRAPER_PLATFORM_MIN_ENTITIES
+
+    def test_reproduces_all_reddit_attempt_now_checks_x(self):
+        """30 Reddit jobs whose total claim dwarfs 2 X jobs. The manipulation
+        targeted X → 0; X must now reach its floor, every seed."""
+        bundle = self._bundle([('reddit', 400, 30), ('x', 5, 2)])
+        for seed in [f'0x{i:064x}' for i in range(10)]:
+            with self.subTest(seed=seed):
+                scraped, result = self._run(bundle, seed)
+                self.assertIn('x', scraped, f"X never scraper-checked: {dict(scraped)}")
+                self.assertIn('reddit', scraped)
+                self.assertGreaterEqual(scraped['x'], self.FLOOR, dict(scraped))
+                # No single platform may own the whole validated budget.
+                self.assertLess(scraped['reddit'], result.entities_validated)
+
+    def test_single_x_file_is_still_checked(self):
+        """A platform with only ONE file (the floor clamps to what's available)
+        must still reach a scraper, not be dropped."""
+        bundle = self._bundle([('reddit', 400, 30), ('x', 5, 1)])
+        for seed in [f'0x{i:064x}' for i in range(8)]:
+            with self.subTest(seed=seed):
+                scraped, _ = self._run(bundle, seed)
+                self.assertIn('x', scraped, f"single X file dropped: {dict(scraped)}")
+                self.assertGreaterEqual(scraped['x'], 1)
+
+    def test_max_claim_skew(self):
+        """Widest claim skew that keeps size/claimed >= MIN_BYTES_PER_ROW: X
+        claims 1 row/job. X's files still get forced in and checked."""
+        bundle = self._bundle([('reddit', 500, 20), ('x', 1, 3)])
+        for seed in [f'0x{i:064x}' for i in range(8)]:
+            with self.subTest(seed=seed):
+                scraped, _ = self._run(bundle, seed)
+                self.assertGreaterEqual(scraped['x'], self.FLOOR, dict(scraped))
+
+    def test_reverse_skew_reddit_minority(self):
+        """Symmetry: shrink Reddit instead. Reddit must reach its floor too."""
+        bundle = self._bundle([('x', 400, 20), ('reddit', 5, 2)])
+        for seed in [f'0x{i:064x}' for i in range(8)]:
+            with self.subTest(seed=seed):
+                scraped, _ = self._run(bundle, seed)
+                self.assertGreaterEqual(scraped['reddit'], self.FLOOR, dict(scraped))
+
+    def test_balanced_layout_checks_both(self):
+        bundle = self._bundle([('reddit', 300, 8), ('x', 300, 8)])
+        for seed in [f'0x{i:064x}' for i in range(6)]:
+            with self.subTest(seed=seed):
+                scraped, _ = self._run(bundle, seed)
+                self.assertGreaterEqual(scraped['x'], self.FLOOR)
+                self.assertGreaterEqual(scraped['reddit'], self.FLOOR)
+
+
+class TestResistanceFuzz(ResistanceHarness):
+    FLOOR = DuckDBSampledValidator.SCRAPER_PLATFORM_MIN_ENTITIES
+    MIN_FILES = DuckDBSampledValidator.SCRAPER_PLATFORM_MIN_FILES
+
+    def test_random_adversarial_layouts(self):
+        """Fuzz: random counts and claim skews. Every platform that has files —
+        no matter how small its claim — must be scraper-checked, and if it has
+        >= SCRAPER_PLATFORM_MIN_FILES files it must reach the entity floor."""
+        for t in range(25):
+            rnd = random.Random(t)
+            n_reddit = rnd.randint(1, 12)
+            n_x = rnd.randint(1, 6)
+            # Randomly pick which platform is the shrunken minority (claim 1-3)
+            # vs the majority (claim 300-500). Ratios stay within MIN_BYTES_PER_ROW.
+            big, small = rnd.choice([(400, 2), (500, 1), (300, 3)]), None
+            if rnd.random() < 0.5:
+                reddit_claim, x_claim = big[0], big[1]
+            else:
+                reddit_claim, x_claim = big[1], big[0]
+            layout = [('reddit', reddit_claim, n_reddit), ('x', x_claim, n_x)]
+            bundle = self._bundle(layout)
+            seed = f'0x{t:064x}'
+            with self.subTest(t=t, layout=layout):
+                scraped, _ = self._run(bundle, seed)
+                for plat, count in (('reddit', n_reddit), ('x', n_x)):
+                    self.assertIn(plat, scraped,
+                                  f"{plat} shut out (t={t}, {layout}): {dict(scraped)}")
+                    if count >= self.MIN_FILES:
+                        self.assertGreaterEqual(
+                            scraped[plat], self.FLOOR,
+                            f"{plat} below floor (t={t}, {layout}): {dict(scraped)}")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vali_utils/s3_utils.py
+++ b/vali_utils/s3_utils.py
@@ -260,6 +260,15 @@ class DuckDBSampledValidator:
     # scraper-checked entity. See _perform_scraper_validation.
     SCRAPER_ROWS_PER_FILE = 5
 
+    # Files force-included per platform at SELECTION time (validate_miner_s3_data).
+    # The row-weighted draw + top-5 force-include are platform-blind, so a miner
+    # who shrinks one platform's claimed rows to near-zero makes its files never
+    # get sampled — that platform's data is then never scraper-checked, and its
+    # per-platform bar is vacuous (no entities to hold to MIN_SCRAPER_SUCCESS).
+    # Guaranteeing >= 2 files/platform gives the scraper phase enough rows
+    # (2 x SCRAPER_ROWS_PER_FILE, before URL-dedup) to clear the entity floor.
+    SCRAPER_PLATFORM_MIN_FILES = 2
+
     # File size limits - prevent empty file exploit and oversized file OOM
     MIN_FILE_SIZE_BYTES = 15_000                   # 15KB - empty parquet header ≈ 8KB
     MAX_FILE_SIZE_BYTES = 1024 * 1024 * 1024       # 1GB - single file cap
@@ -572,6 +581,34 @@ class DuckDBSampledValidator:
             forced = [item for item in top_n if item[0].get('key') not in picked_keys]
 
             sampled_files_with_job = sampled_files_with_job + forced
+            picked_keys.update(item[0].get('key') for item in forced)
+
+            # Per-platform FILE floor. All four slices above (row-weighted,
+            # uniform-over-jobs, suspicion, top-5) are platform-blind: they key
+            # off claimed rows or job id, never platform. A miner shrinks its X
+            # jobs to a handful of rows so the weighted draw and top-5 pick only
+            # Reddit, and X is never scraper-checked at all (observed: 20/20
+            # sampled entities Reddit, no X). Force in each platform's
+            # highest-claim files until it has >= SCRAPER_PLATFORM_MIN_FILES in
+            # the sample, so every platform earning row credit is inspected and
+            # its per-platform scraper bar can bind.
+            files_by_platform_all: Dict[str, list] = {}
+            for it in active_files:
+                p = self._file_platform(it[0].get('key', ''), expected_jobs)
+                files_by_platform_all.setdefault(p, []).append(it)
+            for p, items in files_by_platform_all.items():
+                have = sum(1 for it in items if it[0].get('key') in picked_keys)
+                need = min(self.SCRAPER_PLATFORM_MIN_FILES, len(items)) - have
+                if need <= 0:
+                    continue
+                extra = sorted(
+                    (it for it in items if it[0].get('key') not in picked_keys),
+                    key=_claimed_rows, reverse=True,
+                )[:need]
+                for it in extra:
+                    sampled_files_with_job.append(it)
+                    picked_keys.add(it[0].get('key'))
+
             self._rng.shuffle(sampled_files_with_job)
             sampled_files = [f for f, _ in sampled_files_with_job]
 
@@ -886,6 +923,21 @@ class DuckDBSampledValidator:
         filename = key.rsplit('/', 1)[-1]
         match = self._FILENAME_ROW_COUNT_RE.match(filename)
         return int(match.group(1)) if match else None
+
+    @staticmethod
+    def _file_platform(file_key: str, expected_jobs: Dict) -> str:
+        """Platform ('x'/'reddit'/...) of a file, via its job_id → expected_jobs.
+
+        Single source for the file→platform mapping used by both the
+        per-platform file floor (selection) and the round-robin scraper read.
+        Returns 'unknown' for keys without a job_id or jobs without a platform.
+        """
+        if '/job_id=' not in file_key:
+            return 'unknown'
+        job_id = file_key.split('/job_id=')[1].split('/')[0]
+        job_config = expected_jobs.get(job_id, {})
+        params = job_config.get('params', {}) if isinstance(job_config, dict) else {}
+        return str(params.get('platform', 'unknown')).lower()
 
     # Rate-limits the crash-orphan sweep (recurring, at most once per interval,
     # so a hard kill's orphans are reclaimed within ~TEMP_ORPHAN_AGE_SECS instead
@@ -1937,46 +1989,90 @@ class DuckDBSampledValidator:
         """
         all_entities = []
 
-        # UNIFORM random file order + a small FIXED per-file row quota.
+        # ROUND-ROBIN read across platforms + a small FIXED per-file row quota.
         #
-        # File *selection* is already row-weighted, and force-includes the top-5
-        # files by claimed rows (see validate_miner_s3_data), so the files that
-        # drive effective_size are guaranteed to be in `sampled_files` before we
-        # get here. Weighting a second time — a row-weighted order plus a
-        # row-proportional per-file budget — let the single largest file absorb
-        # the entire pool: at 20 rows/file the 40-row pool was full after two
-        # files, so all 20 validated entities came from one or two files of one
-        # platform. That is steerable on purpose: shrink the X jobs until Reddit
-        # holds nearly all claimed rows and the X leg is never scraper-checked
-        # at all, which also makes the per-platform bar vacuous (a platform with
-        # no entities in the pool has nothing to hold to MIN_SCRAPER_SUCCESS).
+        # Two miner-steerable holes had to close together:
         #
-        # Uniform over files with <= SCRAPER_ROWS_PER_FILE rows each needs at
-        # least 8 distinct files to fill the pool, so every sampled job has a
-        # real chance of contributing and the per-platform floor below has
-        # something to draw from. Large files keep their advantage where it is
-        # earned: they are far more likely to be *selected* in the first place.
+        #   1. Per-file budget derived from the miner's declared row counts let
+        #      the single largest file absorb the whole pool (all 20 entities
+        #      from one or two files of one platform). Fixed at
+        #      SCRAPER_ROWS_PER_FILE, so no file's share depends on what the
+        #      miner claims.
+        #
+        #   2. A plain uniform shuffle + "stop once the pool is full" still let
+        #      the majority platform starve the minority: if its files shuffle
+        #      first they fill the 40-entity pool before any minority file is
+        #      opened, so 20/20 land on one platform and the minority leg is
+        #      never scraper-checked — its per-platform bar vacuous (a platform
+        #      with 0 entities in the pool has nothing to hold to
+        #      MIN_SCRAPER_SUCCESS). This was still reproducible after fix 1.
+        #
+        # Read the files interleaved by platform and keep going, past the pool
+        # cap if needed, until every platform present has reached the entity
+        # floor (or run out of files). Combined with the per-platform FILE floor
+        # at selection (validate_miner_s3_data guarantees each platform HAS
+        # files here), every platform earning row credit is now checked.
         sampled_files = list(sampled_files)
-        self._rng.shuffle(sampled_files)
+
+        files_by_platform: Dict[str, list] = {}
+        for f in sampled_files:
+            plat = self._file_platform(f.get('key', ''), expected_jobs)
+            files_by_platform.setdefault(plat, []).append(f)
+        for plat in files_by_platform:
+            self._rng.shuffle(files_by_platform[plat])
 
         # Pool target: twice the number of entities we finally validate, so the
         # per-platform floor and the random draw below have slack to work with.
         entity_pool_target = num_entities * 2
+        # Each platform must reach the entity floor so its per-platform bar
+        # (MIN_SCRAPER_SUCCESS over >= SCRAPER_PLATFORM_MIN_ENTITIES) binds.
+        per_platform_target = self.SCRAPER_PLATFORM_MIN_ENTITIES
 
-        # The quota is raised only when the sample holds too few files to fill
-        # the pool at the base rate — a small miner (fewer than 10 files in
-        # total) must not end up with a SMALLER scraper sample than before this
-        # change. It stays the same number for every file either way: what
-        # makes the draw unsteerable is that no file's share depends on the row
-        # count the miner declares, not the size of the share itself.
+        # Flat per-file quota, raised only when the whole sample is too small to
+        # fill the pool. Same number for every file — never derived from
+        # miner-declared rows, so no file's share depends on the miner's claim.
         rows_per_file = self.SCRAPER_ROWS_PER_FILE
         if sampled_files and len(sampled_files) * rows_per_file < entity_pool_target:
             rows_per_file = math.ceil(entity_pool_target / len(sampled_files))
 
-        for file_info in sampled_files:
+        # Interleave: [platA[0], platB[0], platA[1], platB[1], ...] then the tail
+        # of the longer platform. Reading in this order guarantees every platform
+        # contributes before the pool cap could end the scan.
+        read_order: List[Dict] = []
+        if files_by_platform:
+            longest = max(len(v) for v in files_by_platform.values())
+            for i in range(longest):
+                for plat, files in files_by_platform.items():
+                    if i < len(files):
+                        read_order.append(files[i])
 
-            if len(all_entities) >= entity_pool_target:
+        per_platform_counts: Dict[str, int] = {p: 0 for p in files_by_platform}
+        attempted: Dict[str, int] = {p: 0 for p in files_by_platform}
+
+        def _some_platform_below_floor() -> bool:
+            # True while a platform is short of the floor AND still has files
+            # left to read. Bounds the loop: an exhausted platform stops blocking.
+            return any(
+                per_platform_counts[p] < per_platform_target
+                and attempted[p] < len(files_by_platform[p])
+                for p in files_by_platform
+            )
+
+        for file_info in read_order:
+
+            # Stop only when the pool is full AND no platform is still short of
+            # its floor. A minority platform keeps being read past the cap until
+            # it clears the floor (bounded — it has few files).
+            if len(all_entities) >= entity_pool_target and not _some_platform_below_floor():
                 break
+
+            plat_of_file = self._file_platform(file_info.get('key', ''), expected_jobs)
+            # Once the pool is full, don't read more of an already-satisfied
+            # platform — only the still-short ones.
+            if (len(all_entities) >= entity_pool_target
+                    and per_platform_counts.get(plat_of_file, 0) >= per_platform_target):
+                continue
+            attempted[plat_of_file] = attempted.get(plat_of_file, 0) + 1
 
             # Skip oversized files to prevent OOM
             file_size = file_info.get('size', 0)
@@ -2072,6 +2168,7 @@ class DuckDBSampledValidator:
                             ],
                         }
                     all_entities.append((entity, platform, job_id))
+                    per_platform_counts[platform] = per_platform_counts.get(platform, 0) + 1
 
                 del df
             except:

--- a/vali_utils/s3_utils.py
+++ b/vali_utils/s3_utils.py
@@ -243,14 +243,38 @@ class DuckDBSampledValidator:
     MAX_EMPTY_RATE = 10.0       # 10% max empty content
     # Missing URLs = instant fail (no rate threshold needed)
     MIN_JOB_MATCH_RATE = 95.0   # 95% min job content match rate
-    MIN_SCRAPER_SUCCESS = 80.0  # 80% min scraper success rate
+    MIN_SCRAPER_SUCCESS = 80.0  # 80% min COMBINED scraper success rate (all platforms)
     MIN_ENGAGEMENT_RATE = 95.0  # 95% of X rows must have non-null view_count
     MIN_UNIQUE_CONTENT_RATIO = 10.0  # 10% min unique tweet_ids / total rows
+
+    # Per-platform scraper bar — deliberately LOOSER than the combined bar.
+    #
+    # The per-platform check runs on a tiny sample (SCRAPER_PLATFORM_MIN_ENTITIES
+    # = 5), where one extra flaky lookup swings the rate 20 points. At an 80%
+    # bar (fail on >=2/5) an HONEST platform whose rows are all real still fails
+    # purely from irreducible noise — deleted/edited posts, third-party rate
+    # limits, stale historical rows — on ~8% of cycles at 10% lookup-noise and
+    # ~26% at 20% (binomial, measured). That mis-FAILs the whole miner and
+    # decays credibility for something they don't control.
+    #
+    # 60% (fail only on >=3/5) drops that honest false-positive rate to ~0.9%
+    # / ~5.8% while still catching a platform that is MOSTLY fabricated. The
+    # COMBINED bar stays at MIN_SCRAPER_SUCCESS = 80%, so wholesale fabrication
+    # and a dirty MAJORITY platform are still caught there; this only relaxes
+    # the case where a MINORITY platform sits between 60% and 80% real.
+    #
+    # NOTE: this partially relaxes the per-platform strictness added in #901
+    # (which used the combined 80% here). Maintainers can retune via this
+    # constant; the statistically cleaner fix for the small-sample noise is a
+    # larger per-platform floor or an absolute-failure allowance, left as a
+    # follow-up so this change stays minimal.
+    MIN_SCRAPER_SUCCESS_PER_PLATFORM = 60.0
 
     # Per-platform scraper-sampling floor. Every platform with claimed rows in
     # the sampled files gets at least this many rows scraper-validated,
     # regardless of the random draw, and each platform reaching the floor is
-    # held to MIN_SCRAPER_SUCCESS on its own rather than in a combined rate.
+    # held to MIN_SCRAPER_SUCCESS_PER_PLATFORM on its own rather than only in
+    # the combined rate.
     SCRAPER_PLATFORM_MIN_ENTITIES = 5
 
     # Rows drawn from each file during the scraper phase. Small and FIXED, not
@@ -2517,7 +2541,13 @@ class DuckDBSampledValidator:
         )
 
     def _per_platform_issues(self, platform_stats: Dict[str, Dict[str, int]]) -> List[str]:
-        """Issues for platforms that fail MIN_SCRAPER_SUCCESS on their own sample.
+        """Issues for platforms below MIN_SCRAPER_SUCCESS_PER_PLATFORM on their
+        own sample.
+
+        The per-platform bar (60%) is looser than the combined bar (80%): the
+        sample is only SCRAPER_PLATFORM_MIN_ENTITIES rows, so an honest platform
+        would mis-fail on normal lookup noise at 80% (see the constant). The
+        combined MIN_SCRAPER_SUCCESS check remains the strict gate.
 
         Only platforms with at least SCRAPER_PLATFORM_MIN_ENTITIES validated
         entities are held to the bar — below that, one bad row would swing the
@@ -2529,7 +2559,7 @@ class DuckDBSampledValidator:
             if validated < self.SCRAPER_PLATFORM_MIN_ENTITIES:
                 continue
             rate = stats.get('passed', 0) / validated * 100.0
-            if rate < self.MIN_SCRAPER_SUCCESS:
+            if rate < self.MIN_SCRAPER_SUCCESS_PER_PLATFORM:
                 issues.append(f"Low {plat} scraper success: {rate:.1f}%")
         return issues
 


### PR DESCRIPTION
## Summary

Follow-ups to the S3 quality-scoring rollout (#901 / #902), from running it against live miner data. Five fixes in two groups:

**Scoring** — the credibility update penalised the two things an honest miner does every cycle (pass validation, upload more data), and the per-platform bar was sized for a sample far larger than the one it actually runs on.

**Validation integrity** — the entity draw was steerable by numbers the *miner* declares. In the worst case a miner forced all 20/20 scraper-validated entities onto a single platform, leaving the other platform's data never checked at all while it still earned row credit.

**The 2× OD cap on the raw S3 boost is untouched.** So is the failure path (retain `effective_size`, decay credibility geometrically), and so is the combined 80% scraper gate.

| # | Problem | Fix | Commit |
|---|---|---|---|
| 1 | Credibility drops on cycles the miner **passed** — once for an imperfect pass rate, once for having uploaded | EMA toward 1.0 on PASS; `pass_rate` becomes telemetry | `95fea35` |
| 2 | Per-file row budget derived from miner-declared row counts → 1–2 files own the whole sample | Uniform file shuffle + flat per-file quota | `212818d` |
| 3 | A row group padded with duplicate URLs makes the reader return `None` → file **silently skipped** | Dedup before sizing the draw | `ed69d3b` |
| 4 | File **selection** is platform-blind → a whole platform never enters the sample (observed: 20/20 Reddit, zero X) | Per-platform file floor + round-robin read | `7d8bbdc` |
| 5 | Per-platform bar at 80% mis-fails honest miners on a 5-row sample | Split the constant: 80% combined, 60% per-platform | `e08cfec` |

---

## 1. Passing validation must not cost credibility

`rewards/miner_scorer.py::update_s3_effective_size`

### Problem

**a) The pass EMA targeted the observed scraper pass rate.** `MIN_SCRAPER_SUCCESS` already decides pass/fail on that exact sample, so grading the EMA target by the same number charges the miner twice for one sample. 20 live scraper lookups carry irreducible noise (deleted posts, rate limits, stale rows), so 18–19/20 is a normal honest cycle — it reported `is_valid=True` and still pulled credibility down.

**b) Claimed-size growth scaled credibility by `(old/new)^(1/2.5)`.** That rule is P2P's, where score grows directly with claimed bytes so the tax is what stops volume inflation. S3 is shaped differently: the boost is capped at 2×OD **before** credibility (`_s3_component`), so past the cap extra volume buys nothing. Meanwhile miners are supposed to keep crawling the desirability list and uploading, so `new > old` on virtually every honest pass. The multiplier shrank every cycle while the capped boost stayed flat — **uploading more data was strictly negative EV**, judged before anything is known about whether that data is real. Fabricated volume is what the validation gate and the failure path are for.

Steady state for an honest miner growing 8%/cycle (α=0.30, exponent 2.5):

| scraper result each cycle | old: cred → multiplier | new: cred → multiplier |
|---|---|---|
| 19/20 (honest noise) | 0.887 → **0.741** | 1.0 → 1.0 |
| 20/20 (perfect) | 0.934 → **0.843** | 1.0 → 1.0 |

A permanently-passing miner was permanently docked 16–26% of its capped S3 component, and the only way to stop the growth tax was to stop uploading.

### Solution

On PASS: update `effective_size`, EMA credibility toward 1.0 — the pre-rollout rule. The bar decides pass/fail; credibility tracks how consistently the miner clears it. P2P's prove-it rule in `on_miner_evaluated` is unchanged. `pass_rate` stays on the result, in the published blob and in the scorer log as telemetry, so follower validators stay consistent with the primary.

**No state reset.** Credibilities depressed by these rules recover through the normal EMA within a few cycles — gentler than resetting everyone to `STARTING_S3_CREDIBILITY = 0.1`.

## 2. The entity draw must not be steerable by declared row counts

`vali_utils/s3_utils.py::_perform_scraper_validation`

### Problem

The phase ranked sampled files by claimed rows and gave each a row-proportional budget of up to 20 rows — both knobs read the row count the **miner** writes into its own filenames. Keep Reddit jobs huge, shrink X jobs, and the two biggest Reddit files sort first *and* take 20 rows each, filling the 40-row pool before any other file is opened.

### Solution

- **File order**: `rng.shuffle` — uniform. The prefix of a shuffle is a uniform random subset; there is no sort key left to feed.
- **Per-file quota**: flat `SCRAPER_ROWS_PER_FILE = 5`, so filling the 2×`num_entities` pool needs ≥8 **distinct** files. If the whole sample is too small to fill the pool at 5 each, the quota rises to `ceil(pool/len(files))` — still identical for every file, so a small miner does not end up with a *smaller* sample than before.
- **Final selection**: per-platform floors first (claimed rows used only as a boolean "has rows", never as a weight), then uniform random fill; when floors over-subscribe the budget the selection is shuffled before truncation.

Large files keep their advantage at the layer where it is earned: file *selection* in `validate_miner_s3_data` is already row-weighted and force-includes the top-5 by claimed rows. Weighting them again inside this phase was double counting — and it was the half the miner controlled.

## 3. Duplicate-URL padding must not make a file unsampleable

`vali_utils/parquet_reader.py::read_random_row_group`

### Problem

The draw was sized from the **pre-dedup** frame:

```python
df.drop_duplicates(subset=['url']).sample(n=min(max_rows, len(df)), ...)
```

If the drawn row group holds fewer unique URLs than `max_rows`, `sample()` raises, the broad `except` returns `None`, and the caller silently skips the file. One padded row group (10k rows, a handful of unique URLs) is ~0.3% of a 3M-row file — **under the 1% within-job duplicate gate** — yet whenever the group draw lands on it, that file escapes both job-content matching (`max_rows=100`) and scraper validation. A craftable "unsampleable file", in the phase whose stated invariant is that sampled rows never disappear silently. Separately, a group with ≤ `max_rows` rows skipped dedup entirely, so copies of one real row could fill a whole per-file quota.

### Solution

Dedup first, always (when a `url` column is present), and size the draw from the deduped frame — the unique rows come back and get validated, pointing the scrapers at exactly the rows the padding was hiding. Frames read without a `url` column keep plain sampling.

## 4. Every platform must actually be scraper-checked

`vali_utils/s3_utils.py` — `validate_miner_s3_data` + `_perform_scraper_validation`

### Problem

Even after §2, a miner could still force **20/20 entities onto one platform**. Two platform-blind spots remained:

**a) Selection is platform-blind.** All four file-sampling slices — row-weighted, uniform-over-jobs, suspicion, top-5 force-include — key off claimed rows or job id, never platform. Shrink the X jobs to a handful of claimed rows and the weighted draw and top-5 pick only the big Reddit files: **no X file enters `sampled_files` at all**, so the scraper phase cannot produce a single X entity. The per-platform bar from #901 is then vacuous — a platform with zero entities has nothing to hold to a threshold — and X data earns row credit having never been validated.

**b) The read loop could still starve the minority.** A plain uniform shuffle plus "stop once the pool is full" means that if the majority platform's files shuffle first, they fill the 40-entity pool before any minority file is opened.

### Solution

- **Per-platform FILE floor at selection**: force in each active platform's highest-claim files until it has ≥ `SCRAPER_PLATFORM_MIN_FILES = 2` in the sample. Every platform earning row credit now has files inspected.
- **Round-robin read**: read files interleaved by platform, and keep reading past the pool cap until every platform reaches `SCRAPER_PLATFORM_MIN_ENTITIES` (or runs out of files). Bounded — a starved platform has few files by construction.
- Factored the file→platform lookup into `DuckDBSampledValidator._file_platform` (previously duplicated inline).

Together these guarantee each platform reaches the entity floor, so its per-platform bar **actually binds**.

**Cost:** a few extra small files read per cycle (the miner shrank them, so they are cheap), and they are already in the eval-scoped local cache from the dedup phase — local reads, not extra network round trips.

## 5. Size the per-platform bar to the sample it runs on

`vali_utils/s3_utils.py::_per_platform_issues`

### Problem

The per-platform bar introduced in #901 reused `MIN_SCRAPER_SUCCESS` (80%), but it runs on a sample of only `SCRAPER_PLATFORM_MIN_ENTITIES = 5` rows, where one extra flaky lookup swings the rate 20 points. At 80% a platform fails on ≥2/5 — and 2/5 is ordinary noise, not fabrication.

Binomial false-positive rate for an **honest** platform whose rows are all real:

| per-lookup noise | bar 80% (fail ≥2/5) | bar 60% (fail ≥3/5) |
|---|---|---|
| 5% | 2.3% | 0.1% |
| 10% | **8.1%** | 0.9% |
| 15% | **16.5%** | 2.7% |
| 20% | **26.3%** | 5.8% |

At realistic noise an honest miner was mis-FAILED on 8–26% of cycles — losing effective_size growth and decaying credibility for something outside its control.

### Solution

Split the constant rather than moving it:

- `MIN_SCRAPER_SUCCESS = 80.0` — the **combined** gate over all platforms, unchanged. Wholesale fabrication and a dirty *majority* platform are still caught exactly as before.
- `MIN_SCRAPER_SUCCESS_PER_PLATFORM = 60.0` — the small-sample per-platform check, sized to its own noise floor.

**Tradeoff, stated plainly:** this relaxes #901 for the specific case of a *minority* platform sitting between 60% and 80% real. It does not open the combined gate, and it is no longer combinable with hiding a platform from validation entirely (§4). The statistically cleaner fix for small-sample noise is a larger per-platform floor or an absolute-failure allowance; left as a follow-up so this change stays minimal and tunable via the constant. A guard test pins `MIN_SCRAPER_SUCCESS` at 80.0 so a future edit cannot silently lower the combined gate along with it.

---

## Testing

```bash
python -m pytest tests/rewards/test_s3_quality_scoring.py \
                 tests/vali_utils/test_scraper_entity_sampling.py \
                 tests/vali_utils/test_single_platform_resistance.py \
                 tests/vali_utils/test_committed_sampling.py \
                 tests/vali_utils/test_index_fail_freeze.py \
                 tests/vali_utils/test_s3_latest_per_job.py \
                 tests/vali_utils/test_s3_x_snowflake.py \
                 tests/rewards/test_miner_scorer_state.py -q
```

| Suite | Result | Covers |
|---|---|---|
| `test_s3_quality_scoring.py` | 16 passed | credibility rules, cap ordering, per-platform bar |
| `test_scraper_entity_sampling.py` | 9 passed, 27 subtests | the entity draw, stage by stage |
| `test_single_platform_resistance.py` | 6 passed, 65 subtests | end-to-end + fuzz single-platform resistance |
| `test_committed_sampling.py` | 16 passed | committed RNG, row-group reads, padding |

**New — `test_single_platform_resistance.py`.** Drives the **whole** sampling path through `validate_miner_s3_data` on real parquet files: the real selection stage *and* the real round-robin read both execute, with only the external scraper call and the unrelated DuckDB/job-match phases mocked. A spy on `_validate_with_scraper` counts how many entities of each platform actually reached a scraper — the exact quantity the manipulation drove to zero. Cases: the reported layout (30 Reddit jobs dwarfing 2 X jobs) over 10 committed seeds; a platform with a single file; the widest claim skew the validator's own `MIN_BYTES_PER_ROW` gate permits; **reverse skew** (Reddit as minority — the guarantee is symmetric); balanced layouts; and a 25-case fuzz over random file counts and random choice of which platform is shrunk.

**Mutation-tested**, so these fail for the right reason rather than passing by construction:

| Fix disabled | Failures |
|---|---|
| selection per-platform FILE floor | **29** |
| round-robin read → plain shuffle + hard pool cap | **10** |

Restoring either makes the suite green again.

**New — `test_scraper_entity_sampling.py`.** Builds the §2 manipulation on real parquet (3 Reddit files claiming 3,000,000 rows vs 6 X files claiming 1,000) registered in the validator's local-file cache exactly as the download phase does. Asserts X clears the per-platform floor on **all 12 RNG seeds** (pre-fix: fails every seed with `x: validated=2`); ≥8 distinct files feed the pool; the per-file quota is identical across files despite the 3000× claim skew; a 3-file miner still fills the full 20-entity sample; the draw replays exactly under a fixed committed seed. A separate `TestSelectionPlatformFloor` drives `validate_miner_s3_data` with 30 Reddit jobs vs 2 X jobs and asserts X files survive selection across 15 committed seeds — **all 15 fail on the pre-fix selection stage.**

**Extended — `test_committed_sampling.py`**: a duplicate-URL-padded row group returns its unique rows instead of `None`; a short row group is still deduped; frames without a `url` column keep plain sampling. The first two fail on pre-fix code.

**Updated — `test_s3_quality_scoring.py`**: pass-rate independence (two passing miners with different observed rates end at identical credibility); growth-vs-flat credibility parity over 20 cycles; proof the capped S3 component is flat in volume (1e12 → 1e15 `effective_size`, identical score) — which is *why* growth needs no credibility tax; and the new 80/60 split. The #901/#902 tests for cap-before-credibility ordering, `S3=0` without OD, and failure decay are unchanged and still pass.

**Full suites** (`tests/rewards` + `tests/vali_utils`): **152 passed, 100 subtests**, 8 failed — the identical 8 fail on an unmodified `dev` checkout (`test_data_value_calculator` ×4, `test_eval_batch_concurrency` ×1, `test_od_flow` ×3), and `tests/rewards/test_miner_scorer.py` errors at collection on `dev` (`module 'rewards.data_value_calculator' has no attribute 'dt'`). None are touched by this PR.

## Notes for reviewers

- Committed sampling is preserved end to end — every draw (file shuffle, round-robin order, row group, rows, floors, fill) goes through `self._rng`, seeded from H(block hash ‖ hotkey ‖ manifest). Unpredictable at upload time, exactly reproducible afterwards.
- `pass_rate` and `hard_invalid` remain in the published results blob, so follower validators are unaffected.
- The tunable constants are all in one place on `DuckDBSampledValidator`: `MIN_SCRAPER_SUCCESS` (80), `MIN_SCRAPER_SUCCESS_PER_PLATFORM` (60), `SCRAPER_PLATFORM_MIN_ENTITIES` (5), `SCRAPER_PLATFORM_MIN_FILES` (2), `SCRAPER_ROWS_PER_FILE` (5).
- §5 is the one change that *loosens* a check. If maintainers prefer to keep #901's strictness, dropping the last commit (`e08cfec`) leaves fixes 1–4 intact and self-contained.
