### PR TITLE
fix(s3): guarantee every platform and every file size gets audited; size the per-platform bar to its sample

### DIFF
--- a/tests/rewards/test_s3_quality_scoring.py
+++ b/tests/rewards/test_s3_quality_scoring.py
@@ -41,8 +41,9 @@ class TestS3QualityScoring(unittest.TestCase):
     def test_pass_ema_targets_one_whatever_the_pass_rate(self):
         """Passing is the signal; the observed rate must not grade it again.
 
-        MIN_SCRAPER_SUCCESS already refuses anything under 80% (per platform and
-        combined), so a reported pass means the sample cleared the bar. Grading
+        MIN_SCRAPER_SUCCESS already refuses anything under 80% combined (and
+        under 60% per platform), so a reported pass means the sample cleared
+        the bars. Grading
         the EMA target by the rate on top of that made an honest 19/20 cycle —
         one deleted post, one rate-limited lookup — pull credibility DOWN.
         """
@@ -163,20 +164,30 @@ class TestPerPlatformBar(unittest.TestCase):
         # _per_platform_issues only touches class constants; skip __init__.
         self.validator = object.__new__(DuckDBSampledValidator)
 
-    def test_dirty_x_leg_cannot_hide_behind_clean_reddit(self):
-        """3/5 X + 15/15 Reddit = 90% combined (passes the combined bar) but the
-        X leg alone is 60% — dirty X hidden behind clean Reddit ballast."""
+    def test_mostly_fabricated_platform_is_flagged(self):
+        """A platform BELOW the 60% per-platform bar (2/5 = 40%) is still
+        caught on its own, even hidden behind clean Reddit ballast."""
         issues = self.validator._per_platform_issues({
-            'x': {'validated': 5, 'passed': 3},
+            'x': {'validated': 5, 'passed': 2},          # 40% < 60%
             'reddit': {'validated': 15, 'passed': 15},
         })
         self.assertEqual(len(issues), 1)
         self.assertIn('x', issues[0])
-        self.assertIn('60.0', issues[0])
+        self.assertIn('40.0', issues[0])
+
+    def test_sixty_percent_leg_passes_per_platform_bar(self):
+        """3/5 = 60% is intentionally allowed at the per-platform level: on a
+        5-row sample it's within honest lookup noise. The combined 80% bar
+        (checked in validate_miner_s3_data, not here) remains the strict gate."""
+        issues = self.validator._per_platform_issues({
+            'x': {'validated': 5, 'passed': 3},          # 60% == bar
+            'reddit': {'validated': 15, 'passed': 15},
+        })
+        self.assertEqual(issues, [])
 
     def test_clean_platforms_produce_no_issues(self):
         issues = self.validator._per_platform_issues({
-            'x': {'validated': 5, 'passed': 4},       # 80% == bar
+            'x': {'validated': 5, 'passed': 4},         # 80%
             'reddit': {'validated': 15, 'passed': 14},  # 93%
         })
         self.assertEqual(issues, [])
@@ -188,6 +199,12 @@ class TestPerPlatformBar(unittest.TestCase):
             'x': {'validated': 2, 'passed': 0},
         })
         self.assertEqual(issues, [])
+
+    def test_combined_bar_unchanged_at_80(self):
+        """Guard: the split lowered only the per-platform constant. The combined
+        gate stays 80% so wholesale fabrication is still caught."""
+        self.assertEqual(DuckDBSampledValidator.MIN_SCRAPER_SUCCESS, 80.0)
+        self.assertEqual(DuckDBSampledValidator.MIN_SCRAPER_SUCCESS_PER_PLATFORM, 60.0)
 
 
 if __name__ == '__main__':

--- a/tests/vali_utils/test_scraper_entity_sampling.py
+++ b/tests/vali_utils/test_scraper_entity_sampling.py
@@ -182,10 +182,12 @@ class TestPlatformCoverage(ScraperSamplingFixture):
         import vali_utils.s3_utils as s3_utils
         original = s3_utils.read_random_row_group
 
+        # NB: never assert inside the spy — _perform_scraper_validation wraps the
+        # read in a bare `except: continue`, which swallows AssertionError and
+        # turns a real failure into a silently skipped file (a test that passes
+        # for the wrong reason). Collect here, assert after the run.
         def _spy(source, size, **kwargs):
             seen_files.append(source)
-            self.assertEqual(kwargs.get('max_rows'),
-                             DuckDBSampledValidator.SCRAPER_ROWS_PER_FILE)
             return original(source, size, **kwargs)
 
         with patch.object(s3_utils, 'read_random_row_group', side_effect=_spy):
@@ -210,13 +212,33 @@ class TestPerFileQuota(ScraperSamplingFixture):
             self._run()
         return quotas
 
-    def test_quota_is_identical_for_every_file(self):
-        """The Reddit files claim 3000x the rows of the X files; the quota the
-        phase asks each of them for must be the same number."""
+    def test_no_file_is_starved_by_another_files_claim(self):
+        """The exploitable property was a per-file budget PROPORTIONAL to
+        claimed rows: a tiny-claim file got ~2 rows while a mega file took 20,
+        so mega files filled the pool. Every file must now get at least the base
+        quota no matter what any other file claims."""
         quotas = self._quotas_seen()
         self.assertGreater(len(quotas), 1)
-        self.assertEqual(len(set(quotas)), 1, f"per-file quota varied: {quotas}")
-        self.assertEqual(quotas[0], DuckDBSampledValidator.SCRAPER_ROWS_PER_FILE)
+        self.assertTrue(
+            all(q >= DuckDBSampledValidator.SCRAPER_ROWS_PER_FILE for q in quotas),
+            f"a file was starved below the base quota: {quotas}",
+        )
+
+    def test_surplus_is_bounded_and_only_for_top_claim_files(self):
+        """Claimed rows may only ADD depth, to a bounded number of files at a
+        bounded size — never scale a budget continuously the way the exploited
+        version did."""
+        quotas = self._quotas_seen()
+        base = DuckDBSampledValidator.SCRAPER_ROWS_PER_FILE
+        elevated = [q for q in quotas if q > base]
+        self.assertTrue(
+            all(q == DuckDBSampledValidator.SCRAPER_TOP_FILE_ROWS for q in elevated),
+            f"surplus quota is not a fixed size: {quotas}",
+        )
+        self.assertLessEqual(
+            len(elevated), DuckDBSampledValidator.SCRAPER_TOP_FILE_COUNT,
+            f"more files elevated than SCRAPER_TOP_FILE_COUNT: {quotas}",
+        )
 
     def test_small_miner_still_gets_a_full_sample(self):
         """A miner with too few files to fill the pool at 5 rows each must not
@@ -224,10 +246,10 @@ class TestPerFileQuota(ScraperSamplingFixture):
         used to give it. The quota rises; it stays uniform across files."""
         self.files = self.files[:3]  # the 3 Reddit files — 3 x 5 < 40-row pool
         quotas = self._quotas_seen()
-        self.assertEqual(len(set(quotas)), 1, f"per-file quota varied: {quotas}")
-        self.assertGreaterEqual(quotas[0], DuckDBSampledValidator.SCRAPER_ROWS_PER_FILE)
+        self.assertTrue(all(q >= DuckDBSampledValidator.SCRAPER_ROWS_PER_FILE
+                            for q in quotas), quotas)
         # 3 files x quota must still cover the 2 x num_entities pool.
-        self.assertGreaterEqual(quotas[0] * 3, 40)
+        self.assertGreaterEqual(sum(quotas), 40)
         self.assertEqual(self._run()['entities_validated'], 20)
 
 

--- a/tests/vali_utils/test_scraper_entity_sampling.py
+++ b/tests/vali_utils/test_scraper_entity_sampling.py
@@ -19,7 +19,7 @@ import os
 import random
 import tempfile
 import unittest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pandas as pd
 
@@ -248,6 +248,93 @@ class TestBudgetInvariants(ScraperSamplingFixture):
         self.validator._rng = random.Random(99)
         second = self._run()
         self.assertEqual(first['sample_results'], second['sample_results'])
+
+
+class TestSelectionPlatformFloor(unittest.TestCase):
+    """The SELECTION stage (validate_miner_s3_data) must put files from every
+    active platform into the sample, even when a miner shrinks one platform's
+    claimed rows to near-zero. Without the per-platform file floor, the
+    row-weighted draw and the top-5 force-include pick only the high-volume
+    platform, so the minority platform's files never reach the scraper phase
+    at all — the observed '20/20 entities Reddit, no X' hole.
+
+    The read phases are mocked; the test asserts on the files handed to
+    _perform_scraper_validation.
+    """
+
+    N_REDDIT_JOBS = 30
+    N_X_JOBS = 2
+    REDDIT_CLAIMED = 100_000
+    X_CLAIMED = 50  # miner shrinks X to almost nothing
+
+    def _files(self):
+        files = []
+        expected_jobs = {}
+        for i in range(self.N_REDDIT_JOBS):
+            jid = f'redditjob{i}'
+            name = f'data_20260801_120000_{self.REDDIT_CLAIMED}_{"a" * 16}.parquet'
+            files.append({'key': f'data/hotkey=hk/job_id={jid}/{name}',
+                          'size': 8_000_000, 'last_modified': f'2026-08-01T00:00:{i:02d}Z'})
+            expected_jobs[jid] = {'params': {'platform': 'reddit'}}
+        for i in range(self.N_X_JOBS):
+            jid = f'xjob{i}'
+            name = f'data_20260801_120000_{self.X_CLAIMED}_{"b" * 16}.parquet'
+            files.append({'key': f'data/hotkey=hk/job_id={jid}/{name}',
+                          'size': 20_000, 'last_modified': f'2026-08-01T00:00:{i:02d}Z'})
+            expected_jobs[jid] = {'params': {'platform': 'x'}}
+        return files, expected_jobs
+
+    def _validator(self, seed):
+        v = DuckDBSampledValidator.__new__(DuckDBSampledValidator)
+        v.wallet = MagicMock()
+        v.sample_percent = 10.0
+        v._seed_material = seed  # deterministic committed RNG per seed
+        v._local_files = {}
+        v._cached_bytes = 0
+        return v
+
+    def _sampled_files_for(self, seed):
+        v = self._validator(seed)
+        files, expected_jobs = self._files()
+
+        captured = {}
+
+        async def _capture_scraper(hotkey, sampled_files, *a, **k):
+            captured['files'] = sampled_files
+            return {'entities_validated': 20, 'entities_passed': 20,
+                    'success_rate': 100.0, 'sample_results': [],
+                    'platform_stats': {'x': {'validated': 5, 'passed': 5},
+                                       'reddit': {'validated': 15, 'passed': 15}}}
+
+        v.s3_reader = MagicMock()
+        v.s3_reader.list_all_files_with_metadata = AsyncMock(return_value=files)
+        v._get_presigned_urls_batch = AsyncMock(
+            return_value={f['key']: 'https://unused.invalid' for f in files})
+        v._sampled_duckdb_validation = AsyncMock(return_value={
+            'duplicate_rate_within_job': 0.0, 'empty_rate': 0.0,
+            'compression_failures': 0, 'row_count_mismatches': 0,
+            'decode_ratio': 1.0,
+        })
+        v._perform_job_content_matching = AsyncMock(return_value={
+            'total_checked': 20, 'total_matched': 20, 'match_rate': 100.0,
+            'mismatch_samples': [],
+        })
+        v._perform_scraper_validation = _capture_scraper
+
+        asyncio.run(v.validate_miner_s3_data('hk', expected_jobs))
+        return captured['files'], expected_jobs
+
+    def test_x_files_survive_selection_despite_tiny_claimed_rows(self):
+        for seed in [f'0x{i:064x}' for i in range(15)]:
+            with self.subTest(seed=seed):
+                sampled, expected_jobs = self._sampled_files_for(seed)
+                x_files = [f for f in sampled
+                           if DuckDBSampledValidator._file_platform(f['key'], expected_jobs) == 'x']
+                self.assertGreaterEqual(
+                    len(x_files), DuckDBSampledValidator.SCRAPER_PLATFORM_MIN_FILES,
+                    f"X shut out of the sample (seed {seed}): "
+                    f"{[f['key'] for f in sampled]}",
+                )
 
 
 if __name__ == '__main__':

--- a/tests/vali_utils/test_scraper_entity_sampling.py
+++ b/tests/vali_utils/test_scraper_entity_sampling.py
@@ -14,6 +14,7 @@ itself mocked.
 """
 
 import asyncio
+import math
 import datetime as dt
 import os
 import random
@@ -361,3 +362,98 @@ class TestSelectionPlatformFloor(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class TestMegaFileCannotOwnTheAudit(unittest.TestCase):
+    """A few multi-million-row files must not consume the whole entity budget.
+
+    Two files at SCRAPER_TOP_FILE_ROWS already equal the 2 x num_entities pool,
+    so without the breadth floor the scan would stop after reading exactly those
+    two, and without the long-tail reservation the weighted fill would hand them
+    every leftover slot. Both are guarantees, not tendencies, so they are
+    asserted over many seeds including the worst one.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+
+    def _layout(self, claims):
+        files, jobs, local = [], {}, {}
+        for i, c in enumerate(claims):
+            jid = ('big' if c >= 1_000_000 else 'sm') + str(i)
+            name = f'data_20260801_120000_{c}_{"a" * 16}.parquet'
+            key = f'data/hotkey=hk/job_id={jid}/{name}'
+            path = os.path.join(self.tmp.name, f'{jid}.parquet')
+            _reddit_frame(80, jid).to_parquet(path, row_group_size=20)
+            files.append({'key': key, 'size': os.path.getsize(path)})
+            local[key] = path
+            jobs[jid] = {'params': {'platform': 'reddit'}}
+        return files, jobs, local
+
+    def _run(self, claims, seed):
+        files, jobs, local = self._layout(claims)
+        v = DuckDBSampledValidator.__new__(DuckDBSampledValidator)
+        v._rng = random.Random(seed)
+        v._local_files = dict(local)
+        v._cached_bytes = 0
+
+        import vali_utils.s3_utils as s3_utils
+        original = s3_utils.read_random_row_group
+        reads = []
+
+        def _spy(source, size, **kw):
+            reads.append(source)
+            return original(source, size, **kw)
+
+        async def _all_valid(entities, platform):
+            return [ValidationResult(is_valid=True, reason='ok',
+                                     content_size_bytes_validated=10)
+                    for _ in entities]
+
+        with patch.object(s3_utils, 'read_random_row_group', side_effect=_spy), \
+             patch.object(DuckDBSampledValidator, '_validate_with_scraper',
+                          new=AsyncMock(side_effect=_all_valid)):
+            res = asyncio.run(v._perform_scraper_validation(
+                'hk', list(files), jobs,
+                {f['key']: 'https://unused.invalid' for f in files},
+                num_entities=20))
+        small = sum(1 for line in res['sample_results']
+                    if line.split('(')[1].split(')')[0].startswith('sm'))
+        return len(set(reads)), small, res
+
+    def test_two_mega_files_cannot_stop_the_scan(self):
+        """2 x SCRAPER_TOP_FILE_ROWS fills the pool exactly; the breadth floor
+        must keep reading anyway."""
+        need = math.ceil(40 / DuckDBSampledValidator.SCRAPER_ROWS_PER_FILE)
+        for seed in range(10):
+            with self.subTest(seed=seed):
+                distinct, _, _ = self._run([3_000_000] * 2 + [500] * 8, seed)
+                self.assertGreaterEqual(
+                    distinct, need,
+                    f"only {distinct} files read — the mega files ended the scan")
+
+    def test_smaller_files_keep_a_guaranteed_share(self):
+        """Not merely 'on average': every seed must give the files outside the
+        top-claim set at least SCRAPER_LONGTAIL_MIN_ENTITIES of the budget."""
+        floor = DuckDBSampledValidator.SCRAPER_LONGTAIL_MIN_ENTITIES
+        for seed in range(20):
+            with self.subTest(seed=seed):
+                _, small, _ = self._run([3_000_000] * 2 + [500] * 8, seed)
+                self.assertGreaterEqual(
+                    small, floor,
+                    f"small files got {small}/20 — below the long-tail floor")
+
+    def test_single_100m_file_does_not_monopolise(self):
+        floor = DuckDBSampledValidator.SCRAPER_LONGTAIL_MIN_ENTITIES
+        for seed in range(10):
+            with self.subTest(seed=seed):
+                distinct, small, res = self._run([100_000_000] + [500] * 14, seed)
+                self.assertGreaterEqual(small, floor, f"small={small}")
+                self.assertEqual(res['entities_validated'], 20)
+
+    def test_big_files_still_take_the_larger_share(self):
+        """The floors must not invert the priority: the files carrying the
+        claim still get most of the budget."""
+        _, small, _ = self._run([3_000_000] * 2 + [500] * 8, 0)
+        self.assertLess(small, 10, "long-tail floor over-served the small files")

--- a/tests/vali_utils/test_single_platform_resistance.py
+++ b/tests/vali_utils/test_single_platform_resistance.py
@@ -154,6 +154,41 @@ class ResistanceHarness(unittest.TestCase):
         return scraped, result
 
 
+    def _run_capture_files(self, bundle, seed):
+        """Run the real selection stage and capture the file list handed to
+        _perform_scraper_validation (i.e. after suspicion picks are stripped)."""
+        files_meta, expected_jobs, local_files = bundle
+        v = DuckDBSampledValidator.__new__(DuckDBSampledValidator)
+        v.wallet = MagicMock()
+        v.sample_percent = 10.0
+        v._seed_material = seed
+        v._local_files = dict(local_files)
+        v._cached_bytes = 0
+        v.scraper_provider = MagicMock()
+        v.s3_reader = MagicMock()
+        v.s3_reader.list_all_files_with_metadata = AsyncMock(return_value=files_meta)
+        v._get_presigned_urls_batch = AsyncMock(
+            return_value={f['key']: 'https://unused.invalid' for f in files_meta})
+        v._sampled_duckdb_validation = AsyncMock(return_value={
+            'duplicate_rate_within_job': 0.0, 'empty_rate': 0.0,
+            'compression_failures': 0, 'row_count_mismatches': 0, 'decode_ratio': 1.0,
+        })
+        v._perform_job_content_matching = AsyncMock(return_value={
+            'total_checked': 20, 'total_matched': 20, 'match_rate': 100.0,
+            'mismatch_samples': [],
+        })
+        captured = {}
+
+        async def _capture(hotkey, sampled_files, *a, **k):
+            captured['keys'] = [f['key'] for f in sampled_files]
+            return {'entities_validated': 20, 'entities_passed': 20,
+                    'success_rate': 100.0, 'sample_results': [],
+                    'platform_stats': {}}
+
+        v._perform_scraper_validation = _capture
+        result = asyncio.run(v.validate_miner_s3_data('hk', expected_jobs))
+        return captured.get('keys', []), result
+
 class TestEndToEndSinglePlatformResistance(ResistanceHarness):
     FLOOR = DuckDBSampledValidator.SCRAPER_PLATFORM_MIN_ENTITIES
 
@@ -241,3 +276,103 @@ class TestResistanceFuzz(ResistanceHarness):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class TestAuditFindings(ResistanceHarness):
+    """Regressions for holes found auditing the platform-coverage fix itself."""
+
+    FLOOR = DuckDBSampledValidator.SCRAPER_PLATFORM_MIN_ENTITIES
+
+    def test_suspicion_picks_do_not_satisfy_the_platform_file_floor(self):
+        """The suspicion slice is detection-only: the caller strips those picks
+        out of scraper_files. Counting them toward a platform's FILE floor
+        therefore satisfies the floor with files the scraper never sees.
+
+        Reachable, not theoretical: _pick_suspicious_files ranks files sharing an
+        exact byte size first, which is exactly the fingerprint of the shrunken,
+        uniform minority-platform files this manipulation produces — so the more
+        suspicious a platform's files look, the more of its floor gets absorbed
+        by picks that are excluded from validation.
+
+        Asserted on the COMPOSITION of scraper_files rather than on downstream
+        scrape counts: the per-file row quota is generous enough that a single
+        surviving file still reaches the entity floor, which masks the defect
+        end-to-end while the guarantee itself is already broken.
+        """
+        bundle = self._bundle([('reddit', 700, 26), ('x', 5, 3)])
+        files_meta, expected_jobs, _ = bundle
+        x_all = [f['key'] for f in files_meta
+                 if DuckDBSampledValidator._file_platform(f['key'], expected_jobs) == 'x']
+
+        def _stub_suspicion(self_, active_files, pool, k):
+            """Route X's files into the detection-only slice, as the real ranker
+            would when they share a byte size."""
+            picks = [it for it in pool if it[0].get('key') in set(x_all)][:k]
+            if len(picks) < k:
+                picks += [it for it in pool
+                          if it[0].get('key') not in set(x_all)][:k - len(picks)]
+            return picks
+
+        for seed in [f'0x{i:064x}' for i in range(10)]:
+            with self.subTest(seed=seed):
+                with patch.object(DuckDBSampledValidator, '_pick_suspicious_files',
+                                  _stub_suspicion):
+                    scraper_files, result = self._run_capture_files(bundle, seed)
+                x_in_scraper = [k for k in scraper_files if k in x_all]
+                # Every X file the suspicion slice did NOT take is eligible, and
+                # the floor must supply min(SCRAPER_PLATFORM_MIN_FILES, eligible)
+                # of them to the scraper phase.
+                n_suspicion_x = len(set(x_all) - set(scraper_files)
+                                    & set(result.suspicion_files))
+                eligible = len(x_all) - n_suspicion_x
+                want = min(DuckDBSampledValidator.SCRAPER_PLATFORM_MIN_FILES, eligible)
+                self.assertGreaterEqual(
+                    len(x_in_scraper), want,
+                    f"X has {len(x_in_scraper)} file(s) in the scraper pool but "
+                    f"{eligible} were eligible — the floor was satisfied by "
+                    f"detection-only suspicion picks",
+                )
+
+    def test_breadth_survives_the_big_file_surplus(self):
+        """The top-claim surplus must buy depth on big files ON TOP of file
+        breadth, not instead of it: 2-3 files at SCRAPER_TOP_FILE_ROWS can fill
+        the entire pool alone, which would collapse coverage back to exactly the
+        files a fabricator wants inspected."""
+        import vali_utils.s3_utils as s3_utils
+        original = s3_utils.read_random_row_group
+        seen = []
+
+        def _spy(source, size, **kwargs):
+            seen.append(source)
+            return original(source, size, **kwargs)
+
+        bundle = self._bundle([('reddit', 400, 12), ('x', 300, 6)])
+        with patch.object(s3_utils, 'read_random_row_group', side_effect=_spy):
+            self._run(bundle, '0x' + '7' * 64)
+
+        expected = 2 * 20 // DuckDBSampledValidator.SCRAPER_ROWS_PER_FILE
+        self.assertGreaterEqual(
+            len(set(seen)), expected,
+            f"file breadth collapsed to {len(set(seen))} distinct files; the "
+            f"surplus quota ate the pool",
+        )
+
+    def test_big_files_get_more_rows_than_the_base_quota(self):
+        """The fairness rules must not leave the effective_size-driving files at
+        5 sampled rows — that is where fabricated volume pays."""
+        import vali_utils.s3_utils as s3_utils
+        original = s3_utils.read_random_row_group
+        quotas = []
+
+        def _spy(source, size, **kwargs):
+            quotas.append(kwargs.get('max_rows'))
+            return original(source, size, **kwargs)
+
+        bundle = self._bundle([('reddit', 700, 10), ('x', 60, 5)])
+        with patch.object(s3_utils, 'read_random_row_group', side_effect=_spy):
+            self._run(bundle, '0x' + '9' * 64)
+
+        self.assertTrue(
+            any(q == DuckDBSampledValidator.SCRAPER_TOP_FILE_ROWS for q in quotas),
+            f"no file received the top-claim surplus quota: {quotas}",
+        )

--- a/tests/vali_utils/test_single_platform_resistance.py
+++ b/tests/vali_utils/test_single_platform_resistance.py
@@ -1,0 +1,243 @@
+"""End-to-end resistance to the 'force all scraper validation onto one platform'
+manipulation.
+
+A miner shrinks the CLAIMED row counts of one platform's jobs (the number it
+writes into its own filenames) so the row-weighted file draw and the top-5
+force-include pick only the high-volume platform. Before the per-platform file
+floor (selection) + round-robin read (scraper phase), that left the minority
+platform with zero scraper-checked entities — its per-platform bar vacuous, all
+20/20 landing on the majority platform (observed live: all Reddit, no X).
+
+Unlike the focused tests in test_scraper_entity_sampling.py, these drive the
+WHOLE sampling path through validate_miner_s3_data on real parquet files: the
+selection stage AND the real scraper read both run, only the external scraper
+call (_validate_with_scraper) and the unrelated DuckDB/job-match phases are
+mocked. The spy on _validate_with_scraper records how many entities of each
+platform actually reached a scraper — the exact quantity the manipulation tried
+to drive to zero.
+
+Claim skew note: the validator rejects files whose size/claimed-rows ratio is
+below MIN_BYTES_PER_ROW (50), so a test cannot pair a 3M-row CLAIM with a tiny
+file the way production pairs it with a GB file. The layouts here keep the ratio
+valid and still make the majority platform's TOTAL claimed rows dwarf the
+minority's — which is all the row-weighted draw and the top-5 force-include key
+off, so the manipulation is faithfully reproduced.
+
+Only x and reddit are used: _create_data_entity builds entities for those two
+platforms (the subnet's scraper-validated sources); other labels would fail
+entity construction by design.
+"""
+
+import asyncio
+import datetime as dt
+import os
+import random
+import tempfile
+import unittest
+from collections import Counter
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pandas as pd
+
+from scraping.scraper import ValidationResult
+from vali_utils.s3_utils import DuckDBSampledValidator
+
+HEX = "0123456789abcdef"
+PHYSICAL_ROWS = 120  # rows actually written per file (keeps files > MIN_FILE_SIZE)
+
+
+def _reddit_frame(n: int, tag: str) -> pd.DataFrame:
+    now = dt.datetime(2026, 8, 1, tzinfo=dt.timezone.utc)
+    return pd.DataFrame({
+        'datetime': [now] * n, 'label': ['r/test'] * n,
+        'id': [f't3_{tag}{i}' for i in range(n)],
+        'username': [f'user{i}' for i in range(n)], 'communityName': ['r/test'] * n,
+        'body': [f'body {tag} {i} lorem ipsum dolor sit amet' for i in range(n)],
+        'title': [f'title {tag} {i} some longer heading text' for i in range(n)],
+        'createdAt': [now] * n, 'dataType': ['post'] * n, 'parentId': [None] * n,
+        'url': [f'https://reddit.com/r/test/comments/{tag}{i}' for i in range(n)],
+        'media': [None] * n, 'is_nsfw': [False] * n, 'score': [1] * n,
+        'upvote_ratio': [0.9] * n, 'num_comments': [0] * n, 'scrapedAt': [now] * n,
+    })
+
+
+def _x_frame(n: int, tag: str) -> pd.DataFrame:
+    now = dt.datetime(2026, 8, 1, tzinfo=dt.timezone.utc)
+    return pd.DataFrame({
+        'datetime': [now] * n, 'label': ['#test'] * n,
+        'username': [f'@user{i}' for i in range(n)],
+        'text': [f'tweet {tag} {i} lorem ipsum dolor sit amet consectetur' for i in range(n)],
+        'tweet_hashtags': [['#test'] for _ in range(n)], 'timestamp': [now] * n,
+        'url': [f'https://x.com/user{i}/status/19{tag}{i:04d}' for i in range(n)],
+        'media': [None] * n, 'user_id': [f'{i}' for i in range(n)],
+        'user_display_name': [f'User {i}' for i in range(n)], 'user_verified': [False] * n,
+        'tweet_id': [f'19{tag}{i:04d}' for i in range(n)],
+        'is_reply': [False] * n, 'is_quote': [False] * n,
+        'conversation_id': [f'19{tag}{i:04d}' for i in range(n)],
+        'in_reply_to_user_id': [None] * n, 'language': ['en'] * n,
+        'in_reply_to_username': [None] * n, 'quoted_tweet_id': [None] * n,
+        'like_count': [1] * n, 'retweet_count': [0] * n, 'reply_count': [0] * n,
+        'quote_count': [0] * n, 'view_count': [10] * n, 'bookmark_count': [0] * n,
+        'user_blue_verified': [False] * n, 'user_description': ['bio'] * n,
+        'user_location': ['earth'] * n, 'profile_image_url': ['https://x.com/i.png'] * n,
+        'cover_picture_url': ['https://x.com/c.png'] * n,
+        'user_followers_count': [5] * n, 'user_following_count': [5] * n,
+        'scraped_at': [now] * n,
+    })
+
+
+class ResistanceHarness(unittest.TestCase):
+    """Builds real parquet files ONCE per layout and drives
+    validate_miner_s3_data with only the scraper call + DuckDB/job-match mocked."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+
+    def _bundle(self, layout):
+        """layout: list of (platform, claimed_rows, count). Builds the files once.
+
+        physical rows are fixed (PHYSICAL_ROWS) so every file clears
+        MIN_FILE_SIZE and keeps size/claimed >= MIN_BYTES_PER_ROW; the CLAIM in
+        the filename is what the row-weighted draw and top-5 key off.
+        """
+        files_meta, expected_jobs, local_files = [], {}, {}
+        jid_n = 0
+        for platform, claimed, count in layout:
+            for _ in range(count):
+                jid_n += 1
+                jid = f'{platform}job{jid_n}'
+                hexs = ''.join(random.Random(jid_n).choice(HEX) for _ in range(16))
+                name = f'data_20260801_120000_{claimed}_{hexs}.parquet'
+                key = f'data/hotkey=hk/job_id={jid}/{name}'
+                path = os.path.join(self.tmp.name, f'{jid}.parquet')
+                frame = (_x_frame if platform == 'x' else _reddit_frame)(PHYSICAL_ROWS, f'{jid_n}')
+                frame.to_parquet(path, row_group_size=20)
+                files_meta.append({'key': key, 'size': os.path.getsize(path),
+                                   'last_modified': f'2026-08-01T00:00:{jid_n % 60:02d}Z'})
+                local_files[key] = path
+                expected_jobs[jid] = {'params': {'platform': platform}}
+        return files_meta, expected_jobs, local_files
+
+    def _run(self, bundle, seed):
+        files_meta, expected_jobs, local_files = bundle
+
+        v = DuckDBSampledValidator.__new__(DuckDBSampledValidator)
+        v.wallet = MagicMock()
+        v.sample_percent = 10.0
+        v._seed_material = seed
+        v._local_files = dict(local_files)
+        v._cached_bytes = 0
+        v.scraper_provider = MagicMock()
+        v.s3_reader = MagicMock()
+        v.s3_reader.list_all_files_with_metadata = AsyncMock(return_value=files_meta)
+        v._get_presigned_urls_batch = AsyncMock(
+            return_value={f['key']: 'https://unused.invalid' for f in files_meta})
+        v._sampled_duckdb_validation = AsyncMock(return_value={
+            'duplicate_rate_within_job': 0.0, 'empty_rate': 0.0,
+            'compression_failures': 0, 'row_count_mismatches': 0, 'decode_ratio': 1.0,
+        })
+        v._perform_job_content_matching = AsyncMock(return_value={
+            'total_checked': 20, 'total_matched': 20, 'match_rate': 100.0,
+            'mismatch_samples': [],
+        })
+
+        scraped = Counter()
+
+        async def _spy_scraper(entities, platform):
+            scraped[platform] += len(entities)
+            return [ValidationResult(is_valid=True, reason='ok',
+                                     content_size_bytes_validated=10) for _ in entities]
+
+        with patch.object(v, '_validate_with_scraper', side_effect=_spy_scraper):
+            result = asyncio.run(v.validate_miner_s3_data('hk', expected_jobs))
+        return scraped, result
+
+
+class TestEndToEndSinglePlatformResistance(ResistanceHarness):
+    FLOOR = DuckDBSampledValidator.SCRAPER_PLATFORM_MIN_ENTITIES
+
+    def test_reproduces_all_reddit_attempt_now_checks_x(self):
+        """30 Reddit jobs whose total claim dwarfs 2 X jobs. The manipulation
+        targeted X → 0; X must now reach its floor, every seed."""
+        bundle = self._bundle([('reddit', 400, 30), ('x', 5, 2)])
+        for seed in [f'0x{i:064x}' for i in range(10)]:
+            with self.subTest(seed=seed):
+                scraped, result = self._run(bundle, seed)
+                self.assertIn('x', scraped, f"X never scraper-checked: {dict(scraped)}")
+                self.assertIn('reddit', scraped)
+                self.assertGreaterEqual(scraped['x'], self.FLOOR, dict(scraped))
+                # No single platform may own the whole validated budget.
+                self.assertLess(scraped['reddit'], result.entities_validated)
+
+    def test_single_x_file_is_still_checked(self):
+        """A platform with only ONE file (the floor clamps to what's available)
+        must still reach a scraper, not be dropped."""
+        bundle = self._bundle([('reddit', 400, 30), ('x', 5, 1)])
+        for seed in [f'0x{i:064x}' for i in range(8)]:
+            with self.subTest(seed=seed):
+                scraped, _ = self._run(bundle, seed)
+                self.assertIn('x', scraped, f"single X file dropped: {dict(scraped)}")
+                self.assertGreaterEqual(scraped['x'], 1)
+
+    def test_max_claim_skew(self):
+        """Widest claim skew that keeps size/claimed >= MIN_BYTES_PER_ROW: X
+        claims 1 row/job. X's files still get forced in and checked."""
+        bundle = self._bundle([('reddit', 500, 20), ('x', 1, 3)])
+        for seed in [f'0x{i:064x}' for i in range(8)]:
+            with self.subTest(seed=seed):
+                scraped, _ = self._run(bundle, seed)
+                self.assertGreaterEqual(scraped['x'], self.FLOOR, dict(scraped))
+
+    def test_reverse_skew_reddit_minority(self):
+        """Symmetry: shrink Reddit instead. Reddit must reach its floor too."""
+        bundle = self._bundle([('x', 400, 20), ('reddit', 5, 2)])
+        for seed in [f'0x{i:064x}' for i in range(8)]:
+            with self.subTest(seed=seed):
+                scraped, _ = self._run(bundle, seed)
+                self.assertGreaterEqual(scraped['reddit'], self.FLOOR, dict(scraped))
+
+    def test_balanced_layout_checks_both(self):
+        bundle = self._bundle([('reddit', 300, 8), ('x', 300, 8)])
+        for seed in [f'0x{i:064x}' for i in range(6)]:
+            with self.subTest(seed=seed):
+                scraped, _ = self._run(bundle, seed)
+                self.assertGreaterEqual(scraped['x'], self.FLOOR)
+                self.assertGreaterEqual(scraped['reddit'], self.FLOOR)
+
+
+class TestResistanceFuzz(ResistanceHarness):
+    FLOOR = DuckDBSampledValidator.SCRAPER_PLATFORM_MIN_ENTITIES
+    MIN_FILES = DuckDBSampledValidator.SCRAPER_PLATFORM_MIN_FILES
+
+    def test_random_adversarial_layouts(self):
+        """Fuzz: random counts and claim skews. Every platform that has files —
+        no matter how small its claim — must be scraper-checked, and if it has
+        >= SCRAPER_PLATFORM_MIN_FILES files it must reach the entity floor."""
+        for t in range(25):
+            rnd = random.Random(t)
+            n_reddit = rnd.randint(1, 12)
+            n_x = rnd.randint(1, 6)
+            # Randomly pick which platform is the shrunken minority (claim 1-3)
+            # vs the majority (claim 300-500). Ratios stay within MIN_BYTES_PER_ROW.
+            big, small = rnd.choice([(400, 2), (500, 1), (300, 3)]), None
+            if rnd.random() < 0.5:
+                reddit_claim, x_claim = big[0], big[1]
+            else:
+                reddit_claim, x_claim = big[1], big[0]
+            layout = [('reddit', reddit_claim, n_reddit), ('x', x_claim, n_x)]
+            bundle = self._bundle(layout)
+            seed = f'0x{t:064x}'
+            with self.subTest(t=t, layout=layout):
+                scraped, _ = self._run(bundle, seed)
+                for plat, count in (('reddit', n_reddit), ('x', n_x)):
+                    self.assertIn(plat, scraped,
+                                  f"{plat} shut out (t={t}, {layout}): {dict(scraped)}")
+                    if count >= self.MIN_FILES:
+                        self.assertGreaterEqual(
+                            scraped[plat], self.FLOOR,
+                            f"{plat} below floor (t={t}, {layout}): {dict(scraped)}")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vali_utils/s3_utils.py
+++ b/vali_utils/s3_utils.py
@@ -260,6 +260,15 @@ class DuckDBSampledValidator:
     # scraper-checked entity. See _perform_scraper_validation.
     SCRAPER_ROWS_PER_FILE = 5
 
+    # Files force-included per platform at SELECTION time (validate_miner_s3_data).
+    # The row-weighted draw + top-5 force-include are platform-blind, so a miner
+    # who shrinks one platform's claimed rows to near-zero makes its files never
+    # get sampled — that platform's data is then never scraper-checked, and its
+    # per-platform bar is vacuous (no entities to hold to MIN_SCRAPER_SUCCESS).
+    # Guaranteeing >= 2 files/platform gives the scraper phase enough rows
+    # (2 x SCRAPER_ROWS_PER_FILE, before URL-dedup) to clear the entity floor.
+    SCRAPER_PLATFORM_MIN_FILES = 2
+
     # File size limits - prevent empty file exploit and oversized file OOM
     MIN_FILE_SIZE_BYTES = 15_000                   # 15KB - empty parquet header ≈ 8KB
     MAX_FILE_SIZE_BYTES = 1024 * 1024 * 1024       # 1GB - single file cap
@@ -572,6 +581,34 @@ class DuckDBSampledValidator:
             forced = [item for item in top_n if item[0].get('key') not in picked_keys]
 
             sampled_files_with_job = sampled_files_with_job + forced
+            picked_keys.update(item[0].get('key') for item in forced)
+
+            # Per-platform FILE floor. All four slices above (row-weighted,
+            # uniform-over-jobs, suspicion, top-5) are platform-blind: they key
+            # off claimed rows or job id, never platform. A miner shrinks its X
+            # jobs to a handful of rows so the weighted draw and top-5 pick only
+            # Reddit, and X is never scraper-checked at all (observed: 20/20
+            # sampled entities Reddit, no X). Force in each platform's
+            # highest-claim files until it has >= SCRAPER_PLATFORM_MIN_FILES in
+            # the sample, so every platform earning row credit is inspected and
+            # its per-platform scraper bar can bind.
+            files_by_platform_all: Dict[str, list] = {}
+            for it in active_files:
+                p = self._file_platform(it[0].get('key', ''), expected_jobs)
+                files_by_platform_all.setdefault(p, []).append(it)
+            for p, items in files_by_platform_all.items():
+                have = sum(1 for it in items if it[0].get('key') in picked_keys)
+                need = min(self.SCRAPER_PLATFORM_MIN_FILES, len(items)) - have
+                if need <= 0:
+                    continue
+                extra = sorted(
+                    (it for it in items if it[0].get('key') not in picked_keys),
+                    key=_claimed_rows, reverse=True,
+                )[:need]
+                for it in extra:
+                    sampled_files_with_job.append(it)
+                    picked_keys.add(it[0].get('key'))
+
             self._rng.shuffle(sampled_files_with_job)
             sampled_files = [f for f, _ in sampled_files_with_job]
 
@@ -886,6 +923,21 @@ class DuckDBSampledValidator:
         filename = key.rsplit('/', 1)[-1]
         match = self._FILENAME_ROW_COUNT_RE.match(filename)
         return int(match.group(1)) if match else None
+
+    @staticmethod
+    def _file_platform(file_key: str, expected_jobs: Dict) -> str:
+        """Platform ('x'/'reddit'/...) of a file, via its job_id → expected_jobs.
+
+        Single source for the file→platform mapping used by both the
+        per-platform file floor (selection) and the round-robin scraper read.
+        Returns 'unknown' for keys without a job_id or jobs without a platform.
+        """
+        if '/job_id=' not in file_key:
+            return 'unknown'
+        job_id = file_key.split('/job_id=')[1].split('/')[0]
+        job_config = expected_jobs.get(job_id, {})
+        params = job_config.get('params', {}) if isinstance(job_config, dict) else {}
+        return str(params.get('platform', 'unknown')).lower()
 
     # Rate-limits the crash-orphan sweep (recurring, at most once per interval,
     # so a hard kill's orphans are reclaimed within ~TEMP_ORPHAN_AGE_SECS instead
@@ -1937,46 +1989,90 @@ class DuckDBSampledValidator:
         """
         all_entities = []
 
-        # UNIFORM random file order + a small FIXED per-file row quota.
+        # ROUND-ROBIN read across platforms + a small FIXED per-file row quota.
         #
-        # File *selection* is already row-weighted, and force-includes the top-5
-        # files by claimed rows (see validate_miner_s3_data), so the files that
-        # drive effective_size are guaranteed to be in `sampled_files` before we
-        # get here. Weighting a second time — a row-weighted order plus a
-        # row-proportional per-file budget — let the single largest file absorb
-        # the entire pool: at 20 rows/file the 40-row pool was full after two
-        # files, so all 20 validated entities came from one or two files of one
-        # platform. That is steerable on purpose: shrink the X jobs until Reddit
-        # holds nearly all claimed rows and the X leg is never scraper-checked
-        # at all, which also makes the per-platform bar vacuous (a platform with
-        # no entities in the pool has nothing to hold to MIN_SCRAPER_SUCCESS).
+        # Two miner-steerable holes had to close together:
         #
-        # Uniform over files with <= SCRAPER_ROWS_PER_FILE rows each needs at
-        # least 8 distinct files to fill the pool, so every sampled job has a
-        # real chance of contributing and the per-platform floor below has
-        # something to draw from. Large files keep their advantage where it is
-        # earned: they are far more likely to be *selected* in the first place.
+        #   1. Per-file budget derived from the miner's declared row counts let
+        #      the single largest file absorb the whole pool (all 20 entities
+        #      from one or two files of one platform). Fixed at
+        #      SCRAPER_ROWS_PER_FILE, so no file's share depends on what the
+        #      miner claims.
+        #
+        #   2. A plain uniform shuffle + "stop once the pool is full" still let
+        #      the majority platform starve the minority: if its files shuffle
+        #      first they fill the 40-entity pool before any minority file is
+        #      opened, so 20/20 land on one platform and the minority leg is
+        #      never scraper-checked — its per-platform bar vacuous (a platform
+        #      with 0 entities in the pool has nothing to hold to
+        #      MIN_SCRAPER_SUCCESS). This was still reproducible after fix 1.
+        #
+        # Read the files interleaved by platform and keep going, past the pool
+        # cap if needed, until every platform present has reached the entity
+        # floor (or run out of files). Combined with the per-platform FILE floor
+        # at selection (validate_miner_s3_data guarantees each platform HAS
+        # files here), every platform earning row credit is now checked.
         sampled_files = list(sampled_files)
-        self._rng.shuffle(sampled_files)
+
+        files_by_platform: Dict[str, list] = {}
+        for f in sampled_files:
+            plat = self._file_platform(f.get('key', ''), expected_jobs)
+            files_by_platform.setdefault(plat, []).append(f)
+        for plat in files_by_platform:
+            self._rng.shuffle(files_by_platform[plat])
 
         # Pool target: twice the number of entities we finally validate, so the
         # per-platform floor and the random draw below have slack to work with.
         entity_pool_target = num_entities * 2
+        # Each platform must reach the entity floor so its per-platform bar
+        # (MIN_SCRAPER_SUCCESS over >= SCRAPER_PLATFORM_MIN_ENTITIES) binds.
+        per_platform_target = self.SCRAPER_PLATFORM_MIN_ENTITIES
 
-        # The quota is raised only when the sample holds too few files to fill
-        # the pool at the base rate — a small miner (fewer than 10 files in
-        # total) must not end up with a SMALLER scraper sample than before this
-        # change. It stays the same number for every file either way: what
-        # makes the draw unsteerable is that no file's share depends on the row
-        # count the miner declares, not the size of the share itself.
+        # Flat per-file quota, raised only when the whole sample is too small to
+        # fill the pool. Same number for every file — never derived from
+        # miner-declared rows, so no file's share depends on the miner's claim.
         rows_per_file = self.SCRAPER_ROWS_PER_FILE
         if sampled_files and len(sampled_files) * rows_per_file < entity_pool_target:
             rows_per_file = math.ceil(entity_pool_target / len(sampled_files))
 
-        for file_info in sampled_files:
+        # Interleave: [platA[0], platB[0], platA[1], platB[1], ...] then the tail
+        # of the longer platform. Reading in this order guarantees every platform
+        # contributes before the pool cap could end the scan.
+        read_order: List[Dict] = []
+        if files_by_platform:
+            longest = max(len(v) for v in files_by_platform.values())
+            for i in range(longest):
+                for plat, files in files_by_platform.items():
+                    if i < len(files):
+                        read_order.append(files[i])
 
-            if len(all_entities) >= entity_pool_target:
+        per_platform_counts: Dict[str, int] = {p: 0 for p in files_by_platform}
+        attempted: Dict[str, int] = {p: 0 for p in files_by_platform}
+
+        def _some_platform_below_floor() -> bool:
+            # True while a platform is short of the floor AND still has files
+            # left to read. Bounds the loop: an exhausted platform stops blocking.
+            return any(
+                per_platform_counts[p] < per_platform_target
+                and attempted[p] < len(files_by_platform[p])
+                for p in files_by_platform
+            )
+
+        for file_info in read_order:
+
+            # Stop only when the pool is full AND no platform is still short of
+            # its floor. A minority platform keeps being read past the cap until
+            # it clears the floor (bounded — it has few files).
+            if len(all_entities) >= entity_pool_target and not _some_platform_below_floor():
                 break
+
+            plat_of_file = self._file_platform(file_info.get('key', ''), expected_jobs)
+            # Once the pool is full, don't read more of an already-satisfied
+            # platform — only the still-short ones.
+            if (len(all_entities) >= entity_pool_target
+                    and per_platform_counts.get(plat_of_file, 0) >= per_platform_target):
+                continue
+            attempted[plat_of_file] = attempted.get(plat_of_file, 0) + 1
 
             # Skip oversized files to prevent OOM
             file_size = file_info.get('size', 0)
@@ -2072,6 +2168,7 @@ class DuckDBSampledValidator:
                             ],
                         }
                     all_entities.append((entity, platform, job_id))
+                    per_platform_counts[platform] = per_platform_counts.get(platform, 0) + 1
 
                 del df
             except:

--- a/vali_utils/s3_utils.py
+++ b/vali_utils/s3_utils.py
@@ -243,14 +243,38 @@ class DuckDBSampledValidator:
     MAX_EMPTY_RATE = 10.0       # 10% max empty content
     # Missing URLs = instant fail (no rate threshold needed)
     MIN_JOB_MATCH_RATE = 95.0   # 95% min job content match rate
-    MIN_SCRAPER_SUCCESS = 80.0  # 80% min scraper success rate
+    MIN_SCRAPER_SUCCESS = 80.0  # 80% min COMBINED scraper success rate (all platforms)
     MIN_ENGAGEMENT_RATE = 95.0  # 95% of X rows must have non-null view_count
     MIN_UNIQUE_CONTENT_RATIO = 10.0  # 10% min unique tweet_ids / total rows
+
+    # Per-platform scraper bar — deliberately LOOSER than the combined bar.
+    #
+    # The per-platform check runs on a tiny sample (SCRAPER_PLATFORM_MIN_ENTITIES
+    # = 5), where one extra flaky lookup swings the rate 20 points. At an 80%
+    # bar (fail on >=2/5) an HONEST platform whose rows are all real still fails
+    # purely from irreducible noise — deleted/edited posts, third-party rate
+    # limits, stale historical rows — on ~8% of cycles at 10% lookup-noise and
+    # ~26% at 20% (binomial, measured). That mis-FAILs the whole miner and
+    # decays credibility for something they don't control.
+    #
+    # 60% (fail only on >=3/5) drops that honest false-positive rate to ~0.9%
+    # / ~5.8% while still catching a platform that is MOSTLY fabricated. The
+    # COMBINED bar stays at MIN_SCRAPER_SUCCESS = 80%, so wholesale fabrication
+    # and a dirty MAJORITY platform are still caught there; this only relaxes
+    # the case where a MINORITY platform sits between 60% and 80% real.
+    #
+    # NOTE: this partially relaxes the per-platform strictness added in #901
+    # (which used the combined 80% here). Maintainers can retune via this
+    # constant; the statistically cleaner fix for the small-sample noise is a
+    # larger per-platform floor or an absolute-failure allowance, left as a
+    # follow-up so this change stays minimal.
+    MIN_SCRAPER_SUCCESS_PER_PLATFORM = 60.0
 
     # Per-platform scraper-sampling floor. Every platform with claimed rows in
     # the sampled files gets at least this many rows scraper-validated,
     # regardless of the random draw, and each platform reaching the floor is
-    # held to MIN_SCRAPER_SUCCESS on its own rather than in a combined rate.
+    # held to MIN_SCRAPER_SUCCESS_PER_PLATFORM on its own rather than only in
+    # the combined rate.
     SCRAPER_PLATFORM_MIN_ENTITIES = 5
 
     # Rows drawn from each file during the scraper phase. Small and FIXED, not
@@ -2517,7 +2541,13 @@ class DuckDBSampledValidator:
         )
 
     def _per_platform_issues(self, platform_stats: Dict[str, Dict[str, int]]) -> List[str]:
-        """Issues for platforms that fail MIN_SCRAPER_SUCCESS on their own sample.
+        """Issues for platforms below MIN_SCRAPER_SUCCESS_PER_PLATFORM on their
+        own sample.
+
+        The per-platform bar (60%) is looser than the combined bar (80%): the
+        sample is only SCRAPER_PLATFORM_MIN_ENTITIES rows, so an honest platform
+        would mis-fail on normal lookup noise at 80% (see the constant). The
+        combined MIN_SCRAPER_SUCCESS check remains the strict gate.
 
         Only platforms with at least SCRAPER_PLATFORM_MIN_ENTITIES validated
         entities are held to the bar — below that, one bad row would swing the
@@ -2529,7 +2559,7 @@ class DuckDBSampledValidator:
             if validated < self.SCRAPER_PLATFORM_MIN_ENTITIES:
                 continue
             rate = stats.get('passed', 0) / validated * 100.0
-            if rate < self.MIN_SCRAPER_SUCCESS:
+            if rate < self.MIN_SCRAPER_SUCCESS_PER_PLATFORM:
                 issues.append(f"Low {plat} scraper success: {rate:.1f}%")
         return issues
 

--- a/vali_utils/s3_utils.py
+++ b/vali_utils/s3_utils.py
@@ -293,6 +293,31 @@ class DuckDBSampledValidator:
     # (2 x SCRAPER_ROWS_PER_FILE, before URL-dedup) to clear the entity floor.
     SCRAPER_PLATFORM_MIN_FILES = 2
 
+    # Platforms _create_data_entity can build entities for, i.e. the ones a
+    # scraper can actually check. The per-platform floors apply only to these:
+    # forcing in a file for any other platform cannot produce a validated
+    # entity, it can only trip the entity-construction hard-fail.
+    SCRAPER_VALIDATABLE_PLATFORMS = frozenset({'x', 'twitter', 'reddit'})
+
+    # Detection surplus for the files that carry the effective_size claim.
+    #
+    # The fairness rules (uniform file order, flat SCRAPER_ROWS_PER_FILE quota)
+    # are what stop a miner from steering the draw — but applied alone they also
+    # cut the biggest files from ~20 sampled rows down to 5, and those are
+    # exactly the files where fabricated volume pays. Detection power against a
+    # fraction f of fabricated rows inside one file is 1-(1-f)^r:
+    #
+    #     f=0.20   r=5 -> 67%    r=20 -> 99%
+    #     f=0.10   r=5 -> 41%    r=20 -> 88%
+    #
+    # So the top files by CLAIMED ROWS get a larger quota, drawn AFTER every
+    # platform has reached its floor. Fairness is a floor, not a cap: the
+    # guarantee is that no platform can be shut out, not that a 3M-row file and
+    # a 50-row file get equal audit effort. Claimed rows steer only this
+    # surplus, and steering it costs the miner more inspection, not less.
+    SCRAPER_TOP_FILE_COUNT = 3
+    SCRAPER_TOP_FILE_ROWS = 20
+
     # File size limits - prevent empty file exploit and oversized file OOM
     MIN_FILE_SIZE_BYTES = 15_000                   # 15KB - empty parquet header ≈ 8KB
     MAX_FILE_SIZE_BYTES = 1024 * 1024 * 1024       # 1GB - single file cap
@@ -619,14 +644,29 @@ class DuckDBSampledValidator:
             files_by_platform_all: Dict[str, list] = {}
             for it in active_files:
                 p = self._file_platform(it[0].get('key', ''), expected_jobs)
-                files_by_platform_all.setdefault(p, []).append(it)
+                # Only platforms the scraper can actually validate. Forcing in a
+                # file the entity builder cannot parse (unknown platform) would
+                # trip the "_create_data_entity returned None" hard-fail path and
+                # mis-fail an honest miner over a job whose params lack a
+                # platform — a floor must never manufacture a failure.
+                if p in self.SCRAPER_VALIDATABLE_PLATFORMS:
+                    files_by_platform_all.setdefault(p, []).append(it)
             for p, items in files_by_platform_all.items():
-                have = sum(1 for it in items if it[0].get('key') in picked_keys)
-                need = min(self.SCRAPER_PLATFORM_MIN_FILES, len(items)) - have
+                # Count only files that will REACH the scraper phase. Suspicion
+                # picks are detection-only and get filtered out of scraper_files
+                # by the caller, so counting them here would satisfy the floor
+                # with files the scraper never sees — and the suspicion picker
+                # targets repeated-exact-size files, exactly the fingerprint a
+                # shrunken minority platform has. Without this the manipulation
+                # reopens: the more suspicious a platform's files look, the less
+                # likely it was to be scraper-validated at all.
+                eligible = [it for it in items if it[0].get('key') not in suspicion_keys]
+                have = sum(1 for it in eligible if it[0].get('key') in picked_keys)
+                need = min(self.SCRAPER_PLATFORM_MIN_FILES, len(eligible)) - have
                 if need <= 0:
                     continue
                 extra = sorted(
-                    (it for it in items if it[0].get('key') not in picked_keys),
+                    (it for it in eligible if it[0].get('key') not in picked_keys),
                     key=_claimed_rows, reverse=True,
                 )[:need]
                 for it in extra:
@@ -2059,6 +2099,27 @@ class DuckDBSampledValidator:
         if sampled_files and len(sampled_files) * rows_per_file < entity_pool_target:
             rows_per_file = math.ceil(entity_pool_target / len(sampled_files))
 
+        # Detection surplus (see SCRAPER_TOP_FILE_ROWS): the files carrying the
+        # largest CLAIMED row counts get a bigger quota, because that is where
+        # fabricated volume pays. This is the one place claimed rows steer the
+        # draw, and it can only ADD inspection: the floors above are already
+        # guaranteed, so a miner inflating a file's claim just buys that file
+        # more scrutiny. Ties broken by key so the set is stable per cycle.
+        def _claimed(f):
+            return self._parse_row_count_from_filename(f.get('key', '')) or 0
+
+        top_claim_keys = {
+            f.get('key')
+            for f in sorted(sampled_files,
+                            key=lambda f: (-_claimed(f), f.get('key', '')))
+            [:self.SCRAPER_TOP_FILE_COUNT]
+        }
+
+        def _quota_for(f):
+            if f.get('key') in top_claim_keys:
+                return max(rows_per_file, self.SCRAPER_TOP_FILE_ROWS)
+            return rows_per_file
+
         # Interleave: [platA[0], platB[0], platA[1], platB[1], ...] then the tail
         # of the longer platform. Reading in this order guarantees every platform
         # contributes before the pool cap could end the scan.
@@ -2072,6 +2133,18 @@ class DuckDBSampledValidator:
 
         per_platform_counts: Dict[str, int] = {p: 0 for p in files_by_platform}
         attempted: Dict[str, int] = {p: 0 for p in files_by_platform}
+        contributing_files: Set[str] = set()
+
+        # Breadth floor. The surplus quota above lets 2-3 big files fill the
+        # whole pool on their own, which would collapse file coverage back to
+        # the handful of files the miner most wants inspected — the opposite of
+        # the fairness rule. So the pool cap cannot stop the scan until at least
+        # this many DISTINCT files have contributed. Depth on big files is
+        # bought on TOP of breadth, never instead of it.
+        min_files_contributing = min(
+            len(sampled_files),
+            math.ceil(entity_pool_target / self.SCRAPER_ROWS_PER_FILE),
+        )
 
         def _some_platform_below_floor() -> bool:
             # True while a platform is short of the floor AND still has files
@@ -2084,16 +2157,19 @@ class DuckDBSampledValidator:
 
         for file_info in read_order:
 
-            # Stop only when the pool is full AND no platform is still short of
-            # its floor. A minority platform keeps being read past the cap until
-            # it clears the floor (bounded — it has few files).
-            if len(all_entities) >= entity_pool_target and not _some_platform_below_floor():
+            # Stop only when all three obligations are met: the pool is full,
+            # no platform is short of its entity floor, and enough DISTINCT
+            # files have contributed. Any one of them still outstanding keeps
+            # the scan going (bounded by the file list either way).
+            pool_full = len(all_entities) >= entity_pool_target
+            breadth_met = len(contributing_files) >= min_files_contributing
+            if pool_full and breadth_met and not _some_platform_below_floor():
                 break
 
             plat_of_file = self._file_platform(file_info.get('key', ''), expected_jobs)
-            # Once the pool is full, don't read more of an already-satisfied
-            # platform — only the still-short ones.
-            if (len(all_entities) >= entity_pool_target
+            # Past the cap, only read what an outstanding obligation needs: a
+            # platform still under its floor, or breadth still short.
+            if (pool_full and breadth_met
                     and per_platform_counts.get(plat_of_file, 0) >= per_platform_target):
                 continue
             attempted[plat_of_file] = attempted.get(plat_of_file, 0) + 1
@@ -2159,7 +2235,7 @@ class DuckDBSampledValidator:
                 # from it — same quota for every file, big or small.
                 df = read_random_row_group(
                     read_source, file_size,
-                    columns=None, max_rows=rows_per_file,
+                    columns=None, max_rows=_quota_for(file_info),
                     rng=self._rng
                 )
 
@@ -2191,8 +2267,9 @@ class DuckDBSampledValidator:
                                 f"Failed to create DataEntity for sampled row"
                             ],
                         }
-                    all_entities.append((entity, platform, job_id))
+                    all_entities.append((entity, platform, job_id, _claimed(file_info)))
                     per_platform_counts[platform] = per_platform_counts.get(platform, 0) + 1
+                    contributing_files.add(file_key)
 
                 del df
             except:
@@ -2239,11 +2316,20 @@ class DuckDBSampledValidator:
                     selected.append(item)
                     selected_ids.add(id(item))
 
-        # Fill the rest of the budget with a random draw over everything not yet picked.
+        # Fill the rest of the budget WEIGHTED by the claimed rows of the file
+        # each entity came from. The floors above already guarantee every
+        # platform is represented, so weighting the remainder cannot shut anyone
+        # out — it only sends the leftover audit effort to the files that carry
+        # the effective_size claim, which is where fabricated volume pays.
+        # Inflating a file's claim therefore raises its own odds of being
+        # checked; it can never lower another file's guaranteed share.
         remaining = [it for it in all_entities if id(it) not in selected_ids]
         fill = max(0, target - len(selected))
         if fill > 0:
-            selected.extend(self._rng.sample(remaining, min(fill, len(remaining))))
+            weights = [max(1, it[3]) for it in remaining]
+            selected.extend(_weighted_sample_without_replacement(
+                remaining, weights, min(fill, len(remaining)), rng=self._rng
+            ))
         else:
             # The floors alone already over-subscribed the budget (enough
             # platforms x SCRAPER_PLATFORM_MIN_ENTITIES > target). Shuffle
@@ -2259,7 +2345,7 @@ class DuckDBSampledValidator:
         platform_stats: Dict[str, Dict[str, int]] = {}
 
         entities_by_platform = {}
-        for entity, platform, job_id in entities_to_validate:
+        for entity, platform, job_id, _claimed_rows_of_file in entities_to_validate:
             if platform not in entities_by_platform:
                 entities_by_platform[platform] = []
             entities_by_platform[platform].append((entity, job_id))

--- a/vali_utils/s3_utils.py
+++ b/vali_utils/s3_utils.py
@@ -318,6 +318,16 @@ class DuckDBSampledValidator:
     SCRAPER_TOP_FILE_COUNT = 3
     SCRAPER_TOP_FILE_ROWS = 20
 
+    # Long-tail floor on the FINAL entity budget. The weighted fill sends
+    # leftover slots to the biggest claims, which is economically right — audit
+    # effort should track the rows at risk. But on a single-platform layout the
+    # per-platform floor is the only thing holding slots for smaller files, and
+    # it does so only in expectation (a random draw from a pool the big files
+    # dominate). Reserve slots outright instead, so "small files are still
+    # checked" is a guarantee rather than a tendency, matching how every other
+    # coverage rule here works.
+    SCRAPER_LONGTAIL_MIN_ENTITIES = 3
+
     # File size limits - prevent empty file exploit and oversized file OOM
     MIN_FILE_SIZE_BYTES = 15_000                   # 15KB - empty parquet header ≈ 8KB
     MAX_FILE_SIZE_BYTES = 1024 * 1024 * 1024       # 1GB - single file cap
@@ -2108,6 +2118,7 @@ class DuckDBSampledValidator:
         def _claimed(f):
             return self._parse_row_count_from_filename(f.get('key', '')) or 0
 
+        claimed_rows_by_key = {f.get('key'): _claimed(f) for f in sampled_files}
         top_claim_keys = {
             f.get('key')
             for f in sorted(sampled_files,
@@ -2325,6 +2336,30 @@ class DuckDBSampledValidator:
         # checked; it can never lower another file's guaranteed share.
         remaining = [it for it in all_entities if id(it) not in selected_ids]
         fill = max(0, target - len(selected))
+        if fill > 0:
+            # Long-tail reservation first: entities from files OUTSIDE the
+            # top-claim set. Without it a couple of multi-million-row files take
+            # every leftover slot, and the smaller files are audited only by
+            # whatever the per-platform floor's random draw happened to catch.
+            # Classify by file identity, not by a claim threshold. When the
+            # miner has fewer than SCRAPER_TOP_FILE_COUNT genuinely large files,
+            # a small file gets pulled into the top set and a threshold
+            # collapses to that small claim, leaving the long-tail set empty —
+            # the exact layout ("2 huge + 8 tiny") this floor exists for.
+            # After _keep_latest_per_job a job maps 1:1 to a file, so the job id
+            # carried on each entity identifies its source file.
+            top_claim_jobs = {
+                k.split('/job_id=')[1].split('/')[0]
+                for k in top_claim_keys if k and '/job_id=' in k
+            }
+            longtail = [it for it in remaining if it[2] not in top_claim_jobs]
+            reserve = min(self.SCRAPER_LONGTAIL_MIN_ENTITIES, fill, len(longtail))
+            if reserve > 0:
+                picked_longtail = self._rng.sample(longtail, reserve)
+                selected.extend(picked_longtail)
+                selected_ids.update(id(it) for it in picked_longtail)
+                remaining = [it for it in remaining if id(it) not in selected_ids]
+                fill -= reserve
         if fill > 0:
             weights = [max(1, it[3]) for it in remaining]
             selected.extend(_weighted_sample_without_replacement(


### PR DESCRIPTION
## Summary

Follow-up to #905, from running it against live miner data.

#905 stopped a miner from steering the entity draw *inside* the files that get sampled. It did not touch the stage before that — **choosing which files get sampled at all** — and that stage is platform-blind. A miner shrinks the row counts it declares for one platform, that platform's files stop being selected, and its data is never scraper-checked while it still earns row credit toward `effective_size`. Reported from a live validator as 20/20 validated entities Reddit, zero X.

Fixing that exposed a second problem: the fairness rules needed to close it also cut the biggest files from ~20 sampled rows down to 5, and the biggest files are exactly where fabricated volume pays. Getting both at once is the substance of this PR.

Third, the per-platform bar from #901 is applied to a 5-row sample using a threshold sized for a much larger one, so it mis-fails honest miners on ordinary lookup noise.

| Problem | Fix |
|---|---|
| A whole platform can be kept out of validation entirely | Per-platform **file** floor at selection + round-robin read |
| Fairness rules cost detection power on the files that carry the claim | Surplus row quota for top-claim files + claim-weighted final fill |
| That surplus then let 2 files own the entire sample | Breadth floor: N distinct files must contribute before the scan can stop |
| Weighted fill starved smaller files (0/20 at worst) | Long-tail reservation on the final entity budget |
| Per-platform bar mis-fails honest miners on a 5-row sample | Split the constant: 80% combined (unchanged), 60% per-platform |

The combined `MIN_SCRAPER_SUCCESS` gate, the 2× OD cap, `effective_size`, and the failure path are all untouched.

---

## The design in one idea

Every coverage rule here is a **floor, not a cap**, and the miner's declared row counts may only steer what is left over after the floors are paid.

That matters because claimed rows are the one input the miner fully controls. The old code let them drive the whole allocation, so shrinking one number could remove a platform, or a file, from validation completely. Now:

- **Floors** decide what *must* be audited. None of them read claimed rows as a weight — only as "does this platform/file exist".
- **The surplus** is allocated by claimed rows, because that is where the reward — and therefore the risk — actually is.

Inflating a file's claim can now only buy that file *more* scrutiny. It can never reduce another file's guaranteed share. That property is what makes the draw safe to weight at all.

---

## 1. A platform could be kept out of validation entirely

`validate_miner_s3_data` + `_perform_scraper_validation`

### Problem

**Selection is platform-blind.** All four file-sampling slices — row-weighted, uniform-over-jobs, suspicion, top-5 force-include — key off claimed rows or job id. None looks at platform. Shrink the X jobs to a handful of claimed rows and the weighted draw and the top-5 pick only the large Reddit files: **no X file enters `sampled_files`**, so the scraper phase cannot produce a single X entity however it draws.

That also makes the per-platform bar from #901 vacuous. A platform with zero entities in the pool has nothing to hold to a threshold, so the check silently passes on data it never saw.

**The read loop could starve the minority too.** Even with X files present, #905's uniform shuffle plus "stop once the pool is full" means that if the Reddit files shuffle first they fill the 40-entity pool before any X file is opened.

### Solution

Four independent guarantees, each closing one escape:

1. **Per-platform file floor** (selection) — force in each active platform's highest-claim files until it holds at least `SCRAPER_PLATFORM_MIN_FILES = 2`.
2. **Round-robin read** — files are read interleaved by platform, so the minority is reached before the pool can fill.
3. **Stop condition** — the scan continues past the pool cap until every platform has reached `SCRAPER_PLATFORM_MIN_ENTITIES` (or has run out of files). Bounded: a starved platform has few files by construction.
4. **Per-platform entity floor** (final selection) — 5 of the 20 reserved per platform.

None of the four reads claimed rows as a weight, and the guarantee is symmetric: shrinking Reddit instead of X behaves identically (there is a test for exactly that, so the fix cannot quietly become X-specific).

Two details worth reviewing, both found auditing this change rather than by testing it:

- The floor counts **only files that will reach the scraper phase**. Suspicion-slice picks are detection-only and the caller strips them out of `scraper_files`, so counting them would satisfy the floor with files the scraper never sees. This is reachable, not theoretical: `_pick_suspicious_files` ranks repeated-exact-size files first, which is exactly the fingerprint of the shrunken, uniform minority-platform files this manipulation produces.
- The floor applies **only to `SCRAPER_VALIDATABLE_PLATFORMS`**. Forcing in a file the entity builder cannot parse walks straight into the `_create_data_entity returned None` hard-fail and would mis-fail an honest miner over a job whose params lack a platform. A coverage floor must never manufacture a failure.

## 2. Keeping detection power on the files that carry the claim

### Problem

The fairness rules above want every file treated alike. But `effective_size` is driven by claimed rows, so fabricated volume pays in the biggest files — and a flat 5-row quota cut those from ~20 sampled rows to 5. Against a fraction `f` of fabricated rows in one file, detection is `1-(1-f)^r`:

| f | r=5 | r=20 |
|---|---|---|
| 0.20 | 67% | 99% |
| 0.10 | **41%** | 88% |

This is the real tension in the PR: audit the big files hard, without letting them crowd out everything else.

### Solution

Fairness as a floor, competition on the surplus:

- Every file still gets `SCRAPER_ROWS_PER_FILE = 5`, so **no file can be starved by what another file claims** — that was the exploitable property.
- The top `SCRAPER_TOP_FILE_COUNT = 3` files by claimed rows additionally get `SCRAPER_TOP_FILE_ROWS = 20`, drawn *after* every platform has met its floor.
- The final entity fill is **weighted by the claimed rows of the file each entity came from**, so leftover budget goes where the reward is.

Weighting the leftover is not just safe here, it is self-correcting. Measured share of the audit budget against share of claimed rows:

| Smaller files hold | They receive |
|---|---|
| 0.1% of rows | **17.8%** of audit slots |
| 33% of rows | 71% |
| 50% of rows | 43% |
| 67% of rows | 50% |

Hiding fabrication in small files gains almost nothing; accumulating enough of it to matter raises their row share, and the weighting follows automatically.

## 3. The surplus then created two problems of its own

### 3a. Two files could own the whole sample

`2 × SCRAPER_TOP_FILE_ROWS` equals the `2 × num_entities` pool exactly, so two multi-million-row files could fill it alone and end the scan — collapsing coverage back to precisely the files a fabricator wants inspected.

**Breadth floor:** the pool cap cannot stop the scan until at least `ceil(pool / SCRAPER_ROWS_PER_FILE)` **distinct** files have contributed. Depth on big files is bought on top of breadth, never instead of it. Measured distinct files read:

| Layout | Files read |
|---|---|
| 2 huge (3M rows) + 8 tiny | **8** |
| 1 mega (**100M rows**) + 14 tiny | **8** |
| 10 huge, all equal | **8** |

### 3b. The weighted fill starved smaller files

The pool now contains small-file entities, but the claim-weighted fill rarely selected them. On a single-platform layout the per-platform floor is the only thing holding slots for smaller files, and it does so only *in expectation* — a random draw from a pool the big files dominate. Measured over 40 seeds on "2 huge(3M) + 8 tiny":

| | Before | After |
|---|---|---|
| Smaller files, average | 3.2/20 | 6.2/20 |
| Smaller files, **worst seed** | **0/20** | **3/20** |
| Big files | 16.8/20 | 13.8/20 |

Coverage that holds only on average is not coverage. `SCRAPER_LONGTAIL_MIN_ENTITIES = 3` of the fill is reserved for entities from files outside the top-claim set, before the weighted draw. The floor sets a minimum; it does not invert the priority — the big files still take the larger share, and there is a guard test asserting the long-tail floor has not over-served.

Classification is by **file identity** (job id, 1:1 with a file after `_keep_latest_per_job`), not by a claim threshold. A threshold breaks on exactly the layout this exists for: with fewer than `SCRAPER_TOP_FILE_COUNT` genuinely large files, a small file is pulled into the top set, the threshold collapses to that small claim, and the long-tail set comes back empty. The first implementation had this bug; measurement caught it, the tests did not.

## 4. Sizing the per-platform bar to the sample it runs on

`_per_platform_issues`

### Problem

The per-platform bar from #901 reuses `MIN_SCRAPER_SUCCESS` (80%), but runs on `SCRAPER_PLATFORM_MIN_ENTITIES = 5` rows, where one extra flaky lookup swings the rate 20 points. At 80% a platform fails on ≥2/5 — and 2/5 is ordinary noise: deleted or edited posts, third-party rate limits, stale historical rows.

Binomial false-positive rate for an **honest** platform whose rows are all real:

| per-lookup noise | bar 80% (fail ≥2/5) | bar 60% (fail ≥3/5) |
|---|---|---|
| 5% | 2.3% | 0.1% |
| 10% | **8.1%** | 0.9% |
| 15% | **16.5%** | 2.7% |
| 20% | **26.3%** | 5.8% |

At realistic noise an honest miner was mis-FAILED on 8–26% of cycles, losing `effective_size` growth and decaying `s3_credibility` for something outside its control.

### Solution

Split the constant rather than moving it:

- `MIN_SCRAPER_SUCCESS = 80.0` — the **combined** gate across all platforms, unchanged. Wholesale fabrication and a dirty *majority* platform are caught exactly as before.
- `MIN_SCRAPER_SUCCESS_PER_PLATFORM = 60.0` — the small-sample per-platform check, sized to its own noise floor.

**Tradeoff, stated plainly:** this relaxes #901 for the case of a *minority* platform sitting between 60% and 80% real. It does not open the combined gate, and after fix 1 it is no longer combinable with hiding a platform from validation. The statistically cleaner answer to small-sample noise is a larger per-platform floor or an absolute-failure allowance; left as a follow-up so this stays minimal and tunable via the constant. A guard test pins `MIN_SCRAPER_SUCCESS` at 80.0 so a future edit cannot lower the combined gate along with it.

---

## Where each guarantee lives

| Stage | Protects big files | Protects small files | Protects every platform |
|---|---|---|---|
| File selection | force top-5 by claimed rows | uniform-over-jobs slice | file floor, ≥2 per platform |
| Row read | top-3 get 20 rows | every file gets ≥5 | round-robin order |
| Stop rule | — | ≥8 distinct files must contribute | continue until each platform hits its entity floor |
| Final 20 | claim-weighted fill | 3 slots reserved for long-tail | 5 slots reserved per platform |

Claimed rows appear in exactly two cells, both surplus.

## Constants

All on `DuckDBSampledValidator`, so behaviour is tunable without touching logic:

| Constant | Value | Meaning |
|---|---|---|
| `MIN_SCRAPER_SUCCESS` | 80.0 | combined gate, unchanged |
| `MIN_SCRAPER_SUCCESS_PER_PLATFORM` | 60.0 | per-platform gate (new) |
| `SCRAPER_PLATFORM_MIN_ENTITIES` | 5 | entity floor per platform |
| `SCRAPER_PLATFORM_MIN_FILES` | 2 | file floor per platform (new) |
| `SCRAPER_ROWS_PER_FILE` | 5 | base row quota, every file |
| `SCRAPER_TOP_FILE_COUNT` / `_ROWS` | 3 / 20 | surplus for top-claim files (new) |
| `SCRAPER_LONGTAIL_MIN_ENTITIES` | 3 | reserved slots outside top claims (new) |
| `SCRAPER_VALIDATABLE_PLATFORMS` | x, twitter, reddit | platforms the floors apply to (new) |

---

## Testing

```bash
python -m pytest tests/vali_utils/test_single_platform_resistance.py \
                 tests/vali_utils/test_scraper_entity_sampling.py \
                 tests/rewards/test_s3_quality_scoring.py -q
```

| Suite | Result |
|---|---|
| `test_single_platform_resistance.py` (new) | 9 passed, 75 subtests |
| `test_scraper_entity_sampling.py` (extended) | 14 passed, 67 subtests |
| `test_s3_quality_scoring.py` (updated) | 16 passed |

**`test_single_platform_resistance.py`** drives the **whole** sampling path through `validate_miner_s3_data` on real parquet files — the real selection stage *and* the real round-robin read both execute, with only the external scraper call and the unrelated DuckDB/job-match phases mocked. A spy on `_validate_with_scraper` counts how many entities of each platform actually reached a scraper: the exact quantity the manipulation drove to zero.

Covered: the reported layout (30 Reddit jobs dwarfing 2 X jobs) over 10 committed seeds; a platform with a single file; the widest claim skew the validator's own `MIN_BYTES_PER_ROW` gate permits; **reverse skew** with Reddit as the minority; balanced layouts; and a 25-case fuzz over random file counts and a random choice of which platform is shrunk.

**`test_scraper_entity_sampling.py`** adds `TestSelectionPlatformFloor` (X files survive selection across 15 committed seeds) and `TestMegaFileCannotOwnTheAudit` (mega files cannot end the scan; the long-tail floor holds on every one of 20 seeds; a single 100M-row file does not monopolise; and the floor has not over-served the small files).

**Every fix is mutation-verified** — the tests were checked to fail for the right reason rather than passing by construction:

| Fix disabled | Result |
|---|---|
| selection per-platform file floor | 29 failures |
| suspicion exclusion in that floor | 10/10 seeds fail |
| round-robin read → plain shuffle + hard cap | 10 failures |
| breadth floor | its test fails |
| top-claim surplus quota | its test fails |
| long-tail reservation | 8 subtests fail |

One pre-existing test was also fixed: it asserted **inside** a read spy, and `_perform_scraper_validation` wraps the read in a bare `except: continue` that swallowed the `AssertionError` into a silently skipped file — so it passed for the wrong reason.

**Full suites** (`tests/rewards` + `tests/vali_utils`): **160 passed, 150 subtests passed**, 8 failed — the identical 8 fail on an unmodified `dev` checkout (`test_data_value_calculator` ×4, `test_eval_batch_concurrency` ×1, `test_od_flow` ×3), and `tests/rewards/test_miner_scorer.py` errors at collection on `dev` (`module 'rewards.data_value_calculator' has no attribute 'dt'`). None are touched by this PR.

## Notes for reviewers

- **Committed sampling is preserved end to end.** Every draw — file shuffle, round-robin order, row group, rows, floors, long-tail reservation, weighted fill — goes through `self._rng`, seeded from H(block hash ‖ hotkey ‖ manifest). Unpredictable at upload time, exactly reproducible afterwards.
- **Cost:** the scraper phase reads ~8–15 files instead of ~2–3. Those files are already in the eval-scoped local cache from the dedup phase, so in the normal path these are local reads, not extra network round trips. The extra files forced in by the platform floor are small by construction — the miner shrank them.
- **Known residual, out of scope.** `effective_size` sums the row counts declared for *all* files, but the row-count-vs-parquet-metadata check runs only on sampled files. A miner with many files can still inflate the claim on files that were not sampled this cycle. Row-weighted selection limits this — the probability of catching at least one inflated file depends on the fabricated *share*, not on how many files it is split across — and repeated cycles with fresh seeds compound it. A real fix means scoring verified rows rather than declared rows, which is an economic change worth its own discussion.
- **Section 4 is the only change that loosens a check.** It is a self-contained commit (`20316ee`); dropping it leaves everything else intact.
